### PR TITLE
fix(Recruit): 유효값 검증 실패 시 400으로 반환되어 서버 주소 노출되는 문제 해결

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/recruit/controller/RecruitMemberController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/recruit/controller/RecruitMemberController.java
@@ -7,14 +7,12 @@ import inha.gdgoc.domain.recruit.service.RecruitMemberService;
 import inha.gdgoc.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -34,30 +32,21 @@ public class RecruitMemberController {
     public ResponseEntity<ApiResponse<Boolean>> duplicatedStudentIdDetails(
             @Valid @ModelAttribute CheckStudentIdRequest studentIdRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.failure(HttpStatus.BAD_REQUEST,
-                            false,
-                            bindingResult.getFieldError().getDefaultMessage()));
+            return ResponseEntity.ok(ApiResponse.failure(true, "학번 형식에 맞지 않는 값입니다."));
         }
 
         boolean exists = recruitMemberService.isRegisteredStudentId(studentIdRequest.getStudentId());
         return ResponseEntity.ok(ApiResponse.success(exists, exists ? "이미 등록된 학번입니다." : "사용 가능한 학번입니다."));
     }
 
-    /// /check?phoneNumber = 1213445 (want)
-    /// /check/phoneNumber?phoneNumber=12345
     @GetMapping("/check/phoneNumber")
     public ResponseEntity<ApiResponse<Boolean>> duplicatedPhoneNumberDetails(
             @Valid @ModelAttribute CheckPhoneNumberRequest phoneNumberRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.failure(HttpStatus.BAD_REQUEST,
-                            false,
-                            bindingResult.getFieldError().getDefaultMessage()));
+            return ResponseEntity.ok(ApiResponse.failure(true, "전화번호 형식에 맞지 않는 값입니다."));
         }
 
         boolean exists = recruitMemberService.isRegisteredPhoneNumber(phoneNumberRequest.getPhoneNumber());
         return ResponseEntity.ok(ApiResponse.success(exists, exists ? "이미 등록된 전화번호입니다." : "사용 가능한 전화번호입니다."));
     }
-
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/recruit/service/RecruitMemberService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/recruit/service/RecruitMemberService.java
@@ -41,7 +41,7 @@ public class RecruitMemberService {
         answerRepository.saveAll(answers);
     }
 
-    public boolean isRegisteredStudentId(String studentId){
+    public boolean isRegisteredStudentId(String studentId) {
         return recruitMemberRepository.existsByStudentId(studentId);
     }
 

--- a/gdgoc/src/main/java/inha/gdgoc/global/common/ApiResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/global/common/ApiResponse.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 
 @Getter
 public class ApiResponse<T> {
-    private boolean isSuccess;       // 성공 여부
-    private int statusCode;
-    private T data;                // 실제 데이터
-    private String message;        // 응답 메시지
+    private final boolean isSuccess;       // 성공 여부
+    private final int statusCode;
+    private final T data;                // 실제 데이터
+    private final String message;        // 응답 메시지
 
     private ApiResponse(boolean isSuccess, int statusCode, T data, String message) {
         this.isSuccess = isSuccess;
@@ -25,8 +25,12 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, HttpStatus.OK.value(), data, message);
     }
 
-    public static <T> ApiResponse<T> success( HttpStatus status, T data, String message) {
+    public static <T> ApiResponse<T> success(HttpStatus status, T data, String message) {
         return new ApiResponse<>(true, status.value(), data, message);
+    }
+
+    public static <T> ApiResponse<T> failure(T data, String message) {
+        return new ApiResponse<>(false, HttpStatus.OK.value(), data, message);
     }
 
     public static <T> ApiResponse<T> failure(HttpStatus status, T data, String message) {


### PR DESCRIPTION
### 📌 관련 이슈
#19 

### 📌 세부 내용
유효값 검증 실패 시 400을 반환하는데, 프론트 사이트에서 개발자 도구 이용하면 서버 주소가 노출돼서 200으로 변경