### PR TITLE
[FIX] 게임 예문에 실행 결과까지 추가

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/dto/request/GameQuestionRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/dto/request/GameQuestionRequest.java
@@ -9,11 +9,13 @@ import lombok.NoArgsConstructor;
 public class GameQuestionRequest {
     private String language;
     private String content;
+    private String result;
 
     public GameQuestion toEntity() {
         return GameQuestion.builder()
                 .language(language)
                 .content(content)
+                .result(result)
                 .build();
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/dto/response/GameQuestionResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/dto/response/GameQuestionResponse.java
@@ -9,10 +9,12 @@ public class GameQuestionResponse {
     private Long id;
     private String language;
     private String content;
+    private String result;
 
     public GameQuestionResponse(GameQuestion gameQuestion) {
         this.id = gameQuestion.getId();
         this.language = gameQuestion.getLanguage();
         this.content = gameQuestion.getContent();
+        this.result = gameQuestion.getResult();
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/entity/GameQuestion.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/entity/GameQuestion.java
@@ -28,4 +28,7 @@ public class GameQuestion {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    @Column(name = "result", nullable = false)
+    private String result;
 }


### PR DESCRIPTION
### 📌 연관된 이슈
closed #27 


### ✨ 작업 내용
비개발자의 흥미 유도를 위해 타자게임 하고나서 실제로 컴파일했으면 이렇게 나온다는 내용을 추가하기 위해 엔티티에 실행 결과 추가


### 💬 리뷰 요구사항(선택)
