### PR TITLE
[FIX] application.yml이 .env 못 찾아서 서버 무한 재시작하는 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
           echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env
+          echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .env
+          echo "GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}" >> .env
           
           zip -r deploy.zip .env docker-compose.yml deploy.sh appspec.yml
 

--- a/gdgoc/docker-compose.yml
+++ b/gdgoc/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       SPRING_DATASOURCE_URL: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}"
       SPRING_DATASOURCE_USERNAME: "${DB_USERNAME}"
       SPRING_DATASOURCE_PASSWORD: "${DB_PASSWORD}"
+    env_file:
+      - .env


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
application.yml이 .env 못 찾아서 서버 무한 재시작하는 문제 해결했습니다.
깃허브 시크릿에 키 추가하고 그걸 CI 중에 .env에 넣어서 얘를 사용할 수 있도록 바꿨습니다.


### 💬 리뷰 요구사항(선택)
