### PR TITLE
[FIX] 토큰 재발급 시 헤더 대신 쿠키로 확인하도록

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -10,10 +10,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,8 +44,8 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshToken(
-            @RequestHeader("Authorization") String refreshToken) {
+    public ResponseEntity<?> refreshAccessToken(
+            @CookieValue(value = "refresh_token", required = false) String refreshToken) {
         String newAccessToken = refreshTokenService.refreshAccessToken(refreshToken);
         AccessTokenResponse data = new AccessTokenResponse(newAccessToken);
         return ResponseEntity.ok(ApiResponse.success(data));


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- 토큰 재발급 시 쿠키 분석하는 걸로 변경


### 💬 리뷰 요구사항(선택)
