### PR TITLE
[FIX] 토큰 재발급 시 헤더 대신 쿠키로 확인하도록

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -10,10 +10,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,8 +44,8 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshToken(
-            @RequestHeader("Authorization") String refreshToken) {
+    public ResponseEntity<?> refreshAccessToken(
+            @CookieValue(value = "refresh_token", required = false) String refreshToken) {
         String newAccessToken = refreshTokenService.refreshAccessToken(refreshToken);
         AccessTokenResponse data = new AccessTokenResponse(newAccessToken);
         return ResponseEntity.ok(ApiResponse.success(data));

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/GoogleOAuthService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/GoogleOAuthService.java
@@ -97,7 +97,7 @@ public class GoogleOAuthService {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
-        cookie.setMaxAge(60 * 10); // 2주로 변경하기
+        cookie.setMaxAge(20); // 2주로 변경하기
         response.addCookie(cookie);
 
         return Map.of(


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- 토큰 재발급 시 헤더 대신 쿠키로 확인하도록


### 💬 리뷰 요구사항(선택)
