### PR TITLE
[FIX] 리프레시 토큰 갱신 시 토큰 검사 건너뛰도록 변경

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
@@ -26,6 +26,13 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             @NotNull HttpServletRequest request,
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        if (uri.equals("/auth/refresh")) {
+            // 리프레시 토큰은 여기서 검사하지 않음
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = getAccessToken(request);
         log.info("요청 URI: {}, 추출된 access token: {}", request.getRequestURI(), token);
 


### PR DESCRIPTION
### 📌 연관된 이슈
#5

### ✨ 작업 내용
- 리프레시 토큰 갱신 시 토큰 검사 건너뛰도록 변경

### 💬 리뷰 요구사항(선택)
