### PR TITLE
[FIX] 리프레시 토큰 갱신 시 토큰 검사 건너뛰도록 변경

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
@@ -26,6 +26,13 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             @NotNull HttpServletRequest request,
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        if (uri.equals("/auth/refresh")) {
+            // 리프레시 토큰은 여기서 검사하지 않음
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = getAccessToken(request);
         log.info("요청 URI: {}, 추출된 access token: {}", request.getRequestURI(), token);
 

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import inha.gdgoc.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,6 +47,9 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshAccessToken(
             @CookieValue(value = "refresh_token", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token is missing.");
+        }
         String newAccessToken = refreshTokenService.refreshAccessToken(refreshToken);
         AccessTokenResponse data = new AccessTokenResponse(newAccessToken);
         return ResponseEntity.ok(ApiResponse.success(data));


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- 리프레시 토큰 갱신 시 토큰 검사 건너뛰도록 변경


### 💬 리뷰 요구사항(선택)
