### PR TITLE
[FIX] access token 갱신 시 Null로 반환되는 부분과 관련한 로그 추가

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import inha.gdgoc.domain.auth.service.GoogleOAuthService;
 import inha.gdgoc.domain.auth.service.RefreshTokenService;
 import inha.gdgoc.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,24 +48,32 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshAccessToken(
+    public ResponseEntity<ApiResponse<Map<String, Object>>> refreshAccessToken(
             @CookieValue(value = "refresh_token", required = false) String refreshToken) {
 
         log.info("리프레시 토큰 요청 받음. 토큰 존재 여부: {}", refreshToken != null);
 
         if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token is missing.");
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.failure(HttpStatus.UNAUTHORIZED, null, "Refresh token is missing."));
         }
 
         log.info("리프레시 토큰 값: {}", refreshToken);
 
         try {
             String newAccessToken = refreshTokenService.refreshAccessToken(refreshToken);
-            AccessTokenResponse data = new AccessTokenResponse(newAccessToken);
+            log.info("새로운 AccessToken 값: {}", newAccessToken);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("accessToken", newAccessToken);
+
             return ResponseEntity.ok(ApiResponse.success(data));
         } catch (Exception e) {
             log.error("리프레시 토큰 처리 중 오류: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid refresh token: " + e.getMessage());
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.failure(HttpStatus.UNAUTHORIZED, null, "Invalid refresh token: " + e.getMessage()));
         }
     }
 

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/RefreshTokenService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/RefreshTokenService.java
@@ -85,7 +85,7 @@ public class RefreshTokenService {
                 throw new RuntimeException("Invalid Refresh Token");
             }
 
-            return tokenProvider.generateGoogleLoginToken(user, Duration.ofHours(1));
+            return tokenProvider.generateGoogleLoginToken(user, Duration.ofSeconds(5));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- access token 갱신 api에서 200은 뜨고, 에러 로그는 나오지 않는데 데이터가 Null로 반환되는 부분을 확인하기 위한 코드를 추가했습니다.


### 💬 리뷰 요구사항(선택)
