### PR TITLE
[REFACTOR] api 공통 응답에서 의미 중복되는 부분 삭제 및 오류 시 응답 분리

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/UserLoginRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/UserLoginRequest.java
@@ -1,0 +1,8 @@
+package inha.gdgoc.domain.auth.dto.request;
+
+import inha.gdgoc.global.common.BaseEntity;
+
+public class UserLoginRequest extends BaseEntity {
+    private String id;
+    private String password;
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameQuestionController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameQuestionController.java
@@ -24,11 +24,11 @@ public class GameQuestionController {
             @RequestBody GameQuestionRequest gameQuestionRequest) {
         gameQuestionService.saveQuestion(gameQuestionRequest);
 
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity.ok(ApiResponse.of(null));
     }
 
     @GetMapping("/game/questions")
     public ResponseEntity<ApiResponse<List<GameQuestionResponse>>> getRandomGameQuestions() {
-        return ResponseEntity.ok(ApiResponse.success(gameQuestionService.getRandomQuestionsByLanguage()));
+        return ResponseEntity.ok(ApiResponse.of(gameQuestionService.getRandomQuestionsByLanguage()));
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameUserController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameUserController.java
@@ -20,11 +20,11 @@ public class GameUserController {
 
     @PostMapping("/game/result")
     public ResponseEntity<ApiResponse<List<GameUserResponse>>> saveGameResult(@RequestBody GameUserRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(gameUserService.saveGameResultAndGetRanking(request)));
+        return ResponseEntity.ok(ApiResponse.of(gameUserService.saveGameResultAndGetRanking(request)));
     }
 
     @GetMapping("/game/results")
     public ResponseEntity<ApiResponse<List<GameUserResponse>>> getUserRankings() {
-        return ResponseEntity.ok(ApiResponse.success(gameUserService.findUserRankings()));
+        return ResponseEntity.ok(ApiResponse.of(gameUserService.findUserRankings()));
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/recruit/controller/RecruitMemberController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/recruit/controller/RecruitMemberController.java
@@ -25,28 +25,28 @@ public class RecruitMemberController {
     public ResponseEntity<ApiResponse<ApplicationRequest>> recruitMemberAdd(
             @RequestBody ApplicationRequest applicationRequest) {
         recruitMemberService.addRecruitMember(applicationRequest);
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity.ok(ApiResponse.of(null));
     }
 
     @GetMapping("/check/studentId")
     public ResponseEntity<ApiResponse<Boolean>> duplicatedStudentIdDetails(
             @Valid @ModelAttribute CheckStudentIdRequest studentIdRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return ResponseEntity.ok(ApiResponse.failure(true, "학번 형식에 맞지 않는 값입니다."));
+            return ResponseEntity.ok(ApiResponse.of(true));
         }
 
         boolean exists = recruitMemberService.isRegisteredStudentId(studentIdRequest.getStudentId());
-        return ResponseEntity.ok(ApiResponse.success(exists, exists ? "이미 등록된 학번입니다." : "사용 가능한 학번입니다."));
+        return ResponseEntity.ok(ApiResponse.of(exists));
     }
 
     @GetMapping("/check/phoneNumber")
     public ResponseEntity<ApiResponse<Boolean>> duplicatedPhoneNumberDetails(
             @Valid @ModelAttribute CheckPhoneNumberRequest phoneNumberRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return ResponseEntity.ok(ApiResponse.failure(true, "전화번호 형식에 맞지 않는 값입니다."));
+            return ResponseEntity.ok(ApiResponse.of(true));
         }
 
         boolean exists = recruitMemberService.isRegisteredPhoneNumber(phoneNumberRequest.getPhoneNumber());
-        return ResponseEntity.ok(ApiResponse.success(exists, exists ? "이미 등록된 전화번호입니다." : "사용 가능한 전화번호입니다."));
+        return ResponseEntity.ok(ApiResponse.of(exists));
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/global/common/ApiResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/global/common/ApiResponse.java
@@ -1,39 +1,22 @@
 package inha.gdgoc.global.common;
 
-import org.springframework.http.HttpStatus;
 import lombok.Getter;
 
 @Getter
 public class ApiResponse<T> {
-    private final boolean isSuccess;       // 성공 여부
-    private final int statusCode;
-    private final T data;                // 실제 데이터
-    private final String message;        // 응답 메시지
+    private final T data;
+    private final Object meta; // meta는 optional
 
-    private ApiResponse(boolean isSuccess, int statusCode, T data, String message) {
-        this.isSuccess = isSuccess;
-        this.statusCode = statusCode;
+    private ApiResponse(T data, Object meta) {
         this.data = data;
-        this.message = message;
+        this.meta = meta;
     }
 
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, HttpStatus.OK.value(), data, "요청이 성공적으로 처리되었습니다.");
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data, null);
     }
 
-    public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, HttpStatus.OK.value(), data, message);
-    }
-
-    public static <T> ApiResponse<T> success(HttpStatus status, T data, String message) {
-        return new ApiResponse<>(true, status.value(), data, message);
-    }
-
-    public static <T> ApiResponse<T> failure(T data, String message) {
-        return new ApiResponse<>(false, HttpStatus.OK.value(), data, message);
-    }
-
-    public static <T> ApiResponse<T> failure(HttpStatus status, T data, String message) {
-        return new ApiResponse<>(false, status.value(), data, message);
+    public static <T> ApiResponse<T> of(T data, Object meta) {
+        return new ApiResponse<>(data, meta);
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/global/common/ErrorResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/global/common/ErrorResponse.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String error;
+}


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- api 공통 응답에서 statusCode, isSuccess, message가 같은 정보를 알려주고 있어 삭제
- 오류 시 응답은 message만 전달하여 프론트에 상세 정보만 추가로 알려줌


### 💬 리뷰 요구사항(선택)
