### PR TITLE
[REFACTOR] api 공통 응답에서 의미 중복되는 부분 삭제 및 오류 시 응답 분리

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -7,7 +7,6 @@ import inha.gdgoc.domain.auth.service.GoogleOAuthService;
 import inha.gdgoc.domain.auth.service.RefreshTokenService;
 import inha.gdgoc.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +47,7 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> refreshAccessToken(
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshAccessToken(
             @CookieValue(value = "refresh_token", required = false) String refreshToken) {
 
         log.info("리프레시 토큰 요청 받음. 토큰 존재 여부: {}", refreshToken != null);
@@ -63,12 +62,8 @@ public class AuthController {
 
         try {
             String newAccessToken = refreshTokenService.refreshAccessToken(refreshToken);
-            log.info("새로운 AccessToken 값: {}", newAccessToken);
-
-            Map<String, Object> data = new HashMap<>();
-            data.put("accessToken", newAccessToken);
-
-            return ResponseEntity.ok(ApiResponse.success(data));
+            AccessTokenResponse accessTokenResponse = new AccessTokenResponse(newAccessToken);
+            return ResponseEntity.ok(ApiResponse.success(accessTokenResponse));
         } catch (Exception e) {
             log.error("리프레시 토큰 처리 중 오류: {}", e.getMessage(), e);
             return ResponseEntity

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/UserLoginRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/UserLoginRequest.java
@@ -1,0 +1,8 @@
+package inha.gdgoc.domain.auth.dto.request;
+
+import inha.gdgoc.global.common.BaseEntity;
+
+public class UserLoginRequest extends BaseEntity {
+    private String id;
+    private String password;
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/response/AccessTokenResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,11 +1,13 @@
 package inha.gdgoc.domain.auth.dto.response;
 
 import inha.gdgoc.global.common.BaseEntity;
+import lombok.Getter;
 
+@Getter
 public class AccessTokenResponse extends BaseEntity {
-    private final String accessToken;
+    private final String access_token;
 
     public AccessTokenResponse(String accessToken) {
-        this.accessToken = accessToken;
+        this.access_token = accessToken;
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameQuestionController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameQuestionController.java
@@ -24,11 +24,11 @@ public class GameQuestionController {
             @RequestBody GameQuestionRequest gameQuestionRequest) {
         gameQuestionService.saveQuestion(gameQuestionRequest);
 
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity.ok(ApiResponse.of(null));
     }
 
     @GetMapping("/game/questions")
     public ResponseEntity<ApiResponse<List<GameQuestionResponse>>> getRandomGameQuestions() {
-        return ResponseEntity.ok(ApiResponse.success(gameQuestionService.getRandomQuestionsByLanguage()));
+        return ResponseEntity.ok(ApiResponse.of(gameQuestionService.getRandomQuestionsByLanguage()));
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameUserController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/game/controller/GameUserController.java
@@ -20,11 +20,11 @@ public class GameUserController {
 
     @PostMapping("/game/result")
     public ResponseEntity<ApiResponse<List<GameUserResponse>>> saveGameResult(@RequestBody GameUserRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(gameUserService.saveGameResultAndGetRanking(request)));
+        return ResponseEntity.ok(ApiResponse.of(gameUserService.saveGameResultAndGetRanking(request)));
     }
 
     @GetMapping("/game/results")
     public ResponseEntity<ApiResponse<List<GameUserResponse>>> getUserRankings() {
-        return ResponseEntity.ok(ApiResponse.success(gameUserService.findUserRankings()));
+        return ResponseEntity.ok(ApiResponse.of(gameUserService.findUserRankings()));
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/recruit/controller/RecruitMemberController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/recruit/controller/RecruitMemberController.java
@@ -28,29 +28,29 @@ public class RecruitMemberController {
     public ResponseEntity<ApiResponse<ApplicationRequest>> recruitMemberAdd(
             @RequestBody ApplicationRequest applicationRequest) {
         recruitMemberService.addRecruitMember(applicationRequest);
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity.ok(ApiResponse.of(null));
     }
 
     @GetMapping("/check/studentId")
     public ResponseEntity<ApiResponse<Boolean>> duplicatedStudentIdDetails(
             @Valid @ModelAttribute CheckStudentIdRequest studentIdRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return ResponseEntity.ok(ApiResponse.failure(true, "학번 형식에 맞지 않는 값입니다."));
+            return ResponseEntity.ok(ApiResponse.of(true));
         }
 
         boolean exists = recruitMemberService.isRegisteredStudentId(studentIdRequest.getStudentId());
-        return ResponseEntity.ok(ApiResponse.success(exists, exists ? "이미 등록된 학번입니다." : "사용 가능한 학번입니다."));
+        return ResponseEntity.ok(ApiResponse.of(exists));
     }
 
     @GetMapping("/check/phoneNumber")
     public ResponseEntity<ApiResponse<Boolean>> duplicatedPhoneNumberDetails(
             @Valid @ModelAttribute CheckPhoneNumberRequest phoneNumberRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return ResponseEntity.ok(ApiResponse.failure(true, "전화번호 형식에 맞지 않는 값입니다."));
+            return ResponseEntity.ok(ApiResponse.of(true));
         }
 
         boolean exists = recruitMemberService.isRegisteredPhoneNumber(phoneNumberRequest.getPhoneNumber());
-        return ResponseEntity.ok(ApiResponse.success(exists, exists ? "이미 등록된 전화번호입니다." : "사용 가능한 전화번호입니다."));
+        return ResponseEntity.ok(ApiResponse.of(exists));
     }
 
     @GetMapping("/recruit/member")

--- a/gdgoc/src/main/java/inha/gdgoc/global/common/ApiResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/global/common/ApiResponse.java
@@ -1,39 +1,22 @@
 package inha.gdgoc.global.common;
 
-import org.springframework.http.HttpStatus;
 import lombok.Getter;
 
 @Getter
 public class ApiResponse<T> {
-    private final boolean isSuccess;       // 성공 여부
-    private final int statusCode;
-    private final T data;                // 실제 데이터
-    private final String message;        // 응답 메시지
+    private final T data;
+    private final Object meta; // meta는 optional
 
-    private ApiResponse(boolean isSuccess, int statusCode, T data, String message) {
-        this.isSuccess = isSuccess;
-        this.statusCode = statusCode;
+    private ApiResponse(T data, Object meta) {
         this.data = data;
-        this.message = message;
+        this.meta = meta;
     }
 
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, HttpStatus.OK.value(), data, "요청이 성공적으로 처리되었습니다.");
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data, null);
     }
 
-    public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, HttpStatus.OK.value(), data, message);
-    }
-
-    public static <T> ApiResponse<T> success(HttpStatus status, T data, String message) {
-        return new ApiResponse<>(true, status.value(), data, message);
-    }
-
-    public static <T> ApiResponse<T> failure(T data, String message) {
-        return new ApiResponse<>(false, HttpStatus.OK.value(), data, message);
-    }
-
-    public static <T> ApiResponse<T> failure(HttpStatus status, T data, String message) {
-        return new ApiResponse<>(false, status.value(), data, message);
+    public static <T> ApiResponse<T> of(T data, Object meta) {
+        return new ApiResponse<>(data, meta);
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/global/common/ErrorResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/global/common/ErrorResponse.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String error;
+}


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- api 공통 응답에서 isSuccess, statusCode, message가 같은 의미로 사용되어 삭제
- 오류 시 응답을 기본 응답과 분리하고, 오류 시에는 실패 이유를 설명할 수 있는 message만 json body에 전달


### 💬 리뷰 요구사항(선택)
