### PR TITLE
[FEAT] 아이디 찾기 구현

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package inha.gdgoc.domain.auth.controller;
 
+import inha.gdgoc.domain.auth.dto.request.FindIdRequest;
 import inha.gdgoc.domain.auth.dto.request.UserSignupRequest;
 import inha.gdgoc.domain.auth.dto.response.AccessTokenResponse;
+import inha.gdgoc.domain.auth.dto.response.FindIdResponse;
 import inha.gdgoc.domain.auth.service.AuthService;
 import inha.gdgoc.domain.auth.service.GoogleOAuthService;
 import inha.gdgoc.domain.auth.service.RefreshTokenService;
@@ -81,4 +83,15 @@ public class AuthController {
 
     // TODO 로그아웃
 
+    @GetMapping("/findId")
+    public ResponseEntity<?> findId(@RequestBody FindIdRequest findIdRequest) {
+        try {
+            FindIdResponse response = authService.findId(findIdRequest);
+            return ResponseEntity.ok(ApiResponse.of(response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(new ErrorResponse("해당 정보로 가입된 사용자가 없습니다."));
+        }
+    }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/FindIdRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/FindIdRequest.java
@@ -1,0 +1,13 @@
+package inha.gdgoc.domain.auth.dto.request;
+
+import inha.gdgoc.global.common.BaseEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FindIdRequest extends BaseEntity {
+    private String name;
+    private String major;
+    private String phoneNumber;
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/response/FindIdResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/response/FindIdResponse.java
@@ -1,0 +1,4 @@
+package inha.gdgoc.domain.auth.dto.response;
+
+public record FindIdResponse(String email) {
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/user/repository/UserRepositoryCustom.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/user/repository/UserRepositoryCustom.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepositoryCustom {
     List<User> findAllUsers();
     Optional<User> findByEmail(String email);
+    Optional<User> findByNameAndMajorAndPhoneNumber(String name, String major, String phoneNumber);
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/user/repository/UserRepositoryImpl.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/user/repository/UserRepositoryImpl.java
@@ -36,4 +36,20 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
         return Optional.ofNullable(foundUser);
     }
+
+    @Override
+    public Optional<User> findByNameAndMajorAndPhoneNumber(String name, String major, String phoneNumber) {
+        QUser user = QUser.user;
+
+        User foundUser = queryFactory
+                .selectFrom(user)
+                .where(
+                        user.name.eq(name),
+                        user.major.eq(major),
+                        user.phoneNumber.eq(phoneNumber)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(foundUser);
+    }
 }


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
- 이름, 학과, 전화번호로 가입된 유저 정보를 찾고, 유저가 있으면 해당 유저의 이메일을 마스킹하여 반환합니다.


### 💬 리뷰 요구사항(선택)
