### PR TITLE
[FEAT] 자체 로그인, 로그아웃, 비밀번호 재설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
           echo "GOOGLE_ISSUER=${{secrets.GOOGLE_ISSUER}}" >> .env
           echo "SELF_ISSUER=${{secrets.SELF_ISSUER}}" >> .env
           echo "SECRET_KEY=${{secrets.SECRET_KEY}}" >> .env
+          echo "GMAIL=${{secrets.GMAIL}}" >> .env
+          ehco "GMAIL_PASSWORD=${{secrets.GMAIL_PASSWORD}}" >> .env
           
           zip -r deploy.zip .env docker-compose.yml deploy.sh appspec.yml
 

--- a/gdgoc/build.gradle
+++ b/gdgoc/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+    // mail sender
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/gdgoc/src/main/java/inha/gdgoc/config/DotenvLoader.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/DotenvLoader.java
@@ -14,6 +14,8 @@ public class DotenvLoader {
             System.setProperty("GOOGLE_CLIENT_ID", dotenv.get("GOOGLE_CLIENT_ID"));
             System.setProperty("GOOGLE_CLIENT_SECRET", dotenv.get("GOOGLE_CLIENT_SECRET"));
             System.setProperty("GOOGLE_REDIRECT_URI", dotenv.get("GOOGLE_REDIRECT_URI"));
+            System.setProperty("GMAIL", dotenv.get("GMAIL"));
+            System.setProperty("GMAIL_PASSWORD", dotenv.get("GMAIL_PASSWORD"));
         } catch (Exception e) {
             e.printStackTrace();  // 오류 로그 출력
             throw new RuntimeException("Error loading .env file: " + e.getMessage(), e);

--- a/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             @NotNull FilterChain filterChain) throws ServletException, IOException {
         String uri = request.getRequestURI();
         List<String> skipPaths = List.of("/auth/refresh", "/auth/login", "/auth/oauth2/google/callback",
-                "/auth/signup", "/auth/findId");
+                "/auth/signup", "/auth/findId", "/auth/password-reset/request");
         if (skipPaths.contains(uri)) {
             filterChain.doFilter(request, response);
             return;

--- a/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/TokenAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -27,8 +28,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain) throws ServletException, IOException {
         String uri = request.getRequestURI();
-        if (uri.equals("/auth/refresh")) {
-            // 리프레시 토큰은 여기서 검사하지 않음
+        List<String> skipPaths = List.of("/auth/refresh", "/auth/login", "/auth/oauth2/google/callback",
+                "/auth/signup", "/auth/findId");
+        if (skipPaths.contains(uri)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/gdgoc/src/main/java/inha/gdgoc/config/jwt/TokenProvider.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/jwt/TokenProvider.java
@@ -48,6 +48,15 @@ public class TokenProvider {
         );
     }
 
+    public String generateRefreshToken(User user, Duration expiredAt) {
+        Date now = new Date();
+        return makeToken(
+                new Date(now.getTime() + expiredAt.toMillis()),
+                user,
+                LoginType.REFRESH
+        );
+    }
+
     public Claims validToken(String token) {
         try {
             return getClaims(token);

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -116,9 +116,9 @@ public class AuthController {
         Cookie cookie = new Cookie("refresh_token", null);
         cookie.setMaxAge(0);
         cookie.setPath("/");
-        cookie.setHttpOnly(true);
+        cookie.setHttpOnly(false);
         cookie.setSecure(true);
-        cookie.setDomain(".gdgocinha.com");
+        cookie.setDomain("localhost");
         response.addCookie(cookie);
     }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package inha.gdgoc.domain.auth.controller;
 
+import inha.gdgoc.domain.auth.dto.request.CodeVerificationRequest;
 import inha.gdgoc.domain.auth.dto.request.PasswordResetRequest;
 import inha.gdgoc.domain.auth.dto.request.UserLoginRequest;
 import inha.gdgoc.domain.auth.dto.response.AccessTokenResponse;
+import inha.gdgoc.domain.auth.dto.response.CodeVerificationResponse;
 import inha.gdgoc.domain.auth.dto.response.LoginResponse;
 import inha.gdgoc.domain.auth.service.AuthCodeService;
 import inha.gdgoc.domain.auth.service.AuthService;
@@ -121,8 +123,18 @@ public class AuthController {
                 .body(ApiResponse.of(null, null));
     }
 
+    @PostMapping("/password-reset/verify")
+    public ResponseEntity<ApiResponse<CodeVerificationResponse>> verifyCode(
+            @RequestBody CodeVerificationRequest codeVerificationRequest
+    ) {
+        return ResponseEntity.ok(ApiResponse.of(new CodeVerificationResponse(authCodeService.verify(
+                codeVerificationRequest.email(), codeVerificationRequest.code()))));
+    }
+
     private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() == null) return null;
+        if (request.getCookies() == null) {
+            return null;
+        }
         for (Cookie cookie : request.getCookies()) {
             if ("refresh_token".equals(cookie.getName())) {
                 return cookie.getValue();

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/CodeVerificationRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/CodeVerificationRequest.java
@@ -1,0 +1,4 @@
+package inha.gdgoc.domain.auth.dto.request;
+
+public record CodeVerificationRequest(String email, String code) {
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/PasswordResetRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/PasswordResetRequest.java
@@ -1,4 +1,4 @@
 package inha.gdgoc.domain.auth.dto.request;
 
-public record PasswordResetRequest(String name, String email) {
+public record PasswordResetRequest(String email, String password) {
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/PasswordResetRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/PasswordResetRequest.java
@@ -1,0 +1,4 @@
+package inha.gdgoc.domain.auth.dto.request;
+
+public record PasswordResetRequest(String name, String email) {
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/SendingCodeRequest.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/request/SendingCodeRequest.java
@@ -1,0 +1,4 @@
+package inha.gdgoc.domain.auth.dto.request;
+
+public record SendingCodeRequest(String name, String email) {
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/response/CodeVerificationResponse.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/dto/response/CodeVerificationResponse.java
@@ -1,0 +1,4 @@
+package inha.gdgoc.domain.auth.dto.response;
+
+public record CodeVerificationResponse(boolean isEqual) {
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/entity/RefreshToken.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/entity/RefreshToken.java
@@ -4,11 +4,12 @@ import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,7 +30,7 @@ public class RefreshToken extends BaseEntity {
     @Column(nullable = false, unique = true, columnDefinition = "TEXT")
     private String token;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY) // 1:N 관계
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/enums/LoginType.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/enums/LoginType.java
@@ -2,5 +2,6 @@ package inha.gdgoc.domain.auth.enums;
 
 public enum LoginType {
     SELF_SIGNUP,
-    GOOGLE_LOGIN
+    GOOGLE_LOGIN,
+    REFRESH
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/repository/RefreshTokenRepository.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/repository/RefreshTokenRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByUser(User user);
+
+    void deleteByUserIdAndToken(Long userId, String token); // 로그아웃할 때 이 토큰만 삭제
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthCodeService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthCodeService.java
@@ -1,0 +1,49 @@
+package inha.gdgoc.domain.auth.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCodeService {
+
+    private static class AuthCodeInfo {
+        private final String code;
+        private final LocalDateTime issuedAt;
+
+        AuthCodeInfo(String code, LocalDateTime issuedAt) {
+            this.code = code;
+            this.issuedAt = issuedAt;
+        }
+
+        boolean isExpired(Duration expiration) {
+            return issuedAt.plus(expiration).isBefore(LocalDateTime.now());
+        }
+
+        boolean matches(String inputCode) {
+            return code.equals(inputCode);
+        }
+    }
+
+    private final Map<String, AuthCodeInfo> codeStorage = new ConcurrentHashMap<>();
+    private final Duration EXPIRATION = Duration.ofMinutes(5);
+
+    public void saveAuthCode(String email, String code) {
+        codeStorage.put(email, new AuthCodeInfo(code, LocalDateTime.now()));
+    }
+
+    public boolean verify(String email, String code) {
+        AuthCodeInfo info = codeStorage.get(email);
+        if (info == null) return false;
+        if (info.isExpired(EXPIRATION)) {
+            codeStorage.remove(email); // 만료된 건 제거
+            return false;
+        }
+        return info.matches(code);
+    }
+}
+

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
@@ -95,11 +95,11 @@ public class AuthService {
         String refreshToken = refreshTokenService.getOrCreateRefreshToken(user, Duration.ofDays(1));
 
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
-                .httpOnly(true)
+                .httpOnly(false)
                 .secure(true)
                 .sameSite("None")
                 .path("/")
-                .domain(".gdgocinha.com")
+                .domain("localhost")
                 .maxAge(Duration.ofDays(1))
                 .build();
 
@@ -128,11 +128,11 @@ public class AuthService {
         String refreshToken = refreshTokenService.getOrCreateRefreshToken(foundUser, Duration.ofDays(1));
 
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
-                .httpOnly(true)
-                .secure(true)
+                .httpOnly(false)
+                .secure(false)
                 .sameSite("None")
                 .path("/")
-                .domain(".gdgocinha.com")
+                .domain("localhost")
                 .maxAge(Duration.ofDays(1))
                 .build();
 

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
@@ -91,21 +91,20 @@ public class AuthService {
 
         User user = foundUser.get();
 
-        // TODO 시간 바꾸기
-        String jwtAccessToken = tokenProvider.generateGoogleLoginToken(user, Duration.ofSeconds(5));
-        String refreshToken = refreshTokenService.getOrCreateRefreshToken(user, Duration.ofSeconds(20));
+        String jwtAccessToken = tokenProvider.generateGoogleLoginToken(user, Duration.ofHours(1));
+        String refreshToken = refreshTokenService.getOrCreateRefreshToken(user, Duration.ofDays(1));
 
-        // ResponseCookie 객체 생성
-        ResponseCookie responseCookie = ResponseCookie.from("refresh_token", refreshToken)
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
-                .secure(true)  // HTTPS 사용 시
+                .secure(true)
+                .sameSite("None")
                 .path("/")
-                .maxAge(Duration.ofSeconds(20))
-                .sameSite("None")  // 크로스 사이트 요청 허용 (secure=true 필요)
+                .domain(".gdgocinha.com")
+                .maxAge(Duration.ofDays(1))
                 .build();
 
         // Set-Cookie 헤더로 추가
-        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         return Map.of(
                 "exists", true, // 회원 존재 & 로그인
@@ -125,20 +124,19 @@ public class AuthService {
             return new LoginResponse(false, null);
         }
 
-        String accessToken = tokenProvider.generateSelfSignupToken(foundUser, Duration.ofSeconds(5));
-        String refreshToken = refreshTokenService.getOrCreateRefreshToken(foundUser, Duration.ofSeconds(20));
+        String accessToken = tokenProvider.generateSelfSignupToken(foundUser, Duration.ofHours(1));
+        String refreshToken = refreshTokenService.getOrCreateRefreshToken(foundUser, Duration.ofDays(1));
 
-        // ResponseCookie 객체 생성
-        ResponseCookie responseCookie = ResponseCookie.from("refresh_token", refreshToken)
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
-                .secure(true)  // HTTPS 사용 시
+                .secure(true)
+                .sameSite("None")
                 .path("/")
-                .maxAge(Duration.ofSeconds(20))
-                .sameSite("None")  // 크로스 사이트 요청 허용 (secure=true 필요)
+                .domain(".gdgocinha.com")
+                .maxAge(Duration.ofDays(1))
                 .build();
 
-        // Set-Cookie 헤더로 추가
-        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         return new LoginResponse(true, accessToken);
     }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/MailService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/MailService.java
@@ -1,0 +1,36 @@
+package inha.gdgoc.domain.auth.service;
+
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    @Value("${spring.mail.username}")
+    private String sender;
+
+    @Autowired(required = false)
+    private final JavaMailSender mailSender;
+
+    public String sendAuthCode(String toEmail) {
+        String code = String.format("%06d", new Random().nextInt(999999));
+        String subject = "[GDGoC INHA] 비밀번호 재설정 인증 코드";
+        String text = "5분 내에 인증을 완료해주세요!\n인증 코드: " + code;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setFrom(sender);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+
+        return code;
+    }
+
+}

--- a/gdgoc/src/main/java/inha/gdgoc/domain/user/entity/User.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.user.entity;
 
 import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.global.common.BaseEntity;
+import inha.gdgoc.util.EncryptUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -82,4 +83,7 @@ public class User extends BaseEntity {
         this.careers = careers != null ? careers : new Careers();
     }
 
+    public void updatePassword(String password) {
+        this.password = EncryptUtil.encrypt(password, this.salt);
+    }
 }

--- a/gdgoc/src/main/java/inha/gdgoc/domain/user/repository/UserRepository.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
+    boolean existsByNameAndEmail(String name, String email);
 }

--- a/gdgoc/src/main/resources/application-local.yml
+++ b/gdgoc/src/main/resources/application-local.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     database: postgresql
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         default_batch_fetch_size: 100

--- a/gdgoc/src/main/resources/application-local.yml
+++ b/gdgoc/src/main/resources/application-local.yml
@@ -14,6 +14,17 @@ spring:
         default_batch_fetch_size: 100
         jdbc:
           time_zone: Asia/Seoul
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/gdgoc/src/main/resources/application-prod.yml
+++ b/gdgoc/src/main/resources/application-prod.yml
@@ -17,7 +17,17 @@ spring:
         default_batch_fetch_size: 100
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 logging:
   level:


### PR DESCRIPTION
### 📌 연관된 이슈
- #5 

### ✨ 작업 내용
- 자체 로그인 시 토큰 발급 부분 약간 수정
- 로그아웃 구현 (인당 하나의 리프레시 토큰만 관리)
- 메일 센더 이용해서 비밀번호 재설정 구현


### 💬 리뷰 요구사항(선택)
