### PR TITLE
[FIX] 토큰 재발급 시 로그인 타입을 enum으로 저장

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/RefreshTokenService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/RefreshTokenService.java
@@ -84,7 +84,8 @@ public class RefreshTokenService {
         }
 
         // 3. AccessToken 새로 발급
-        LoginType loginType = claims.get("loginType", LoginType.class);
+        String loginTypeStr = claims.get("loginType", String.class);
+        LoginType loginType = LoginType.valueOf(loginTypeStr);
 
         return (loginType == LoginType.SELF_SIGNUP)
                 ? tokenProvider.generateSelfSignupToken(user, Duration.ofHours(1))


### PR DESCRIPTION
### 📌 연관된 이슈
- #156

### ✨ 작업 내용
- 토큰 재발급 시 로그인 타입 enum으로 저장


### 💬 리뷰 요구사항(선택)
