### PR TITLE
fix(auth): 구글 로그인 시 쿠키 도메인을 프론트 도메인으로 설정

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
+++ b/gdgoc/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
@@ -106,6 +106,7 @@ public class AuthService {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
+                .domain(".gdgocinha.com")
                 .path("/")
                 .maxAge(Duration.ofDays(1))
                 .build();


### PR DESCRIPTION
### 📌 연관된 이슈
- #156

### ✨ 작업 내용
- 구글 로그인 시 쿠키 도메인을 프론트 도메인으로 설정

### 💬 리뷰 요구사항(선택)
