### PR TITLE
[HotFix] file upload size restrictions

### DIFF
--- a/gdgoc/src/main/resources/application-local.yml
+++ b/gdgoc/src/main/resources/application-local.yml
@@ -10,8 +10,8 @@ spring:
     password:
   servlet:
     multipart:
-      max-file-size: 15MB
-      max-request-size: 15MB
+      max-file-size: 10MB
+      max-request-size: 12MB
   jpa:
     database: postgresql
     hibernate:

--- a/gdgoc/src/main/resources/application-local.yml
+++ b/gdgoc/src/main/resources/application-local.yml
@@ -8,6 +8,10 @@ spring:
     url: jdbc:postgresql://localhost:5432/gdgoc
     username: postgres
     password:
+  servlet:
+    multipart:
+      max-file-size: 15MB
+      max-request-size: 15MB
   jpa:
     database: postgresql
     hibernate:

--- a/gdgoc/src/main/resources/application-prod.yml
+++ b/gdgoc/src/main/resources/application-prod.yml
@@ -11,8 +11,8 @@ spring:
     driver-class-name: org.postgresql.Driver
   servlet:
     multipart:
-      max-file-size: 15MB
-      max-request-size: 15MB
+      max-file-size: 10MB
+      max-request-size: 12MB
   jpa:
     database: postgresql
     hibernate:

--- a/gdgoc/src/main/resources/application-prod.yml
+++ b/gdgoc/src/main/resources/application-prod.yml
@@ -9,6 +9,10 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  servlet:
+    multipart:
+      max-file-size: 15MB
+      max-request-size: 15MB
   jpa:
     database: postgresql
     hibernate:

--- a/gdgoc/src/main/resources/application.yml
+++ b/gdgoc/src/main/resources/application.yml
@@ -3,5 +3,5 @@ spring:
     active: local
   servlet:
     multipart:
-      max-file-size: 15MB
-      max-request-size: 15MB
+      max-file-size: 10MB
+      max-request-size: 12MB

--- a/gdgoc/src/main/resources/application.yml
+++ b/gdgoc/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   profiles:
     active: local
+  servlet:
+    multipart:
+      max-file-size: 15MB
+      max-request-size: 15MB

--- a/gdgoc/src/main/resources/application.yml
+++ b/gdgoc/src/main/resources/application.yml
@@ -1,7 +1,3 @@
 spring:
   profiles:
     active: local
-  servlet:
-    multipart:
-      max-file-size: 10MB
-      max-request-size: 12MB


### PR DESCRIPTION
### 📌 연관된 이슈
 > 생성된 이슈 없음

### ✨ 작업 내용
> 자바 스프링의 기본 파일 및 요청 사이즈가 1~2MB이기에 스터디 생성시 일부 이미지가 업로드 불가 문제가 있음.
> 이를 해결하기 위해 최대 파일 업로드 용량 및 최대 요청 용량을 각각 10MB, 12MB로 설정함.

### 💬 리뷰 요구사항(선택)
