### PR TITLE
feat: 행사 게시판 CRUD API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local dev ###
+docker-compose-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ configurations.configureEach {
 dependencies {
     // --- Spring Boot Starters ---
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
@@ -4,6 +4,7 @@ import static inha.gdgoc.domain.board.event.controller.message.EventBoardMessage
 
 import inha.gdgoc.domain.board.event.dto.request.EventBoardCreateRequest;
 import inha.gdgoc.domain.board.event.dto.request.EventBoardUpdateRequest;
+import inha.gdgoc.domain.board.event.dto.response.DeletedEventBoardSummaryResponse;
 import inha.gdgoc.domain.board.event.dto.response.EventBoardDetailResponse;
 import inha.gdgoc.domain.board.event.dto.response.EventBoardSummaryResponse;
 import inha.gdgoc.domain.board.event.enums.SearchType;
@@ -45,7 +46,7 @@ public class EventBoardController {
       @RequestParam(required = false) String keyword) {
     Page<EventBoardSummaryResponse> result =
         eventBoardService.listEventBoards(
-            page, size, searchType, keyword, me != null ? me.getTeam() : null);
+            page, size, searchType, keyword, me != null ? me.getTeam() : null, me != null ? me.getRole() : null);
     return ResponseEntity.ok(
         ApiResponse.ok(EVENT_BOARD_LIST_RETRIEVED, result, PageMeta.of(result)));
   }
@@ -56,7 +57,7 @@ public class EventBoardController {
     return ResponseEntity.ok(
         ApiResponse.ok(
             EVENT_BOARD_RETRIEVED,
-            eventBoardService.getEventBoard(id, me != null ? me.getTeam() : null)));
+            eventBoardService.getEventBoard(id, me != null ? me.getTeam() : null, me != null ? me.getRole() : null)));
   }
 
   @Authorize(@Condition(atLeast = UserRole.CORE))
@@ -73,7 +74,7 @@ public class EventBoardController {
   public ResponseEntity<ApiResponse<Void, Void>> updateEventBoard(
       @AuthenticationPrincipal CustomUserDetails me,
       @PathVariable Long id, @Valid @RequestBody EventBoardUpdateRequest req) {
-    eventBoardService.updateEventBoard(id, req, me.getTeam());
+    eventBoardService.updateEventBoard(id, req, me.getRole(), me.getTeam());
     return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_UPDATED));
   }
 
@@ -82,7 +83,28 @@ public class EventBoardController {
   public ResponseEntity<ApiResponse<Void, Void>> deleteEventBoard(
       @AuthenticationPrincipal CustomUserDetails me,
       @PathVariable Long id) {
-    eventBoardService.deleteEventBoard(id, me.getTeam());
+    eventBoardService.deleteEventBoard(id, me.getRole(), me.getTeam());
     return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_DELETED));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.CORE))
+  @GetMapping("/deleted")
+  public ResponseEntity<ApiResponse<Page<DeletedEventBoardSummaryResponse>, PageMeta>> listDeletedBoards(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "12") int size) {
+    Page<DeletedEventBoardSummaryResponse> result =
+        eventBoardService.listDeletedBoards(page, size, me.getRole(), me.getTeam());
+    return ResponseEntity.ok(
+        ApiResponse.ok(EVENT_BOARD_DELETED_LIST_RETRIEVED, result, PageMeta.of(result)));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.CORE))
+  @PostMapping("/{id}/restore")
+  public ResponseEntity<ApiResponse<Void, Void>> restoreEventBoard(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long id) {
+    eventBoardService.restoreEventBoard(id, me.getRole(), me.getTeam());
+    return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_RESTORED));
   }
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
@@ -1,0 +1,85 @@
+package inha.gdgoc.domain.board.event.controller;
+
+import static inha.gdgoc.domain.board.event.controller.message.EventBoardMessage.*;
+
+import inha.gdgoc.domain.board.event.dto.request.EventBoardCreateRequest;
+import inha.gdgoc.domain.board.event.dto.request.EventBoardUpdateRequest;
+import inha.gdgoc.domain.board.event.dto.response.EventBoardDetailResponse;
+import inha.gdgoc.domain.board.event.dto.response.EventBoardSummaryResponse;
+import inha.gdgoc.domain.board.event.enums.SearchType;
+import inha.gdgoc.domain.board.event.service.EventBoardService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.dto.response.PageMeta;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/board/events")
+@RequiredArgsConstructor
+public class EventBoardController {
+
+  private final EventBoardService eventBoardService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<Page<EventBoardSummaryResponse>, PageMeta>> listEventBoards(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "12") int size,
+      @RequestParam(defaultValue = "TITLE_AND_CONTENT") SearchType searchType,
+      @RequestParam(required = false) String keyword) {
+    Page<EventBoardSummaryResponse> result =
+        eventBoardService.listEventBoards(
+            page, size, searchType, keyword, me != null ? me.getTeam() : null);
+    return ResponseEntity.ok(
+        ApiResponse.ok(EVENT_BOARD_LIST_RETRIEVED, result, PageMeta.of(result)));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<EventBoardDetailResponse, Void>> getEventBoard(
+      @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long id) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(
+            EVENT_BOARD_RETRIEVED,
+            eventBoardService.getEventBoard(id, me != null ? me.getTeam() : null)));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.CORE))
+  @PostMapping
+  public ResponseEntity<ApiResponse<Void, Void>> createEventBoard(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @Valid @RequestBody EventBoardCreateRequest req) {
+    eventBoardService.createEventBoard(req, me.getUserId());
+    return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_CREATED));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.CORE))
+  @PatchMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void, Void>> updateEventBoard(
+      @PathVariable Long id, @Valid @RequestBody EventBoardUpdateRequest req) {
+    eventBoardService.updateEventBoard(id, req);
+    return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_UPDATED));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.CORE))
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void, Void>> deleteEventBoard(@PathVariable Long id) {
+    eventBoardService.deleteEventBoard(id);
+    return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_DELETED));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
@@ -61,25 +61,28 @@ public class EventBoardController {
 
   @Authorize(@Condition(atLeast = UserRole.CORE))
   @PostMapping
-  public ResponseEntity<ApiResponse<Void, Void>> createEventBoard(
+  public ResponseEntity<ApiResponse<Long, Void>> createEventBoard(
       @AuthenticationPrincipal CustomUserDetails me,
       @Valid @RequestBody EventBoardCreateRequest req) {
-    eventBoardService.createEventBoard(req, me.getUserId());
-    return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_CREATED));
+    Long id = eventBoardService.createEventBoard(req, me.getUserId());
+    return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_CREATED, id));
   }
 
   @Authorize(@Condition(atLeast = UserRole.CORE))
   @PatchMapping("/{id}")
   public ResponseEntity<ApiResponse<Void, Void>> updateEventBoard(
+      @AuthenticationPrincipal CustomUserDetails me,
       @PathVariable Long id, @Valid @RequestBody EventBoardUpdateRequest req) {
-    eventBoardService.updateEventBoard(id, req);
+    eventBoardService.updateEventBoard(id, req, me.getTeam());
     return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_UPDATED));
   }
 
   @Authorize(@Condition(atLeast = UserRole.CORE))
   @DeleteMapping("/{id}")
-  public ResponseEntity<ApiResponse<Void, Void>> deleteEventBoard(@PathVariable Long id) {
-    eventBoardService.deleteEventBoard(id);
+  public ResponseEntity<ApiResponse<Void, Void>> deleteEventBoard(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long id) {
+    eventBoardService.deleteEventBoard(id, me.getTeam());
     return ResponseEntity.ok(ApiResponse.ok(EVENT_BOARD_DELETED));
   }
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/controller/EventBoardController.java
@@ -16,10 +16,13 @@ import inha.gdgoc.global.dto.response.PageMeta;
 import inha.gdgoc.global.security.annotation.Authorize;
 import inha.gdgoc.global.security.annotation.Condition;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/board/events")
 @RequiredArgsConstructor
+@Validated
 public class EventBoardController {
 
   private final EventBoardService eventBoardService;
@@ -40,8 +44,8 @@ public class EventBoardController {
   @GetMapping
   public ResponseEntity<ApiResponse<Page<EventBoardSummaryResponse>, PageMeta>> listEventBoards(
       @AuthenticationPrincipal CustomUserDetails me,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "12") int size,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "12") @Min(1) @Max(100) int size,
       @RequestParam(defaultValue = "TITLE_AND_CONTENT") SearchType searchType,
       @RequestParam(required = false) String keyword) {
     Page<EventBoardSummaryResponse> result =
@@ -91,8 +95,8 @@ public class EventBoardController {
   @GetMapping("/deleted")
   public ResponseEntity<ApiResponse<Page<DeletedEventBoardSummaryResponse>, PageMeta>> listDeletedBoards(
       @AuthenticationPrincipal CustomUserDetails me,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "12") int size) {
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "12") @Min(1) @Max(100) int size) {
     Page<DeletedEventBoardSummaryResponse> result =
         eventBoardService.listDeletedBoards(page, size, me.getRole(), me.getTeam());
     return ResponseEntity.ok(

--- a/src/main/java/inha/gdgoc/domain/board/event/controller/message/EventBoardMessage.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/controller/message/EventBoardMessage.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.domain.board.event.controller.message;
+
+public class EventBoardMessage {
+
+  public static final String EVENT_BOARD_LIST_RETRIEVED = "행사 게시판 목록을 조회했습니다.";
+  public static final String EVENT_BOARD_RETRIEVED = "행사 게시판 글을 조회했습니다.";
+  public static final String EVENT_BOARD_CREATED = "행사 게시판 글 작성이 완료되었습니다.";
+  public static final String EVENT_BOARD_UPDATED = "행사 게시판 글 수정이 완료되었습니다.";
+  public static final String EVENT_BOARD_DELETED = "행사 게시판 글 삭제가 완료되었습니다.";
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/controller/message/EventBoardMessage.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/controller/message/EventBoardMessage.java
@@ -7,4 +7,6 @@ public class EventBoardMessage {
   public static final String EVENT_BOARD_CREATED = "행사 게시판 글 작성이 완료되었습니다.";
   public static final String EVENT_BOARD_UPDATED = "행사 게시판 글 수정이 완료되었습니다.";
   public static final String EVENT_BOARD_DELETED = "행사 게시판 글 삭제가 완료되었습니다.";
+  public static final String EVENT_BOARD_DELETED_LIST_RETRIEVED = "삭제된 행사 게시판 목록을 조회했습니다.";
+  public static final String EVENT_BOARD_RESTORED = "행사 게시판 글이 복구되었습니다.";
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/request/EventBoardCreateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/request/EventBoardCreateRequest.java
@@ -1,0 +1,21 @@
+package inha.gdgoc.domain.board.event.dto.request;
+
+import inha.gdgoc.domain.user.enums.TeamType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+public record EventBoardCreateRequest(
+    @NotBlank String title,
+    @NotNull LocalDate eventStartDate,
+    @NotNull LocalDate eventEndDate,
+    @NotNull TeamType organizingTeam,
+    String thumbnailKey,
+    @NotBlank String content,
+    boolean isPublished,
+    @Valid List<AttachmentEntry> attachments) {
+
+  public record AttachmentEntry(@NotBlank String fileKey, @NotBlank String fileName) {}
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/request/EventBoardCreateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/request/EventBoardCreateRequest.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.board.event.dto.request;
 
 import inha.gdgoc.domain.user.enums.TeamType;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -16,6 +17,11 @@ public record EventBoardCreateRequest(
     @NotBlank String content,
     boolean isPublished,
     @Valid List<AttachmentEntry> attachments) {
+
+  @AssertTrue(message = "행사 종료일은 시작일보다 앞설 수 없습니다.")
+  private boolean isEventPeriodValid() {
+    return eventStartDate == null || eventEndDate == null || !eventEndDate.isBefore(eventStartDate);
+  }
 
   public record AttachmentEntry(@NotBlank String fileKey, @NotBlank String fileName) {}
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/request/EventBoardUpdateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/request/EventBoardUpdateRequest.java
@@ -1,0 +1,16 @@
+package inha.gdgoc.domain.board.event.dto.request;
+
+import inha.gdgoc.domain.user.enums.TeamType;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+
+public record EventBoardUpdateRequest(
+    String title,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    TeamType organizingTeam,
+    String thumbnailKey,
+    String content,
+    Boolean isPublished,
+    @Valid List<EventBoardCreateRequest.AttachmentEntry> attachments) {}

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/response/DeletedEventBoardSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/response/DeletedEventBoardSummaryResponse.java
@@ -1,0 +1,13 @@
+package inha.gdgoc.domain.board.event.dto.response;
+
+import inha.gdgoc.domain.user.enums.TeamType;
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record DeletedEventBoardSummaryResponse(
+    Long id,
+    String title,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    TeamType organizingTeam,
+    Instant deletedAt) {}

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardDetailResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardDetailResponse.java
@@ -12,6 +12,7 @@ public record EventBoardDetailResponse(
     LocalDate eventStartDate,
     LocalDate eventEndDate,
     TeamType organizingTeam,
+    String authorName,
     String thumbnailUrl,
     String content,
     boolean isPublished,

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardDetailResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardDetailResponse.java
@@ -1,0 +1,24 @@
+package inha.gdgoc.domain.board.event.dto.response;
+
+import inha.gdgoc.domain.board.event.enums.EventBoardStatus;
+import inha.gdgoc.domain.user.enums.TeamType;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public record EventBoardDetailResponse(
+    Long id,
+    String title,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    TeamType organizingTeam,
+    String thumbnailUrl,
+    String content,
+    boolean isPublished,
+    EventBoardStatus status,
+    List<AttachmentResponse> attachments,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public record AttachmentResponse(Long id, String fileUrl, String fileName) {}
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardSummaryResponse.java
@@ -11,4 +11,5 @@ public record EventBoardSummaryResponse(
     LocalDate eventStartDate,
     LocalDate eventEndDate,
     TeamType organizingTeam,
+    String authorName,
     EventBoardStatus status) {}

--- a/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/dto/response/EventBoardSummaryResponse.java
@@ -1,0 +1,14 @@
+package inha.gdgoc.domain.board.event.dto.response;
+
+import inha.gdgoc.domain.board.event.enums.EventBoardStatus;
+import inha.gdgoc.domain.user.enums.TeamType;
+import java.time.LocalDate;
+
+public record EventBoardSummaryResponse(
+    Long id,
+    String title,
+    String thumbnailUrl,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    TeamType organizingTeam,
+    EventBoardStatus status) {}

--- a/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoard.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoard.java
@@ -1,0 +1,101 @@
+package inha.gdgoc.domain.board.event.entity;
+
+import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "event_board")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventBoard extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 255)
+  private String title;
+
+  @Column(nullable = false)
+  private LocalDate eventStartDate;
+
+  @Column(nullable = false)
+  private LocalDate eventEndDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 32)
+  private TeamType organizingTeam;
+
+  @Column(length = 512)
+  private String thumbnailKey;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Column(nullable = false)
+  private boolean isPublished;
+
+  @Column(name = "author_id", nullable = false)
+  private Long authorId;
+
+  @OneToMany(mappedBy = "eventBoard", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<EventBoardAttachment> attachments = new ArrayList<>();
+
+  public static EventBoard create(
+      String title,
+      LocalDate eventStartDate,
+      LocalDate eventEndDate,
+      TeamType organizingTeam,
+      String thumbnailKey,
+      String content,
+      boolean isPublished,
+      Long authorId) {
+    EventBoard board = new EventBoard();
+    board.title = title;
+    board.eventStartDate = eventStartDate;
+    board.eventEndDate = eventEndDate;
+    board.organizingTeam = organizingTeam;
+    board.thumbnailKey = thumbnailKey;
+    board.content = content;
+    board.isPublished = isPublished;
+    board.authorId = authorId;
+    return board;
+  }
+
+  public void addAttachment(String fileKey, String fileName) {
+    this.attachments.add(EventBoardAttachment.create(this, fileKey, fileName));
+  }
+
+  public void update(
+      String title,
+      LocalDate eventStartDate,
+      LocalDate eventEndDate,
+      TeamType organizingTeam,
+      String thumbnailKey,
+      String content,
+      Boolean isPublished) {
+    if (title != null) this.title = title;
+    if (eventStartDate != null) this.eventStartDate = eventStartDate;
+    if (eventEndDate != null) this.eventEndDate = eventEndDate;
+    if (organizingTeam != null) this.organizingTeam = organizingTeam;
+    if (thumbnailKey != null) this.thumbnailKey = thumbnailKey;
+    if (content != null) this.content = content;
+    if (isPublished != null) this.isPublished = isPublished;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoard.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoard.java
@@ -55,6 +55,9 @@ public class EventBoard extends BaseEntity {
   @Column(name = "author_id", nullable = false)
   private Long authorId;
 
+  @Column(name = "author_name", nullable = false, length = 100)
+  private String authorName;
+
   @Column
   private Instant deletedAt;
 
@@ -69,7 +72,8 @@ public class EventBoard extends BaseEntity {
       String thumbnailKey,
       String content,
       boolean isPublished,
-      Long authorId) {
+      Long authorId,
+      String authorName) {
     EventBoard board = new EventBoard();
     board.title = title;
     board.eventStartDate = eventStartDate;
@@ -79,6 +83,7 @@ public class EventBoard extends BaseEntity {
     board.content = content;
     board.isPublished = isPublished;
     board.authorId = authorId;
+    board.authorName = authorName;
     return board;
   }
 

--- a/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoard.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoard.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,9 @@ public class EventBoard extends BaseEntity {
   @Column(name = "author_id", nullable = false)
   private Long authorId;
 
+  @Column
+  private Instant deletedAt;
+
   @OneToMany(mappedBy = "eventBoard", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<EventBoardAttachment> attachments = new ArrayList<>();
 
@@ -76,6 +80,14 @@ public class EventBoard extends BaseEntity {
     board.isPublished = isPublished;
     board.authorId = authorId;
     return board;
+  }
+
+  public void softDelete() {
+    this.deletedAt = Instant.now();
+  }
+
+  public void restore() {
+    this.deletedAt = null;
   }
 
   public void addAttachment(String fileKey, String fileName) {

--- a/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoardAttachment.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/entity/EventBoardAttachment.java
@@ -1,0 +1,44 @@
+package inha.gdgoc.domain.board.event.entity;
+
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "event_board_attachment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventBoardAttachment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "event_board_id", nullable = false)
+  private EventBoard eventBoard;
+
+  @Column(nullable = false, length = 512)
+  private String fileKey;
+
+  @Column(nullable = false, length = 255)
+  private String fileName;
+
+  static EventBoardAttachment create(EventBoard eventBoard, String fileKey, String fileName) {
+    EventBoardAttachment attachment = new EventBoardAttachment();
+    attachment.eventBoard = eventBoard;
+    attachment.fileKey = fileKey;
+    attachment.fileName = fileName;
+    return attachment;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/enums/EventBoardStatus.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/enums/EventBoardStatus.java
@@ -1,0 +1,16 @@
+package inha.gdgoc.domain.board.event.enums;
+
+import java.time.LocalDate;
+
+public enum EventBoardStatus {
+  UPCOMING,
+  IN_PROGRESS,
+  ENDED;
+
+  public static EventBoardStatus of(LocalDate startDate, LocalDate endDate) {
+    LocalDate today = LocalDate.now();
+    if (endDate.isBefore(today)) return ENDED;
+    if (startDate.isAfter(today)) return UPCOMING;
+    return IN_PROGRESS;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/enums/SearchType.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/enums/SearchType.java
@@ -3,5 +3,6 @@ package inha.gdgoc.domain.board.event.enums;
 public enum SearchType {
   TITLE_AND_CONTENT,
   TITLE,
-  CONTENT
+  CONTENT,
+  AUTHOR
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/enums/SearchType.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/enums/SearchType.java
@@ -1,0 +1,7 @@
+package inha.gdgoc.domain.board.event.enums;
+
+public enum SearchType {
+  TITLE_AND_CONTENT,
+  TITLE,
+  CONTENT
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardJpaRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardJpaRepository.java
@@ -1,0 +1,6 @@
+package inha.gdgoc.domain.board.event.repository;
+
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventBoardJpaRepository extends JpaRepository<EventBoard, Long> {}

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardJpaRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardJpaRepository.java
@@ -1,6 +1,12 @@
 package inha.gdgoc.domain.board.event.repository;
 
 import inha.gdgoc.domain.board.event.entity.EventBoard;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventBoardJpaRepository extends JpaRepository<EventBoard, Long> {}
+public interface EventBoardJpaRepository extends JpaRepository<EventBoard, Long> {
+
+  Optional<EventBoard> findByIdAndDeletedAtIsNull(Long id);
+
+  Optional<EventBoard> findByIdAndDeletedAtIsNotNull(Long id);
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardQueryDslRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardQueryDslRepository.java
@@ -3,11 +3,14 @@ package inha.gdgoc.domain.board.event.repository;
 import inha.gdgoc.domain.board.event.entity.EventBoard;
 import inha.gdgoc.domain.board.event.enums.SearchType;
 import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface EventBoardQueryDslRepository {
 
   Page<EventBoard> findVisibleBoards(
-      TeamType userTeam, SearchType searchType, String keyword, Pageable pageable);
+      TeamType userTeam, UserRole userRole, SearchType searchType, String keyword, Pageable pageable);
+
+  Page<EventBoard> findDeletedBoards(TeamType userTeam, UserRole userRole, Pageable pageable);
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardQueryDslRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardQueryDslRepository.java
@@ -1,0 +1,13 @@
+package inha.gdgoc.domain.board.event.repository;
+
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import inha.gdgoc.domain.board.event.enums.SearchType;
+import inha.gdgoc.domain.user.enums.TeamType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EventBoardQueryDslRepository {
+
+  Page<EventBoard> findVisibleBoards(
+      TeamType userTeam, SearchType searchType, String keyword, Pageable pageable);
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepository.java
@@ -7,6 +7,8 @@ public interface EventBoardRepository extends EventBoardQueryDslRepository {
 
   Optional<EventBoard> findById(Long id);
 
+  Optional<EventBoard> findDeletedById(Long id);
+
   EventBoard save(EventBoard board);
 
   void delete(EventBoard board);

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepository.java
@@ -1,0 +1,13 @@
+package inha.gdgoc.domain.board.event.repository;
+
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import java.util.Optional;
+
+public interface EventBoardRepository extends EventBoardQueryDslRepository {
+
+  Optional<EventBoard> findById(Long id);
+
+  EventBoard save(EventBoard board);
+
+  void delete(EventBoard board);
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepositoryImpl.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepositoryImpl.java
@@ -1,0 +1,89 @@
+package inha.gdgoc.domain.board.event.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import inha.gdgoc.domain.board.event.entity.QEventBoard;
+import inha.gdgoc.domain.board.event.enums.SearchType;
+import inha.gdgoc.domain.user.enums.TeamType;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EventBoardRepositoryImpl implements EventBoardRepository {
+
+  private final EventBoardJpaRepository jpaRepository;
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<EventBoard> findById(Long id) {
+    return jpaRepository.findById(id);
+  }
+
+  @Override
+  public EventBoard save(EventBoard board) {
+    return jpaRepository.save(board);
+  }
+
+  @Override
+  public void delete(EventBoard board) {
+    jpaRepository.delete(board);
+  }
+
+  @Override
+  public Page<EventBoard> findVisibleBoards(
+      TeamType userTeam, SearchType searchType, String keyword, Pageable pageable) {
+
+    QEventBoard board = QEventBoard.eventBoard;
+
+    BooleanExpression visibility = visibilityCondition(board, userTeam);
+    BooleanExpression search = searchCondition(board, searchType, keyword);
+
+    BooleanExpression where = visibility;
+    if (search != null) {
+      where = where.and(search);
+    }
+
+    List<EventBoard> content =
+        queryFactory
+            .selectFrom(board)
+            .where(where)
+            .orderBy(board.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total =
+        queryFactory.select(board.count()).from(board).where(where).fetchOne();
+
+    return new PageImpl<>(content, pageable, total == null ? 0 : total);
+  }
+
+  private BooleanExpression visibilityCondition(QEventBoard board, TeamType userTeam) {
+    BooleanExpression publicPosts = board.isPublished.isTrue();
+    if (userTeam == null) {
+      return publicPosts;
+    }
+    return publicPosts.or(
+        board.isPublished.isFalse().and(board.organizingTeam.eq(userTeam)));
+  }
+
+  private BooleanExpression searchCondition(
+      QEventBoard board, SearchType searchType, String keyword) {
+    if (keyword == null || keyword.isBlank()) {
+      return null;
+    }
+    return switch (searchType) {
+      case TITLE -> board.title.containsIgnoreCase(keyword);
+      case CONTENT -> board.content.containsIgnoreCase(keyword);
+      case TITLE_AND_CONTENT ->
+          board.title.containsIgnoreCase(keyword).or(board.content.containsIgnoreCase(keyword));
+    };
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepositoryImpl.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepositoryImpl.java
@@ -6,6 +6,7 @@ import inha.gdgoc.domain.board.event.entity.EventBoard;
 import inha.gdgoc.domain.board.event.entity.QEventBoard;
 import inha.gdgoc.domain.board.event.enums.SearchType;
 import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,12 @@ public class EventBoardRepositoryImpl implements EventBoardRepository {
 
   @Override
   public Optional<EventBoard> findById(Long id) {
-    return jpaRepository.findById(id);
+    return jpaRepository.findByIdAndDeletedAtIsNull(id);
+  }
+
+  @Override
+  public Optional<EventBoard> findDeletedById(Long id) {
+    return jpaRepository.findByIdAndDeletedAtIsNotNull(id);
   }
 
   @Override
@@ -38,11 +44,11 @@ public class EventBoardRepositoryImpl implements EventBoardRepository {
 
   @Override
   public Page<EventBoard> findVisibleBoards(
-      TeamType userTeam, SearchType searchType, String keyword, Pageable pageable) {
+      TeamType userTeam, UserRole userRole, SearchType searchType, String keyword, Pageable pageable) {
 
     QEventBoard board = QEventBoard.eventBoard;
 
-    BooleanExpression visibility = visibilityCondition(board, userTeam);
+    BooleanExpression visibility = visibilityCondition(board, userTeam, userRole);
     BooleanExpression search = searchCondition(board, searchType, keyword);
 
     BooleanExpression where = visibility;
@@ -65,13 +71,47 @@ public class EventBoardRepositoryImpl implements EventBoardRepository {
     return new PageImpl<>(content, pageable, total == null ? 0 : total);
   }
 
-  private BooleanExpression visibilityCondition(QEventBoard board, TeamType userTeam) {
-    BooleanExpression publicPosts = board.isPublished.isTrue();
-    if (userTeam == null) {
-      return publicPosts;
+  @Override
+  public Page<EventBoard> findDeletedBoards(TeamType userTeam, UserRole userRole, Pageable pageable) {
+    QEventBoard board = QEventBoard.eventBoard;
+
+    BooleanExpression where = board.deletedAt.isNotNull();
+
+    if (!UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) {
+      if (userTeam == null) return Page.empty(pageable);
+      where = where.and(board.organizingTeam.eq(userTeam));
     }
-    return publicPosts.or(
-        board.isPublished.isFalse().and(board.organizingTeam.eq(userTeam)));
+
+    List<EventBoard> content =
+        queryFactory
+            .selectFrom(board)
+            .where(where)
+            .orderBy(board.deletedAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total =
+        queryFactory.select(board.count()).from(board).where(where).fetchOne();
+
+    return new PageImpl<>(content, pageable, total == null ? 0 : total);
+  }
+
+  private BooleanExpression visibilityCondition(QEventBoard board, TeamType userTeam, UserRole userRole) {
+    BooleanExpression notDeleted = board.deletedAt.isNull();
+
+    // ORGANIZER+: 모든 활성 게시글 조회 가능
+    if (userRole != null && UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) {
+      return notDeleted;
+    }
+    // 팀 없음 (비로그인·MEMBER): 공개 게시글만
+    if (userTeam == null) {
+      return notDeleted.and(board.isPublished.isTrue());
+    }
+    // CORE·LEAD: 공개 + 같은 팀 비공개
+    return notDeleted.and(
+        board.isPublished.isTrue()
+            .or(board.isPublished.isFalse().and(board.organizingTeam.eq(userTeam))));
   }
 
   private BooleanExpression searchCondition(

--- a/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepositoryImpl.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/repository/EventBoardRepositoryImpl.java
@@ -124,6 +124,7 @@ public class EventBoardRepositoryImpl implements EventBoardRepository {
       case CONTENT -> board.content.containsIgnoreCase(keyword);
       case TITLE_AND_CONTENT ->
           board.title.containsIgnoreCase(keyword).or(board.content.containsIgnoreCase(keyword));
+      case AUTHOR -> board.authorName.containsIgnoreCase(keyword);
     };
   }
 }

--- a/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
@@ -1,0 +1,141 @@
+package inha.gdgoc.domain.board.event.service;
+
+import inha.gdgoc.domain.board.event.dto.request.EventBoardCreateRequest;
+import inha.gdgoc.domain.board.event.dto.request.EventBoardUpdateRequest;
+import inha.gdgoc.domain.board.event.dto.response.EventBoardDetailResponse;
+import inha.gdgoc.domain.board.event.dto.response.EventBoardDetailResponse.AttachmentResponse;
+import inha.gdgoc.domain.board.event.dto.response.EventBoardSummaryResponse;
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import inha.gdgoc.domain.board.event.enums.EventBoardStatus;
+import inha.gdgoc.domain.board.event.enums.SearchType;
+import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.resource.service.S3Service;
+import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventBoardService {
+
+  private final EventBoardRepository eventBoardRepository;
+  private final S3Service s3Service;
+
+  public Page<EventBoardSummaryResponse> listEventBoards(
+      int page, int size, SearchType searchType, String keyword, TeamType userTeam) {
+    return eventBoardRepository
+        .findVisibleBoards(userTeam, searchType, keyword, PageRequest.of(page, size))
+        .map(this::toSummaryResponse);
+  }
+
+  public EventBoardDetailResponse getEventBoard(Long id, TeamType userTeam) {
+    return toDetailResponse(findVisibleBoard(id, userTeam));
+  }
+
+  @Transactional
+  public Long createEventBoard(EventBoardCreateRequest req, Long authorId) {
+    EventBoard board =
+        EventBoard.create(
+            req.title(),
+            req.eventStartDate(),
+            req.eventEndDate(),
+            req.organizingTeam(),
+            req.thumbnailKey(),
+            req.content(),
+            req.isPublished(),
+            authorId);
+
+    if (req.attachments() != null) {
+      req.attachments().forEach(a -> board.addAttachment(a.fileKey(), a.fileName()));
+    }
+
+    return eventBoardRepository.save(board).getId();
+  }
+
+  @Transactional
+  public void updateEventBoard(Long id, EventBoardUpdateRequest req) {
+    EventBoard board =
+        eventBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    board.update(
+        req.title(),
+        req.eventStartDate(),
+        req.eventEndDate(),
+        req.organizingTeam(),
+        req.thumbnailKey(),
+        req.content(),
+        req.isPublished());
+
+    if (req.attachments() != null) {
+      board.getAttachments().clear();
+      req.attachments().forEach(a -> board.addAttachment(a.fileKey(), a.fileName()));
+    }
+  }
+
+  @Transactional
+  public void deleteEventBoard(Long id) {
+    EventBoard board =
+        eventBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+    eventBoardRepository.delete(board);
+  }
+
+  private EventBoard findVisibleBoard(Long id, TeamType userTeam) {
+    EventBoard board =
+        eventBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    if (!board.isPublished() && (userTeam == null || userTeam != board.getOrganizingTeam())) {
+      throw new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND);
+    }
+    return board;
+  }
+
+  private EventBoardSummaryResponse toSummaryResponse(EventBoard board) {
+    String thumbnailUrl =
+        board.getThumbnailKey() != null ? s3Service.getS3FileUrl(board.getThumbnailKey()) : null;
+    return new EventBoardSummaryResponse(
+        board.getId(),
+        board.getTitle(),
+        thumbnailUrl,
+        board.getEventStartDate(),
+        board.getEventEndDate(),
+        board.getOrganizingTeam(),
+        EventBoardStatus.of(board.getEventStartDate(), board.getEventEndDate()));
+  }
+
+  private EventBoardDetailResponse toDetailResponse(EventBoard board) {
+    String thumbnailUrl =
+        board.getThumbnailKey() != null ? s3Service.getS3FileUrl(board.getThumbnailKey()) : null;
+
+    List<AttachmentResponse> attachments =
+        board.getAttachments().stream()
+            .map(a -> new AttachmentResponse(a.getId(), s3Service.getS3FileUrl(a.getFileKey()), a.getFileName()))
+            .toList();
+
+    return new EventBoardDetailResponse(
+        board.getId(),
+        board.getTitle(),
+        board.getEventStartDate(),
+        board.getEventEndDate(),
+        board.getOrganizingTeam(),
+        thumbnailUrl,
+        board.getContent(),
+        board.isPublished(),
+        EventBoardStatus.of(board.getEventStartDate(), board.getEventEndDate()),
+        attachments,
+        board.getCreatedAt(),
+        board.getUpdatedAt());
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
@@ -60,11 +60,15 @@ public class EventBoardService {
   }
 
   @Transactional
-  public void updateEventBoard(Long id, EventBoardUpdateRequest req) {
+  public void updateEventBoard(Long id, EventBoardUpdateRequest req, TeamType userTeam) {
     EventBoard board =
         eventBoardRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    if (userTeam == null || userTeam != board.getOrganizingTeam()) {
+      throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
+    }
 
     board.update(
         req.title(),
@@ -82,11 +86,16 @@ public class EventBoardService {
   }
 
   @Transactional
-  public void deleteEventBoard(Long id) {
+  public void deleteEventBoard(Long id, TeamType userTeam) {
     EventBoard board =
         eventBoardRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    if (userTeam == null || userTeam != board.getOrganizingTeam()) {
+      throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
+    }
+
     eventBoardRepository.delete(board);
   }
 

--- a/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
@@ -95,6 +95,11 @@ public class EventBoardService {
         req.content(),
         req.isPublished());
 
+    if (board.getEventEndDate().isBefore(board.getEventStartDate())) {
+      throw new BusinessException(
+          GlobalErrorCode.BAD_REQUEST, "행사 종료일은 시작일보다 앞설 수 없습니다.");
+    }
+
     if (req.attachments() != null) {
       board.getAttachments().clear();
       req.attachments().forEach(a -> board.addAttachment(a.fileKey(), a.fileName()));

--- a/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
@@ -11,8 +11,10 @@ import inha.gdgoc.domain.board.event.enums.EventBoardStatus;
 import inha.gdgoc.domain.board.event.enums.SearchType;
 import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
 import inha.gdgoc.domain.resource.service.S3Service;
+import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.TeamType;
 import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
 import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
 import java.util.List;
@@ -28,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventBoardService {
 
   private final EventBoardRepository eventBoardRepository;
+  private final UserRepository userRepository;
   private final S3Service s3Service;
 
   public Page<EventBoardSummaryResponse> listEventBoards(
@@ -52,6 +55,9 @@ public class EventBoardService {
 
   @Transactional
   public Long createEventBoard(EventBoardCreateRequest req, Long authorId) {
+    User author = userRepository.findById(authorId)
+        .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
     EventBoard board =
         EventBoard.create(
             req.title(),
@@ -61,7 +67,8 @@ public class EventBoardService {
             req.thumbnailKey(),
             req.content(),
             req.isPublished(),
-            authorId);
+            authorId,
+            author.getName());
 
     if (req.attachments() != null) {
       req.attachments().forEach(a -> board.addAttachment(a.fileKey(), a.fileName()));
@@ -149,6 +156,7 @@ public class EventBoardService {
         board.getEventStartDate(),
         board.getEventEndDate(),
         board.getOrganizingTeam(),
+        board.getAuthorName(),
         EventBoardStatus.of(board.getEventStartDate(), board.getEventEndDate()));
   }
 
@@ -167,6 +175,7 @@ public class EventBoardService {
         board.getEventStartDate(),
         board.getEventEndDate(),
         board.getOrganizingTeam(),
+        board.getAuthorName(),
         thumbnailUrl,
         board.getContent(),
         board.isPublished(),

--- a/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.board.event.service;
 
 import inha.gdgoc.domain.board.event.dto.request.EventBoardCreateRequest;
 import inha.gdgoc.domain.board.event.dto.request.EventBoardUpdateRequest;
+import inha.gdgoc.domain.board.event.dto.response.DeletedEventBoardSummaryResponse;
 import inha.gdgoc.domain.board.event.dto.response.EventBoardDetailResponse;
 import inha.gdgoc.domain.board.event.dto.response.EventBoardDetailResponse.AttachmentResponse;
 import inha.gdgoc.domain.board.event.dto.response.EventBoardSummaryResponse;
@@ -11,6 +12,7 @@ import inha.gdgoc.domain.board.event.enums.SearchType;
 import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
 import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
 import java.util.List;
@@ -29,14 +31,23 @@ public class EventBoardService {
   private final S3Service s3Service;
 
   public Page<EventBoardSummaryResponse> listEventBoards(
-      int page, int size, SearchType searchType, String keyword, TeamType userTeam) {
+      int page, int size, SearchType searchType, String keyword, TeamType userTeam, UserRole userRole) {
     return eventBoardRepository
-        .findVisibleBoards(userTeam, searchType, keyword, PageRequest.of(page, size))
+        .findVisibleBoards(userTeam, userRole, searchType, keyword, PageRequest.of(page, size))
         .map(this::toSummaryResponse);
   }
 
-  public EventBoardDetailResponse getEventBoard(Long id, TeamType userTeam) {
-    return toDetailResponse(findVisibleBoard(id, userTeam));
+  public Page<DeletedEventBoardSummaryResponse> listDeletedBoards(
+      int page, int size, UserRole userRole, TeamType userTeam) {
+    return eventBoardRepository
+        .findDeletedBoards(userTeam, userRole, PageRequest.of(page, size))
+        .map(b -> new DeletedEventBoardSummaryResponse(
+            b.getId(), b.getTitle(), b.getEventStartDate(), b.getEventEndDate(),
+            b.getOrganizingTeam(), b.getDeletedAt()));
+  }
+
+  public EventBoardDetailResponse getEventBoard(Long id, TeamType userTeam, UserRole userRole) {
+    return toDetailResponse(findVisibleBoard(id, userTeam, userRole));
   }
 
   @Transactional
@@ -60,15 +71,13 @@ public class EventBoardService {
   }
 
   @Transactional
-  public void updateEventBoard(Long id, EventBoardUpdateRequest req, TeamType userTeam) {
+  public void updateEventBoard(Long id, EventBoardUpdateRequest req, UserRole userRole, TeamType userTeam) {
     EventBoard board =
         eventBoardRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
 
-    if (userTeam == null || userTeam != board.getOrganizingTeam()) {
-      throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
-    }
+    requireTeamAccess(board, userRole, userTeam);
 
     board.update(
         req.title(),
@@ -86,29 +95,48 @@ public class EventBoardService {
   }
 
   @Transactional
-  public void deleteEventBoard(Long id, TeamType userTeam) {
+  public void deleteEventBoard(Long id, UserRole userRole, TeamType userTeam) {
     EventBoard board =
         eventBoardRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
 
+    requireTeamAccess(board, userRole, userTeam);
+    board.softDelete();
+  }
+
+  @Transactional
+  public void restoreEventBoard(Long id, UserRole userRole, TeamType userTeam) {
+    EventBoard board =
+        eventBoardRepository
+            .findDeletedById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    requireTeamAccess(board, userRole, userTeam);
+    board.restore();
+  }
+
+  private EventBoard findVisibleBoard(Long id, TeamType userTeam, UserRole userRole) {
+    EventBoard board =
+        eventBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    if (!board.isPublished()) {
+      if (!UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) {
+        if (userTeam == null || userTeam != board.getOrganizingTeam()) {
+          throw new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND);
+        }
+      }
+    }
+    return board;
+  }
+
+  private void requireTeamAccess(EventBoard board, UserRole userRole, TeamType userTeam) {
+    if (UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) return;
     if (userTeam == null || userTeam != board.getOrganizingTeam()) {
       throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
     }
-
-    eventBoardRepository.delete(board);
-  }
-
-  private EventBoard findVisibleBoard(Long id, TeamType userTeam) {
-    EventBoard board =
-        eventBoardRepository
-            .findById(id)
-            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
-
-    if (!board.isPublished() && (userTeam == null || userTeam != board.getOrganizingTeam())) {
-      throw new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND);
-    }
-    return board;
   }
 
   private EventBoardSummaryResponse toSummaryResponse(EventBoard board) {

--- a/src/main/java/inha/gdgoc/global/security/AuthorizeAspect.java
+++ b/src/main/java/inha/gdgoc/global/security/AuthorizeAspect.java
@@ -1,0 +1,52 @@
+package inha.gdgoc.global.security;
+
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
+import inha.gdgoc.global.security.AccessGuard.AccessCondition;
+import inha.gdgoc.global.security.annotation.Authorize;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link Authorize} 어노테이션을 AOP로 처리. 메서드/클래스 진입 전 {@link AccessGuard#require}를 호출한다.
+ *
+ * <p>메서드 어노테이션이 클래스 어노테이션보다 우선된다.
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthorizeAspect {
+
+  private final AccessGuard accessGuard;
+
+  @Before(
+      "@annotation(inha.gdgoc.global.security.annotation.Authorize)"
+          + " || (@within(inha.gdgoc.global.security.annotation.Authorize)"
+          + "     && !@annotation(inha.gdgoc.global.security.annotation.Authorize))")
+  public void enforce(JoinPoint jp) {
+    Authorize authorize = resolveAnnotation(jp);
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    CustomUserDetails user =
+        (auth != null && auth.getPrincipal() instanceof CustomUserDetails u) ? u : null;
+
+    AccessCondition[] conditions =
+        Arrays.stream(authorize.value())
+            .map(c -> AccessCondition.of(c.atLeast(), c.teams()))
+            .toArray(AccessCondition[]::new);
+
+    accessGuard.require(user, conditions);
+  }
+
+  private Authorize resolveAnnotation(JoinPoint jp) {
+    MethodSignature sig = (MethodSignature) jp.getSignature();
+    Authorize method = sig.getMethod().getAnnotation(Authorize.class);
+    return method != null ? method : jp.getTarget().getClass().getAnnotation(Authorize.class);
+  }
+}

--- a/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
+++ b/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/v1/auth/logout").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/v1/board/events", "/api/v1/board/events/*").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/board/events").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/board/events/{id:[0-9]+}").permitAll()
                 .requestMatchers(
                     "/swagger-ui/**",
                     "/v3/api-docs/**",

--- a/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
+++ b/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/v1/auth/logout").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/board/events", "/api/v1/board/events/*").permitAll()
                 .requestMatchers(
                     "/swagger-ui/**",
                     "/v3/api-docs/**",

--- a/src/main/java/inha/gdgoc/global/security/annotation/Authorize.java
+++ b/src/main/java/inha/gdgoc/global/security/annotation/Authorize.java
@@ -1,0 +1,29 @@
+package inha.gdgoc.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 메서드 또는 클래스에 접근 가능한 최소 권한 조건을 선언한다.
+ *
+ * <p>{@link Condition}을 OR 관계로 여러 개 나열할 수 있다. 하나라도 충족하면 통과.
+ *
+ * <pre>{@code
+ * // ORGANIZER 이상
+ * @Authorize(@Condition(atLeast = UserRole.ORGANIZER))
+ *
+ * // LEAD 이상 OR CORE + PR팀
+ * @Authorize({
+ *     @Condition(atLeast = UserRole.LEAD),
+ *     @Condition(atLeast = UserRole.CORE, teams = TeamType.PR_DESIGN)
+ * })
+ * }</pre>
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorize {
+
+  Condition[] value();
+}

--- a/src/main/java/inha/gdgoc/global/security/annotation/Condition.java
+++ b/src/main/java/inha/gdgoc/global/security/annotation/Condition.java
@@ -1,0 +1,17 @@
+package inha.gdgoc.global.security.annotation;
+
+import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** AccessCondition 하나를 표현. {@link Authorize#value()}의 요소 타입으로만 사용. */
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Condition {
+
+  UserRole atLeast();
+
+  TeamType[] teams() default {};
+}

--- a/src/main/resources/db/migration/V20260519__create_event_board.sql
+++ b/src/main/resources/db/migration/V20260519__create_event_board.sql
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS event_board_attachment (
     event_board_id   BIGINT       NOT NULL REFERENCES event_board(id) ON DELETE CASCADE,
     file_key         VARCHAR(512) NOT NULL,
     file_name        VARCHAR(255) NOT NULL,
-    created_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_event_board_is_published        ON event_board(is_published);

--- a/src/main/resources/db/migration/V20260519__create_event_board.sql
+++ b/src/main/resources/db/migration/V20260519__create_event_board.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS event_board (
+    id                BIGSERIAL    PRIMARY KEY,
+    title             VARCHAR(255) NOT NULL,
+    event_start_date  DATE         NOT NULL,
+    event_end_date    DATE         NOT NULL,
+    organizing_team   VARCHAR(32)  NOT NULL,
+    thumbnail_key     VARCHAR(512),
+    content           TEXT         NOT NULL,
+    is_published      BOOLEAN      NOT NULL DEFAULT FALSE,
+    author_id         BIGINT       NOT NULL REFERENCES users(id),
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS event_board_attachment (
+    id               BIGSERIAL    PRIMARY KEY,
+    event_board_id   BIGINT       NOT NULL REFERENCES event_board(id) ON DELETE CASCADE,
+    file_key         VARCHAR(512) NOT NULL,
+    file_name        VARCHAR(255) NOT NULL,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_board_is_published        ON event_board(is_published);
+CREATE INDEX IF NOT EXISTS idx_event_board_author_id           ON event_board(author_id);
+CREATE INDEX IF NOT EXISTS idx_event_board_attachment_board_id ON event_board_attachment(event_board_id);

--- a/src/main/resources/db/migration/V20260519__create_event_board.sql
+++ b/src/main/resources/db/migration/V20260519__create_event_board.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS event_board (
     is_published      BOOLEAN      NOT NULL DEFAULT FALSE,
     author_id         BIGINT       NOT NULL REFERENCES users(id),
     created_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at        TIMESTAMPTZ
 );
 
 CREATE TABLE IF NOT EXISTS event_board_attachment (
@@ -23,3 +24,4 @@ CREATE TABLE IF NOT EXISTS event_board_attachment (
 CREATE INDEX IF NOT EXISTS idx_event_board_is_published        ON event_board(is_published);
 CREATE INDEX IF NOT EXISTS idx_event_board_author_id           ON event_board(author_id);
 CREATE INDEX IF NOT EXISTS idx_event_board_attachment_board_id ON event_board_attachment(event_board_id);
+CREATE INDEX IF NOT EXISTS idx_event_board_deleted_at ON event_board(deleted_at) WHERE deleted_at IS NOT NULL;

--- a/src/main/resources/db/migration/V20260519__create_event_board.sql
+++ b/src/main/resources/db/migration/V20260519__create_event_board.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS event_board (
     content           TEXT         NOT NULL,
     is_published      BOOLEAN      NOT NULL DEFAULT FALSE,
     author_id         BIGINT       NOT NULL REFERENCES users(id),
+    author_name       VARCHAR(100) NOT NULL DEFAULT '',
     created_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted_at        TIMESTAMPTZ

--- a/src/test/java/inha/gdgoc/domain/board/event/EventBoardSecurityTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/event/EventBoardSecurityTest.java
@@ -1,0 +1,43 @@
+package inha.gdgoc.domain.board.event;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 행사 게시판 엔드포인트의 인증 경계를 검증한다.
+ *
+ * <p>공개 조회(GET)와 관리자 전용 API가 SecurityConfig 수준에서 올바르게 갈리는지 확인한다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class EventBoardSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void deletedList_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/board/events/deleted"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void list_isPubliclyAccessible() throws Exception {
+        mockMvc.perform(get("/api/v1/board/events"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void detail_isPubliclyAccessible() throws Exception {
+        mockMvc.perform(get("/api/v1/board/events/999999"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/inha/gdgoc/domain/board/event/service/EventBoardServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/event/service/EventBoardServiceTest.java
@@ -1,0 +1,163 @@
+package inha.gdgoc.domain.board.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import inha.gdgoc.domain.board.event.dto.request.EventBoardUpdateRequest;
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.resource.service.S3Service;
+import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * 행사 게시판의 권한·가시성 규칙을 검증한다.
+ *
+ * <p>미공개 글은 존재 자체를 숨겨야 하므로 404, 수정·삭제 권한 부족은 403으로 구분된다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EventBoardServiceTest {
+
+    private static final Long BOARD_ID = 1L;
+
+    @Mock
+    private EventBoardRepository eventBoardRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private EventBoardService eventBoardService;
+
+    // --- 미공개 글 가시성 ---
+
+    @Test
+    void getEventBoard_hidesUnpublishedBoardFromOtherTeam() {
+        givenBoard(unpublishedBoard(TeamType.PR_DESIGN));
+
+        assertThatThrownBy(() -> eventBoardService.getEventBoard(BOARD_ID, TeamType.HR, UserRole.CORE))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(GlobalErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    void getEventBoard_hidesUnpublishedBoardFromAnonymous() {
+        givenBoard(unpublishedBoard(TeamType.PR_DESIGN));
+
+        assertThatThrownBy(() -> eventBoardService.getEventBoard(BOARD_ID, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void getEventBoard_allowsOwningTeamToReadUnpublishedBoard() {
+        givenBoard(unpublishedBoard(TeamType.PR_DESIGN));
+
+        assertThat(eventBoardService.getEventBoard(BOARD_ID, TeamType.PR_DESIGN, UserRole.CORE).isPublished())
+                .isFalse();
+    }
+
+    @Test
+    void getEventBoard_allowsOrganizerToReadUnpublishedBoardOfAnyTeam() {
+        givenBoard(unpublishedBoard(TeamType.PR_DESIGN));
+
+        assertThatCode(() -> eventBoardService.getEventBoard(BOARD_ID, TeamType.HR, UserRole.ORGANIZER))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getEventBoard_allowsAnonymousToReadPublishedBoard() {
+        givenBoard(publishedBoard(TeamType.PR_DESIGN));
+
+        assertThatCode(() -> eventBoardService.getEventBoard(BOARD_ID, null, null))
+                .doesNotThrowAnyException();
+    }
+
+    // --- 수정·삭제 권한 ---
+
+    @Test
+    void updateEventBoard_rejectsOtherTeam() {
+        givenBoard(publishedBoard(TeamType.PR_DESIGN));
+
+        assertThatThrownBy(() -> eventBoardService.updateEventBoard(
+                BOARD_ID, emptyUpdate(), UserRole.CORE, TeamType.HR))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(GlobalErrorCode.FORBIDDEN_USER);
+    }
+
+    @Test
+    void updateEventBoard_allowsOwningTeam() {
+        givenBoard(publishedBoard(TeamType.PR_DESIGN));
+
+        assertThatCode(() -> eventBoardService.updateEventBoard(
+                BOARD_ID, emptyUpdate(), UserRole.CORE, TeamType.PR_DESIGN))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void deleteEventBoard_rejectsOtherTeam() {
+        givenBoard(publishedBoard(TeamType.PR_DESIGN));
+
+        assertThatThrownBy(() -> eventBoardService.deleteEventBoard(BOARD_ID, UserRole.CORE, TeamType.HR))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(GlobalErrorCode.FORBIDDEN_USER);
+    }
+
+    @Test
+    void deleteEventBoard_marksBoardAsDeletedForOwningTeam() {
+        EventBoard board = publishedBoard(TeamType.PR_DESIGN);
+        givenBoard(board);
+
+        eventBoardService.deleteEventBoard(BOARD_ID, UserRole.CORE, TeamType.PR_DESIGN);
+
+        assertThat(board.getDeletedAt()).isNotNull();
+    }
+
+    // --- fixtures ---
+
+    private void givenBoard(EventBoard board) {
+        when(eventBoardRepository.findById(BOARD_ID)).thenReturn(Optional.of(board));
+    }
+
+    private EventBoard publishedBoard(TeamType organizingTeam) {
+        return board(organizingTeam, true);
+    }
+
+    private EventBoard unpublishedBoard(TeamType organizingTeam) {
+        return board(organizingTeam, false);
+    }
+
+    private EventBoard board(TeamType organizingTeam, boolean isPublished) {
+        return EventBoard.create(
+                "인하 GDGoC 행사",
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 2),
+                organizingTeam,
+                null,
+                "본문",
+                isPublished,
+                1L,
+                "차준호");
+    }
+
+    private EventBoardUpdateRequest emptyUpdate() {
+        return new EventBoardUpdateRequest(null, null, null, null, null, null, null, null);
+    }
+}

--- a/src/test/java/inha/gdgoc/domain/recruit/service/RecruitMemberServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/service/RecruitMemberServiceTest.java
@@ -20,11 +20,9 @@ class RecruitMemberServiceTest {
         // given
         RecruitMemberRequest recruitMemberRequest = RecruitMemberRequest.builder()
                 .name("김소연")
-                .grade("4")
                 .studentId("122123388")
                 .enrolledClassification("재학")
                 .phoneNumber("010-1111-2332")
-                .nationality("대한민국")
                 .email("abc@gmail.com")
                 .gender("여성")
                 .birth(LocalDate.of(2002, 8, 18))
@@ -47,11 +45,9 @@ class RecruitMemberServiceTest {
         RecruitMember savedMember = RecruitMember.builder()
                 .id(1L) // 저장될 ID
                 .name("김소연")
-                .grade("4")
                 .studentId("122123388")
                 .enrolledClassification(EnrolledClassification.FULL_REGISTRATION)
                 .phoneNumber("010-1111-2332")
-                .nationality("대한민국")
                 .email("abc@gmail.com")
                 .gender(Gender.FEMALE)
                 .birth(LocalDate.of(2002, 8, 18))


### PR DESCRIPTION
## 개요

행사(이벤트) 게시판 CRUD API를 구현합니다. 게시판 기능 분담 중 이벤트 게시판 담당분입니다.

## 주요 변경

**행사 게시판 API** — `/api/v1/board/events`

| 메서드 | 경로 | 권한 |
|---|---|---|
| GET | `/board/events` | 공개 |
| GET | `/board/events/{id}` | 공개 |
| POST | `/board/events` | CORE 이상 |
| PATCH | `/board/events/{id}` | CORE 이상 + 작성팀 |
| DELETE | `/board/events/{id}` | CORE 이상 + 작성팀 |
| GET | `/board/events/deleted` | CORE 이상 |
| POST | `/board/events/{id}/restore` | CORE 이상 + 작성팀 |

- **소프트 딜리트** — `deleted_at` 기반. 저장소 `findById`가 삭제분을 항상 제외하도록 위임해 서비스 계층에서 삭제 글이 새지 않습니다
- **가시성 규칙** — 미공개 글은 작성팀과 ORGANIZER 이상에게만 노출. 비로그인·타 팀에는 존재 자체를 숨깁니다(404)
- **권한 모델** — 기존 `AccessGuard`를 재사용하는 `@Authorize` AOP 추가
- **검색** — 제목/본문/작성자 (QueryDSL)
- 마이그레이션 `V20260519__create_event_board.sql`

## 보안 수정

리뷰 중 발견해 함께 고쳤습니다.

`/api/v1/board/events/*` 와일드카드가 `/board/events/deleted`까지 매칭해 **관리자 전용 API가 시큐리티 계층에서 permitAll로 처리**되고 있었습니다.

AOP가 막아주고 있어 실제 유출은 없었지만, ① 인증 실패가 401이 아닌 403으로 나가고 ② 앞으로 추가되는 모든 GET 하위 경로가 자동 공개되며 ③ 방어가 AOP 단일 지점에만 의존하는 문제가 있어 공개 대상을 명시했습니다.

## 테스트

12개 추가했습니다.

- `EventBoardSecurityTest` (3) — 인증 경계. 관리자 API 차단, 공개 조회 유지
- `EventBoardServiceTest` (9) — 팀 권한, 미공개 글 가시성, 404/403 구분

권한 검사를 일시 무력화해 4개 테스트가 실제로 실패하는 것을 확인한 뒤 복원했습니다. 회귀 시 확실히 잡힙니다.

## 🚨 CI가 테스트 실패를 감지하지 못하고 있습니다

작업 중 발견한 사항입니다. **본 PR과 무관하지만 시급합니다.**

`.github/workflows/ci.yml:64,80`

```yaml
run: ./gradlew test --no-daemon --stacktrace --info --no-watch-fs | tee test.log
```

`| tee`로 파이프하면 스텝의 종료 코드가 `tee`의 것이 됩니다. **`gradlew`가 실패해도 exit 0**이라 뒤따르는 게이트가 무의미해집니다.

```yaml
- name: Fail if any failed
  if: ${{ always() && (steps.assemble.outcome != 'success' || steps.test.outcome != 'success') }}
```

`steps.test.outcome`이 항상 `success`이기 때문입니다. assemble 스텝도 같은 구조입니다.

**실제로 이 PR의 CI는 6건이 실패했는데도 "✅ Test 성공"을 보고했습니다.**

수정은 스텝에 `set -o pipefail`을 추가하면 됩니다. 다만 고치는 즉시 아래 잔여 실패로 CI가 빨간불이 되므로, **잔여 실패를 먼저 정리한 뒤 게이트를 살리는 순서**가 필요합니다.

## ⚠️ 알려진 테스트 실패 — 본 PR과 무관

1. **컴파일 오류 (본 PR에서 수정)**
   `91047f2`가 `RecruitMemberRequest`/`RecruitMember`의 `grade`, `nationality` 필드를 제거했으나 테스트가 갱신되지 않아 `compileTestJava`가 실패했습니다. **2026-02-14 이후 테스트 태스크 자체가 실행되지 못한 상태**였고, 위 pipefail 문제로 CI는 그동안 계속 초록불이었습니다. 삭제된 필드 참조만 제거해 복구했습니다.

2. **잔여 실패 6건 (수정하지 않음)**
   - `RecruitCoreApplicationServiceTest` 5건 — `RecruitCoreApplicationService.java:33`의 `RECRUITMENT_DEADLINE`이 `2026-03-14`로 하드코딩돼 `Instant.now()`와 비교합니다. 마감일이 지나 실패하며, **실제 운영에서도 코어 지원 API가 계속 차단된 상태**입니다. 다음 모집 시 코드 수정·재배포가 필요합니다
   - `RecruitMemberMemoNotificationServiceTest` 1건 — 알림 상태가 `SENT` 대신 `PENDING`

   둘 다 recruit 도메인 소관이고 `Clock` 주입 등 설계 변경이 필요해 본 PR 범위를 벗어납니다.

**본 PR의 CI 결과: 35 tests / 29 pass / 6 fail.** 추가한 12개는 전부 통과했고, 실패 6건은 위 기존 항목과 정확히 일치합니다.

## 리뷰 요청 사항

**권한 호출 방식을 통일할지 논의가 필요합니다.**

본 PR은 `@Authorize` AOP로, `feature/noticeboard`는 `@PreAuthorize("@accessGuard.check(...)")` SpEL로 호출합니다. 기반 `AccessGuard`는 동일하고 원래 두 방식을 모두 지원하도록 설계돼 있어 충돌은 아니지만, **먼저 머지되는 쪽이 사실상 표준이 됩니다.** 팀 합의 후 진행하는 게 좋겠습니다.

또한 `feature/freeboard`가 `SecurityConfig`를 103줄 수정합니다. 머지 순서에 따라 충돌 조정이 필요합니다.

## 후속 과제 (별도 PR 제안)

**인프라 (우선순위 높음)**
- CI에 `set -o pipefail` 추가 — 현재 테스트 실패가 무시됩니다
- `RECRUITMENT_DEADLINE` 하드코딩 제거 — `Clock` 주입 또는 설정값 분리

**행사 게시판**
- 목록 정렬용 인덱스 부재 — `ORDER BY created_at DESC`인데 해당 인덱스가 없습니다
- 검색이 `LIKE '%kw%'` 풀스캔 — noticeboard의 trgm 인덱스 방식과 맞추는 것을 제안합니다
- `thumbnailKey` 제거 불가 — 부분 업데이트라 null로 지울 수단이 없습니다
- 첨부 수정 시 전량 delete-insert — 변경이 없어도 ID가 매번 바뀝니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C6y8HJTXGsbKsdaHw6fQa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 행사 게시판을 추가해 게시글 작성, 수정, 삭제, 복구 및 상세·목록 조회를 지원합니다.
  * 제목·본문·작성자 검색, 페이지네이션, 행사 진행 상태와 첨부파일 정보를 제공합니다.
  * 공개 게시글은 인증 없이 조회할 수 있습니다.
* **권한 및 보안**
  * 비공개 게시글과 관리 기능에 사용자 역할 및 소속 팀별 접근 제한을 적용했습니다.
  * 삭제된 게시글 목록 조회와 복구는 권한이 있는 사용자만 이용할 수 있습니다.
* **데이터 관리**
  * 게시글과 첨부파일을 안정적으로 저장하며, 삭제 후 복구가 가능합니다.
  * 행사 기간 입력 시 날짜 유효성을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->