### PR TITLE
chore: Claude Code 하네스 도입 (CLAUDE.md, 설계 문서, 훅)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./gradlew compileJava compileTestJava --offline -q 2>&1 || { echo '컴파일 실패 - 위 에러를 확인하세요.' >&2; exit 1; }"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'rm\\s+-rf|git\\s+push\\s+--force|git\\s+push\\s+.*\\s-f\\b|git\\s+reset\\s+--hard|DROP\\s+TABLE|TRUNCATE\\s'; then echo 'BLOCKED: 위험한 명령어가 감지되었습니다.' >&2; exit 1; fi"
+          },
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'deploy\\.prod\\.sh|docker-compose-prod\\.yml|git\\s+push\\s+\\S+\\s+(HEAD:)?main\\b'; then echo 'BLOCKED: 운영 배포는 머지 즉시 자동 실행됩니다. 사용자 확인 없이 실행하지 마세요.' >&2; exit 1; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Claude Code ###
+# 팀 공유 설정(.claude/settings.json)은 커밋하고 개인 설정만 제외
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# 프로젝트: GDGoC INHA 백엔드
+
+인하대학교 GDGoC 공식 웹사이트의 백엔드 API 서버. 프론트엔드는 별도 리포(`GDGoCINHA/24-2_GDGoC_Web`, Next.js)에서 관리한다.
+
+## 기술 스택
+
+- Java 21 / Spring Boot 3.5.9
+- Spring Data JPA + QueryDSL (`io.github.openfeign.querydsl`)
+- PostgreSQL + Flyway
+- Spring Security + JWT(jjwt) + OAuth2(Google)
+- Redis (토큰 저장)
+- AWS S3 (`spring-cloud-aws`)
+- springdoc-openapi (Swagger UI)
+
+## 아키텍처 규칙
+
+- CRITICAL: 도메인은 `domain/{도메인}/` 아래 `controller`·`service`·`repository`·`entity`·`dto`·`enums`로 분리한다. 도메인 간 직접 참조 대신 서비스 계층을 경유한다.
+- CRITICAL: 모든 응답은 `ApiResponse<T, M>`로 감싼다. 컨트롤러가 엔티티를 그대로 반환하지 않는다 — 반드시 DTO(record)로 변환한다.
+- CRITICAL: 스키마 변경은 **반드시 Flyway 마이그레이션**으로 한다. `ddl-auto`에 의존하지 않는다. 파일명은 `V{YYYYMMDD}__{설명}.sql`이며 **기존 파일을 수정하지 않는다**(체크섬 불일치로 부팅 실패).
+- CRITICAL: 권한 검사는 `global/security/AccessGuard`를 사용한다. 직접 role을 비교하는 코드를 새로 만들지 않는다.
+- 엔티티는 `BaseEntity`를 상속해 `created_at`·`updated_at`을 자동 관리한다.
+- 예외는 `BusinessException` + `ErrorCode`로 던진다. HTTP 상태는 `ErrorCode`가 정한다.
+- QueryDSL 동적 쿼리는 `{Entity}RepositoryImpl`에 두고 인터페이스로 노출한다.
+
+## 개발 프로세스
+
+- CRITICAL: 버그 수정 시 **재현 테스트를 먼저 작성**하고, 실패를 확인한 뒤 고친다.
+- CRITICAL: 권한·가시성 로직을 수정하면 반드시 테스트를 추가한다. 회귀 시 보안 사고로 이어진다.
+- 커밋 메시지는 conventional commits를 따른다 (`feat:`, `fix:`, `test:`, `refactor:`, `chore:`).
+- 브랜치는 `feature/{기능}` → `develop` → `main` 순으로 올린다.
+
+## 명령어
+
+```bash
+./gradlew build -x test    # 빌드 (테스트 제외)
+./gradlew test             # 테스트
+./gradlew compileTestJava  # 테스트 컴파일만 확인
+```
+
+로컬 실행에는 PostgreSQL·Redis와 `.env`가 필요하다. 두 파일 모두 리포에 포함되지 않으므로 팀에서 별도로 받는다.
+
+## ⚠️ 이 프로젝트의 함정
+
+코드만 읽어서는 드러나지 않는 것들. **작업 전에 반드시 인지할 것.**
+
+### CI의 초록불을 믿지 마라
+
+`.github/workflows/ci.yml`의 테스트 스텝이 `./gradlew test | tee test.log` 형태다. 파이프 때문에 종료 코드가 `tee`의 것이 되어 **gradlew가 실패해도 CI는 성공으로 보고한다.**
+
+실제로 2026-02-14부터 8월까지 테스트가 컴파일조차 안 되는 상태였으나 CI는 매번 "✅ Test 성공"을 찍었다. 테스트 상태는 CI 배지가 아니라 **`Test Results` 체크나 로컬 실행 결과**로 확인해야 한다.
+
+수정하려면 스텝에 `set -o pipefail`을 추가하면 되지만, 그러면 아래 기존 실패로 모든 PR이 막힌다. **기존 실패를 먼저 정리한 뒤 게이트를 살릴 것.**
+
+### 기존 테스트 6건이 실패 상태다
+
+내가 만든 실패가 아닌지 먼저 확인하라. 2026-08-04 기준:
+
+- `RecruitCoreApplicationServiceTest` 5건 — `RecruitCoreApplicationService.java`의 `RECRUITMENT_DEADLINE`이 `2026-03-14`로 하드코딩되어 `Instant.now()`와 비교한다. 마감일이 지나 실패한다. **운영에서도 코어 지원 API가 계속 차단된 상태**이며, 다음 모집 시 코드 수정·재배포가 필요하다.
+- `RecruitMemberMemoNotificationServiceTest` 1건 — 알림 상태가 `SENT` 대신 `PENDING`.
+
+### 머지가 곧 배포다
+
+승인 단계나 수동 트리거가 없다.
+
+| 브랜치 | 결과 |
+|---|---|
+| `develop` push | CD-DEV → 개발 서버 자동 배포 |
+| `main` push | **CD-PROD → 운영 서버 자동 배포** |
+
+- 배포는 `docker-compose down` → `up` 방식이라 **다운타임이 발생**한다 (블루/그린 아님).
+- **Flyway 마이그레이션은 되돌릴 수 없다.** down 스크립트가 없어 코드를 롤백해도 스키마는 남는다.
+- 롤백은 이전 커밋을 `main`에 다시 push하는 것이 사실상 유일한 수단이다 (`deploy.prod.sh`가 `:latest`만 pull).
+
+### 인증 경로 설정에 와일드카드를 쓰지 마라
+
+`SecurityConfig`에서 `/api/v1/xxx/*` 같은 패턴은 의도치 않은 하위 경로까지 공개한다. 실제로 `/api/v1/board/events/*`가 관리자용 `/deleted`까지 permitAll 처리한 사례가 있었다. **공개할 경로를 개별 명시**하고, 경로 변수는 `{id:[0-9]+}`처럼 제약을 건다.
+
+메서드 단위 인가(`@Authorize` AOP 또는 `@PreAuthorize`)가 막아주더라도, 시큐리티 계층에서 열어두면 401이어야 할 응답이 403으로 나가고 방어가 단일 지점에 의존하게 된다.
+
+## 관련 문서
+
+- `docs/ARCHITECTURE.md` — 디렉터리 구조, 레이어, 인증 흐름
+- `docs/ADR.md` — 주요 설계 결정과 트레이드오프

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -1,0 +1,94 @@
+# Architecture Decision Records
+
+> **이 문서의 성격**
+>
+> 기존 코드베이스에서 **관찰된 결정을 역으로 정리**한 것이다. `결정`과 `트레이드오프`는 코드에서 확인한 사실이지만, `이유` 중 `[추정]` 표시가 붙은 항목은 당시 논의 기록이 없어 추론한 것이다. **당사자가 확인 후 수정하거나 확정 표시로 바꿔달라.**
+
+## 철학
+
+관찰된 경향:
+
+- 도메인별 수직 분할. 공통 인프라는 `global/`에 모으고 도메인은 서로 직접 참조하지 않는다.
+- 응답·예외·감사 필드를 전역 규약으로 통일한다 (`ApiResponse`, `ErrorCode`, `BaseEntity`).
+- 스키마는 코드가 아니라 마이그레이션이 소유한다.
+
+---
+
+### ADR-001: QueryDSL은 openfeign fork를 사용
+
+**결정**: `io.github.openfeign.querydsl:querydsl-jpa`를 사용한다. 원본 `com.querydsl`이 아니다.
+
+**이유**: 원본 QueryDSL이 Jakarta EE(`jakarta.persistence`) 전환에 대응하지 않아 Spring Boot 3.x에서 그대로 쓸 수 없다. openfeign fork가 이를 지원한다.
+
+**트레이드오프**: 업스트림이 아닌 fork에 의존한다. 원본 QueryDSL 문서·예제와 좌표가 달라 혼동이 생길 수 있다.
+
+---
+
+### ADR-002: 스키마 변경은 Flyway로만, 파일명은 날짜 기반
+
+**결정**: `V{YYYYMMDD}__{설명}.sql` 형식으로 마이그레이션을 작성한다. 운영·개발 프로파일에서 `flyway.enabled: true`, `baseline-on-migrate: true`, `clean-disabled: true`.
+
+**이유**: 스키마 이력을 코드와 함께 버전 관리하기 위함. 날짜 기반 네이밍은 [추정] 여러 명이 동시에 브랜치를 파도 버전 번호가 충돌하지 않게 하려는 의도로 보인다.
+
+**트레이드오프**:
+- 날짜 기반이라 **머지 순서와 버전 순서가 어긋날 수 있다.** 늦게 만든 마이그레이션이 먼저 머지되면 out-of-order 상황이 발생한다.
+- **down 스크립트가 없다.** 롤백 시 스키마는 남는다.
+- 테스트는 Flyway를 끄고 `ddl-auto: create-drop`을 쓰므로 **마이그레이션 SQL 자체는 테스트로 검증되지 않는다.**
+
+---
+
+### ADR-003: 권한 검사는 AccessGuard로 중앙화, 호출 방식은 두 가지
+
+**결정**: `global/security/AccessGuard`가 역할·팀 조건 판정을 단독으로 책임진다. 호출 진입점은 둘이다.
+
+- `check(...)` → `@PreAuthorize("@accessGuard.check(...)")` SpEL에서 사용, boolean 반환
+- `require(...)` → `@Authorize` AOP 및 서비스에서 직접 호출, 실패 시 예외
+
+**이유**: 역할 비교 로직이 여러 도메인에 흩어지는 것을 막기 위함. 서열 비교를 `UserRole.rank()` 한 곳에 두어 enum 순서 변경에 영향받지 않게 했다.
+
+**트레이드오프**: 진입점이 둘이라 **도메인마다 다른 방식을 쓸 수 있다.** 실제로 행사 게시판은 `@Authorize`, 공지 게시판은 `@PreAuthorize`를 쓴다. 판정 로직은 동일하므로 기능상 충돌은 없으나, 신규 코드가 어느 쪽을 따라야 하는지 불명확하다. **팀 합의가 필요한 항목.**
+
+---
+
+### ADR-004: 게시판은 소프트 딜리트
+
+**결정**: `deleted_at` 컬럼으로 논리 삭제한다. 저장소의 `findById`는 `findByIdAndDeletedAtIsNull`로 위임하고, 삭제분 조회는 `findDeletedById`로 분리한다.
+
+**이유**: 실수로 삭제한 게시글을 복구하기 위함 (`POST /{id}/restore`).
+
+**트레이드오프**:
+- 모든 조회 경로에 `deleted_at IS NULL` 조건이 필요하다. 저장소 인터페이스에서 기본 동작으로 감싸 실수를 줄였지만, QueryDSL 직접 조회 시에는 조건을 빠뜨릴 수 있다.
+- 첨부파일 등 연관 데이터는 함께 정리되지 않고 남는다.
+
+---
+
+### ADR-005: 인증은 JWT + Redis
+
+**결정**: 액세스 토큰은 JWT(jjwt)로 발급하고 리프레시 토큰 등 상태는 Redis에 둔다. 세션은 `STATELESS`.
+
+**이유**: [추정] 서버 확장 시 세션 공유 문제를 피하고, 토큰 무효화가 필요한 부분만 Redis로 처리하려는 절충으로 보인다.
+
+**트레이드오프**: Redis 장애가 인증 흐름에 영향을 준다. 액세스 토큰 자체는 만료 전까지 무효화할 수 없다.
+
+---
+
+### ADR-006: 배포는 Docker 이미지 + CodeDeploy, 브랜치 push가 트리거
+
+**결정**: `develop` push → 개발 서버, `main` push → 운영 서버로 자동 배포한다. GitHub Actions가 이미지를 빌드해 Docker Hub에 올리고(`:latest` + `:{sha}`), S3를 거쳐 CodeDeploy가 EC2에서 `deploy.prod.sh`를 실행한다.
+
+**이유**: [추정] 별도 배포 인프라 없이 GitHub Actions만으로 파이프라인을 구성하려는 선택으로 보인다.
+
+**트레이드오프**:
+- **승인 단계가 없다.** 머지가 곧 배포다.
+- `docker-compose down` → `up` 방식이라 **다운타임이 발생**한다.
+- `deploy.prod.sh`가 `:latest`만 pull하므로, Docker Hub에 SHA 태그가 남아있어도 **롤백은 이전 커밋을 다시 push하는 방식**에 의존한다.
+
+---
+
+### ADR-007: 응답 포맷 통일
+
+**결정**: 모든 엔드포인트가 `ApiResponse<T, M>(code, message, data, meta)`를 반환한다. `null` 필드는 직렬화에서 제외한다.
+
+**이유**: 프론트엔드가 응답 구조를 일관되게 처리하도록 하기 위함.
+
+**트레이드오프**: HTTP 상태 코드와 본문의 `code`가 중복된다. 제네릭 파라미터가 둘이라 `meta`가 없는 경우에도 `Void`를 명시해야 한다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,133 @@
+# 아키텍처
+
+## 디렉터리 구조
+
+```
+src/main/java/inha/gdgoc/
+├── domain/              # 도메인별 수직 분할
+│   ├── admin/           # 관리자 기능
+│   ├── auth/            # 인증·로그인
+│   ├── board/           # 게시판
+│   ├── core/            # 코어 멤버
+│   ├── game/            # 이벤트성 게임
+│   ├── guestbook/       # 방명록
+│   ├── manito/          # 마니또
+│   ├── recruit/         # 모집 (core / member)
+│   ├── resource/        # S3 파일 업로드·다운로드
+│   ├── study/           # 스터디
+│   └── user/            # 사용자
+└── global/              # 도메인 무관 공통 인프라
+    ├── config/          # jpa, jwt, openapi, querydsl, s3
+    ├── dto/             # ApiResponse, PageMeta, ErrorMeta
+    ├── entity/          # BaseEntity
+    ├── exception/       # BusinessException, ErrorCode
+    ├── security/        # SecurityConfig, AccessGuard, TokenAuthenticationFilter
+    └── util/
+```
+
+각 도메인은 동일한 내부 구조를 갖는다:
+
+```
+domain/{도메인}/
+├── controller/          # HTTP 엔드포인트 (+ message/ 응답 메시지 상수)
+├── dto/request/         # 요청 DTO (record + Bean Validation)
+├── dto/response/        # 응답 DTO (record)
+├── entity/              # JPA 엔티티
+├── enums/
+├── exception/           # 도메인 전용 ErrorCode
+├── repository/          # JpaRepository + QueryDSL Impl
+└── service/             # 비즈니스 로직·트랜잭션 경계
+```
+
+`src/main/resources/db/migration/` 에 Flyway 마이그레이션이 위치한다.
+
+## 레이어 패턴
+
+```
+Controller  →  Service  →  Repository  →  DB
+   │             │            │
+   │             │            └── JpaRepository(단순 조회) + QueryDslRepository(동적 쿼리)
+   │             └── @Transactional 경계. 엔티티 → DTO 변환
+   └── 요청 검증(@Valid), 인가(@Authorize), ApiResponse 래핑
+```
+
+**규칙**
+
+- 컨트롤러는 엔티티를 반환하지 않는다. 서비스가 DTO로 변환해 넘긴다.
+- 트랜잭션은 서비스에서 연다. 클래스에 `@Transactional(readOnly = true)`를 걸고 쓰기 메서드만 `@Transactional`로 덮는 방식을 쓴다.
+- 동적 쿼리는 `{Entity}QueryDslRepository` 인터페이스로 선언하고 `{Entity}RepositoryImpl`에서 구현한다. 서비스는 통합 인터페이스(`{Entity}Repository`)에만 의존한다.
+
+## 인증·인가 흐름
+
+```
+Request
+  │
+  ├─ TokenAuthenticationFilter          JWT 파싱 → CustomUserDetails → SecurityContext
+  │    (shouldNotFilter 목록은 스킵)
+  │
+  ├─ SecurityConfig                     경로 단위 인가 (permitAll / authenticated)
+  │
+  ├─ @Authorize (AuthorizeAspect)       메서드 단위 인가 → AccessGuard.require()
+  │  또는 @PreAuthorize("@accessGuard.check(...)")
+  │
+  └─ Service                            도메인 권한 (예: 작성팀 소유권 검사)
+```
+
+**3중 구조인 이유**
+
+- `SecurityConfig` — 경로 자체가 공개인지 여부. 여기서 열면 인증 정보 없이도 통과하므로 신중히 다룬다.
+- `@Authorize` / `@PreAuthorize` — 역할(role)·팀 기반 정적 조건. 둘 다 내부적으로 `AccessGuard`를 호출한다.
+- 서비스 계층 — "작성한 팀만 수정 가능" 같이 **데이터를 조회해야 판단 가능한** 조건.
+
+`AccessGuard`는 두 진입점을 제공한다.
+
+| 메서드 | 용도 | 실패 시 |
+|---|---|---|
+| `check(...)` | SpEL(`@PreAuthorize`)에서 호출 | `false` 반환 |
+| `require(...)` | AOP·서비스에서 직접 호출 | `AccessDeniedException` |
+
+역할 서열은 `UserRole.rank()`가 정한다: `GUEST(0) < MEMBER(1) < CORE(2) < LEAD(3) < ORGANIZER(4) < ADMIN(5)`. 비교는 항상 `UserRole.hasAtLeast(me, required)`를 쓴다.
+
+## 공통 규약
+
+**응답** — 모든 엔드포인트는 `ApiResponse<T, M>`를 반환한다.
+
+```java
+record ApiResponse<T, M>(int code, String message, T data, M meta)
+```
+
+`meta`에는 페이징 정보(`PageMeta`)나 에러 컨텍스트(`ErrorMeta`)가 들어간다. `null` 필드는 직렬화에서 제외된다.
+
+**예외** — `BusinessException(ErrorCode)` 하나로 던지고, HTTP 상태는 `ErrorCode`가 보유한다. 전역 핸들러가 `ErrorCode.getStatus()`로 응답 코드를 정한다.
+
+| 코드 | 상태 |
+|---|---|
+| `UNAUTHORIZED_USER` | 401 |
+| `FORBIDDEN_USER` | 403 |
+| `RESOURCE_NOT_FOUND` | 404 |
+
+리소스의 **존재 자체를 숨겨야 할 때**는 403이 아니라 404를 쓴다 (권한 없는 사용자에게 존재 여부가 새지 않도록).
+
+**감사 필드** — 엔티티는 `BaseEntity`를 상속해 `created_at`·`updated_at`을 JPA Auditing으로 자동 관리한다.
+
+## 데이터 흐름 (조회 예시)
+
+```
+GET /api/v1/board/events?page=0&size=12
+  → Controller: @AuthenticationPrincipal로 사용자 컨텍스트 추출
+  → Service: 권한에 따른 가시성 조건 결정
+  → RepositoryImpl: QueryDSL 동적 where + count
+  → Service: Entity → DTO 변환 (S3 key → URL 치환)
+  → ApiResponse + PageMeta
+```
+
+## 환경 프로파일
+
+| 프로파일 | DB | Flyway | 용도 |
+|---|---|---|---|
+| `local` | 로컬 PostgreSQL (docker-compose-local.yml) | enabled | 개발 |
+| `test` | H2 (PostgreSQL 모드) | **disabled** (`ddl-auto: create-drop`) | 테스트 |
+| `dev` | 개발 서버 PostgreSQL | enabled | develop 브랜치 배포 |
+| `prod` | 운영 PostgreSQL | enabled | main 브랜치 배포 |
+
+테스트는 Flyway를 끄고 엔티티에서 스키마를 생성한다. **따라서 마이그레이션 SQL의 오류는 테스트로 잡히지 않는다.**


### PR DESCRIPTION
## 개요

AI 코딩 에이전트(Claude Code)가 이 코드베이스에서 작업할 때 필요한 맥락과 가드레일을 추가합니다. 코드 변경은 없습니다.

## 추가된 파일

| 파일 | 내용 |
|---|---|
| `CLAUDE.md` | 기술 스택, 아키텍처·개발 규칙, 이 프로젝트의 함정 |
| `docs/ARCHITECTURE.md` | 디렉터리 구조, 레이어 패턴, 인증·인가 3단 구조, 프로파일별 DB |
| `docs/ADR.md` | 코드에서 관찰된 설계 결정 7건과 트레이드오프 |
| `.claude/settings.json` | 종료 시 컴파일 검증, 위험 명령 차단 훅 |
| `.gitignore` | `.claude/settings.local.json`만 제외 (팀 설정은 커밋) |

## 문서에 담은 것

에이전트에게 유용한 정보는 **코드를 읽어서 알 수 있는 것이 아니라, 읽어도 모르는 것**입니다. `CLAUDE.md`의 '함정' 절에 그런 항목을 모았습니다.

- **CI가 테스트 실패를 감지하지 못한다** — `./gradlew test | tee test.log`의 파이프 때문에 종료 코드가 `tee`의 것이 됩니다. 실제로 이 사실 때문에 테스트가 컴파일조차 안 되던 6개월간 CI는 계속 초록불이었습니다
- **기존 테스트 6건이 실패 상태다** — 새로 유입되는 사람이 자기 탓으로 오해하지 않도록
- **머지가 곧 배포다** — 승인 단계가 없고, 마이그레이션은 down 스크립트가 없어 되돌릴 수 없습니다
- **인증 경로에 와일드카드를 쓰지 마라** — `/api/v1/board/events/*`가 관리자용 `/deleted`까지 공개한 실제 사례를 근거로

## 훅 구성

**Stop** — `./gradlew compileJava compileTestJava`

`test`를 넣지 않았습니다. 기존 6건 실패 때문에 훅이 상시 빨간불이 되면 결국 무시하게 되기 때문입니다. 잔여 실패가 정리되면 그때 `test`로 올리는 것을 제안합니다.

**PreToolUse** — 위험 명령 차단

`rm -rf`, `git push --force`, `git reset --hard`, `DROP TABLE`, `TRUNCATE`, `deploy.prod.sh` 직접 실행, `git push origin main`을 차단합니다.

두 훅 모두 실제 실행해 동작을 확인했습니다.

## 리뷰 요청 사항

**`docs/ADR.md`의 `[추정]` 표시를 확인해 주세요.**

설계 결정의 `결정`·`트레이드오프`는 코드에서 확인한 사실이지만, `이유` 중 일부는 당시 논의 기록이 없어 추론했습니다. 잘못된 근거가 문서로 굳으면 나중에 더 큰 혼란이 되므로 `[추정]`으로 표시해 뒀습니다. **당사자가 확인 후 수정하거나 표시를 제거해 주세요.**

해당 항목: ADR-002(마이그레이션 날짜 네이밍), ADR-005(JWT + Redis), ADR-006(배포 구조).

또한 ADR-003에 적었듯 권한 호출 방식이 `@Authorize`(AOP)와 `@PreAuthorize`(SpEL) 둘로 나뉘어 있습니다. 판정 로직은 동일하므로 충돌은 아니지만 신규 코드가 어느 쪽을 따를지 팀 합의가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C6y8HJTXGsbKsdaHw6fQa
