### PR TITLE
fix: 배포 시 이미지 정리 시점을 컨테이너 기동 이후로 이동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,14 +62,40 @@
 
 승인 단계나 수동 트리거가 없다.
 
-| 브랜치 | 결과 |
-|---|---|
-| `develop` push | CD-DEV → 개발 서버 자동 배포 |
-| `main` push | **CD-PROD → 운영 서버 자동 배포** |
+| 브랜치 | 결과 | 서버 |
+|---|---|---|
+| `develop` push | CD-DEV → 개발 서버 자동 배포 | `https://dev-api.gdgocinha.com` |
+| `main` push | **CD-PROD → 운영 서버 자동 배포** | `https://api.gdgocinha.com` |
 
 - 배포는 `docker-compose down` → `up` 방식이라 **다운타임이 발생**한다 (블루/그린 아님).
 - **Flyway 마이그레이션은 되돌릴 수 없다.** down 스크립트가 없어 코드를 롤백해도 스키마는 남는다.
 - 롤백은 이전 커밋을 `main`에 다시 push하는 것이 사실상 유일한 수단이다 (`deploy.prod.sh`가 `:latest`만 pull).
+
+### 배포 워크플로우의 초록불은 "요청 성공"일 뿐이다
+
+`deploy-dev.yml`·`deploy-prod.yml`의 마지막 스텝은 `aws deploy create-deployment`이며, **`wait`이 없다.** CodeDeploy에 배포를 *요청*하면 워크플로우는 즉시 성공으로 끝난다.
+
+따라서 **Actions가 초록불이어도 서버에는 이전 버전이 떠 있을 수 있고, CodeDeploy가 실패해도 알 수 없다.** 실제 반영까지는 `docker pull` → 컨테이너 기동 → Flyway 마이그레이션 순으로 수 분이 걸린다.
+
+**배포 후에는 반드시 실제 엔드포인트로 확인하라.**
+
+```bash
+# 반영 확인 (공개 GET이므로 인증 불필요)
+curl -s -o /dev/null -w "%{http_code}\n" \
+  "https://dev-api.gdgocinha.com/api/v1/board/events?page=0&size=1"
+```
+
+`200`이면 반영 완료. `401`이면 아직 구버전이다 — 구버전에는 해당 경로가 `permitAll` 목록에 없어 인증을 요구하기 때문이다.
+
+**구버전 판별 요령**: 대조군으로 예전부터 공개였던 경로를 함께 호출한다. `/api/v1/auth/login`이 `400`(시큐리티 통과)인데 확인 대상만 `401`이라면, 시큐리티는 정상 동작하는데 그 경로가 아직 없는 것 — 즉 배포 미반영이다.
+
+### 개발 서버는 디스크 여유가 거의 없다
+
+dev 인스턴스(t2.micro)의 루트 볼륨은 6.8G인데 OS 2.5G + `/var` 2.0G + 스왑 2.0G로 이미 6.4G를 쓴다. 여유는 500~800MB 수준이다.
+
+**디스크가 차면 배포가 스스로를 구제하지 못한다.** 정리 코드는 `AfterInstall`의 `deploy.dev.sh` 안에 있는데, 디스크가 차면 그 앞 단계인 `ApplicationStop`에서 죽어 도달하지 못한다. 이후 모든 단계가 `Skipped`로 남고 구버전이 계속 응답한다.
+
+2026-08-04에 실제로 발생했다. 더 나쁜 건 **SSM 에이전트도 같이 죽어서**(`PingStatus`는 `Online`인데 명령이 0초 만에 빈 출력으로 실패) 원격 진단조차 막혔고, 콘솔에서 EC2 Instance Connect로 직접 붙어야 했다. 이때 공간을 만든 건 `apt-get clean`(330M)과 `journalctl --vacuum-size`(35M)였다 — `docker system prune`은 0B였다.
 
 ### 인증 경로 설정에 와일드카드를 쓰지 마라
 

--- a/deploy.dev.sh
+++ b/deploy.dev.sh
@@ -22,12 +22,6 @@ fi
 # 기존 컨테이너 중지 및 삭제
 docker-compose -f docker-compose-dev.yml down
 
-# 사용되지 않는 컨테이너, 이미지, 네트워크, 볼륨 정리
-docker system prune -af
-
-# 불필요한 Docker 볼륨도 정리 (옵션)
-docker volume prune -f
-
 # 최신 이미지 가져오기
 # shellcheck disable=SC2046
 export $(grep -v '^#' .env | xargs)
@@ -36,3 +30,9 @@ docker pull ${DOCKER_HUB_USERNAME}/gdgoc-be-app-dev:latest
 
 # 컨테이너 실행
 docker-compose -f docker-compose-dev.yml --env-file .env up -d
+
+# 정리는 컨테이너가 뜬 뒤에 한다.
+# 기동 전에 `prune -af` 를 돌리면 down 직후라 모든 이미지가 미사용으로 잡혀
+# redis·dozzle 까지 전부 삭제되고, 매 배포마다 이미지를 통째로 다시 받게 된다.
+# 여기서는 방금 교체된 구버전 앱 이미지(dangling)만 지워진다.
+docker image prune -f

--- a/deploy.prod.sh
+++ b/deploy.prod.sh
@@ -22,12 +22,6 @@ fi
 # 기존 컨테이너 중지 및 삭제
 docker-compose -f docker-compose-prod.yml down
 
-# 사용되지 않는 컨테이너, 이미지, 네트워크, 볼륨 정리
-docker system prune -af
-
-# 불필요한 Docker 볼륨도 정리 (옵션)
-docker volume prune -f
-
 # 최신 이미지 가져오기
 # shellcheck disable=SC2046
 export $(grep -v '^#' .env | xargs)
@@ -36,3 +30,9 @@ docker pull ${DOCKER_HUB_USERNAME}/gdgoc-be-app:latest
 
 # 컨테이너 실행
 docker-compose -f docker-compose-prod.yml --env-file .env up -d
+
+# 정리는 컨테이너가 뜬 뒤에 한다.
+# 기동 전에 `prune -af` 를 돌리면 down 직후라 모든 이미지가 미사용으로 잡혀
+# redis·dozzle 까지 전부 삭제되고, 매 배포마다 이미지를 통째로 다시 받게 된다.
+# 여기서는 방금 교체된 구버전 앱 이미지(dangling)만 지워진다.
+docker image prune -f


### PR DESCRIPTION
## 문제

`deploy.dev.sh` / `deploy.prod.sh` 가 이 순서로 동작한다.

```bash
docker-compose down        # ① 컨테이너 전부 내림
docker system prune -af    # ② 실행 중인 게 없으므로 모든 이미지가 삭제 대상
docker volume prune -f
docker pull ...:latest     # ③ 다시 받음
docker-compose up -d       # ④ redis, dozzle 도 다시 받음
```

②의 `prune -a` 는 **사용 중이 아닌** 이미지를 지운다. 바로 앞에서 컨테이너를 전부 내렸으니 이 시점엔 모든 이미지가 미사용이다. 앱 이미지뿐 아니라 `redis:7-alpine`, `amir20/dozzle` 까지 삭제되고, ③④에서 465MB 를 통째로 다시 받는다.

- 레디스·dozzle 이미지는 바뀐 적이 없는데 매 배포마다 재다운로드된다.
- 앱 이미지도 구버전을 남겨두면 도커가 레이어를 재사용해 바뀐 JAR 레이어만 받으면 되는데, JRE 베이스 레이어(~200MB)까지 버리고 다시 받는다.
- **pull 이 실패하면 되돌아갈 이미지가 이미 없어 서비스가 올라오지 못한다.**

## 변경

정리를 `up -d` 뒤로 옮기고 `docker image prune -f` 로 바꾼다.

```bash
docker-compose down
docker pull ...:latest
docker-compose up -d
docker image prune -f      # 방금 교체된 구버전 앱 이미지(dangling)만 삭제
```

`:latest` 태그가 새 이미지로 옮겨가면서 구버전이 dangling 상태가 되므로, `image prune -f` 가 정확히 그것만 지운다. 사용 중인 redis·dozzle 은 태그가 살아 있어 남는다. 디스크 증가는 여전히 매 배포마다 억제된다.

`docker volume prune -f` 는 제거했다. 현재는 명명된 볼륨이 없어 무해하지만, DB 컨테이너를 볼륨과 함께 추가하는 순간 **매 배포마다 데이터가 사라지는** 지뢰다.

## 트레이드오프

전환 중 구·신 이미지가 잠시 공존하므로 **순간 최대 디스크 사용량이 늘어난다**(약 +250MB). 현재 dev 여유가 797MB 라 감당되지만, 아래 문서화한 대로 dev 볼륨은 원래 빠듯하다. 볼륨 증설(6.8G → 16G)은 비용이 걸린 결정이라 이 PR 범위 밖으로 둔다.

## 문서

`CLAUDE.md` 에 두 가지를 추가했다.

- **배포 워크플로우의 초록불은 "요청 성공"일 뿐** — `aws deploy create-deployment` 에 `wait` 이 없어 CodeDeploy 가 실패해도 Actions 는 초록불이다. 엔드포인트로 확인하는 방법과, 대조군 경로로 구버전을 판별하는 요령을 적었다.
- **개발 서버 디스크 제약** — 2026-08-04 배포 실패의 실제 원인. 루트 볼륨 6.8G 중 6.4G 사용(OS 2.5G + `/var` 2.0G + 스왑 2.0G). 정리 코드가 `AfterInstall` 에 있어 디스크가 차면 앞 단계인 `ApplicationStop` 에서 죽어 도달하지 못하고, SSM 에이전트까지 함께 멎어 원격 진단이 막힌다.

## 검증

- `bash -n` 구문 검사 통과 (양쪽 스크립트)
- 이 PR 자체가 dev 배포를 트리거하므로, 머지 후 실제 반영과 재다운로드 감소를 엔드포인트·디스크로 확인할 예정

> 참고: 배포 스크립트는 CI 로 검증되지 않는다. 실제 실행은 머지 후 CodeDeploy 에서 처음 일어난다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C6y8HJTXGsbKsdaHw6fQa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 개발·운영 서버의 배포 대상과 브랜치별 자동 배포 정보를 추가했습니다.
  * 배포 상태 확인 방법, 상태 코드 해석, 실패 전파 및 장애 대응 절차를 문서화했습니다.

* **개선**
  * 배포 전 전체 시스템 정리를 제거해 불필요한 리소스 삭제를 방지했습니다.
  * 배포 후 사용하지 않는 이미지만 정리하도록 변경해 서비스 실행 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->