### PR TITLE
fix: 아무것도 막지 못하던 PreToolUse 가드 수정

### DIFF
--- a/.claude/hooks/guard.mjs
+++ b/.claude/hooks/guard.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// PreToolUse 가드 — 되돌릴 수 없는 동작을 차단한다.
+//
+// 훅 입력은 **stdin 의 JSON** 으로 들어온다. 환경변수가 아니다.
+// (이전 버전은 `$CLAUDE_TOOL_INPUT` 을 읽어 늘 빈 문자열이었고, 아무것도 막지 못하면서
+//  막는 것처럼 보였다. `guard.test.mjs` 가 그 회귀를 고정한다.)
+//
+// 판정은 `judge()` 하나에 모아 두고 CLI 는 입출력만 한다 — 그래야 테스트가 붙는다.
+
+const DESTRUCTIVE = [
+  // rm -rf / -fr / -Rf / -rfv ... 플래그 뭉치에 r 과 f 가 함께 있으면 잡는다.
+  [/\brm\s+-[a-zA-Z]*([rR][a-zA-Z]*[fF]|[fF][a-zA-Z]*[rR])/, "`rm -rf` 는 되돌릴 수 없다"],
+  [/\bgit\s+push\b[^\n]*\s(--force\b|-f\b)/, "force push 는 남의 커밋을 지운다"],
+  [/\bgit\s+reset\s+--hard\b/, "`git reset --hard` 는 작업 트리를 버린다"],
+  [/\bDROP\s+TABLE\b/i, "`DROP TABLE` 은 되돌릴 수 없다"],
+  [/\bTRUNCATE\b/i, "`TRUNCATE` 는 되돌릴 수 없다"],
+];
+
+const PRODUCTION = [
+  [/\bdeploy\.prod\.sh\b/, "운영 배포 스크립트다"],
+  [/\bdocker-compose-prod\.yml\b/, "운영 컴포즈 파일이다"],
+  // `git push -u origin main` 처럼 플래그가 끼어도 잡히도록 위치를 고정하지 않는다.
+  // 단 ref 끝이 main 일 때만 — `feature/main-menu` 는 대상이 아니다.
+  [/\bgit\s+push\b.*\bmain(\s|$)/, "main 푸시는 운영 자동 배포를 트리거한다"],
+];
+
+/**
+ * @returns {{reason: string} | null}  차단이면 사유, 통과면 null
+ */
+export function judge(input) {
+  // 판정할 수 없으면 통과가 아니라 차단한다(fail-closed).
+  // 조용히 통과시키면 가드가 없는 것과 같다.
+  if (input === null || typeof input !== "object") {
+    return { reason: "훅 입력을 해석할 수 없다" };
+  }
+
+  const command = input?.tool_input?.command;
+  if (input.tool_name === "Bash" && typeof command !== "string") {
+    return { reason: "Bash 호출인데 command 를 읽을 수 없다" };
+  }
+  if (typeof command !== "string") return null;
+
+  for (const [re, why] of DESTRUCTIVE) {
+    if (re.test(command)) return { reason: `${why}. 사용자 확인 없이 실행하지 마라.` };
+  }
+  for (const [re, why] of PRODUCTION) {
+    if (re.test(command)) {
+      return { reason: `${why}. 머지 즉시 자동 배포되므로 사용자 확인 없이 실행하지 마라.` };
+    }
+  }
+  return null;
+}
+
+// --- CLI ------------------------------------------------------------------
+// 이 파일이 직접 실행될 때만 stdin 을 읽는다. import 하는 테스트는 여기 오지 않는다.
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  let raw = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (d) => (raw += d));
+  process.stdin.on("end", () => {
+    let verdict;
+    try {
+      verdict = judge(JSON.parse(raw));
+    } catch {
+      verdict = { reason: "훅 입력 JSON 을 파싱하지 못했다" };
+    }
+    if (!verdict) process.exit(0);
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: `BLOCKED: ${verdict.reason}`,
+        },
+      })
+    );
+    process.exit(0);
+  });
+}

--- a/.claude/hooks/guard.mjs
+++ b/.claude/hooks/guard.mjs
@@ -7,9 +7,18 @@
 //
 // 판정은 `judge()` 하나에 모아 두고 CLI 는 입출력만 한다 — 그래야 테스트가 붙는다.
 
+// 셸 툴 — 이 툴들은 command 를 못 읽으면 판정 불가로 보고 차단한다.
+const SHELL_TOOLS = new Set(["Bash", "PowerShell"]);
+
 const DESTRUCTIVE = [
   // rm -rf / -fr / -Rf / -rfv ... 플래그 뭉치에 r 과 f 가 함께 있으면 잡는다.
   [/\brm\s+-[a-zA-Z]*([rR][a-zA-Z]*[fF]|[fF][a-zA-Z]*[rR])/, "`rm -rf` 는 되돌릴 수 없다"],
+  // PowerShell 의 재귀 삭제. `-Force` 없이도 트리를 지운다.
+  // PowerShell 은 파라미터 축약을 허용하므로 `-Rec` 접두사로 본다.
+  [
+    /\b(Remove-Item|ri|rd|rmdir)\b[^\n]*\s-[Rr]ec/,
+    "`Remove-Item -Recurse` 는 되돌릴 수 없다",
+  ],
   [/\bgit\s+push\b[^\n]*\s(--force\b|-f\b)/, "force push 는 남의 커밋을 지운다"],
   [/\bgit\s+reset\s+--hard\b/, "`git reset --hard` 는 작업 트리를 버린다"],
   [/\bDROP\s+TABLE\b/i, "`DROP TABLE` 은 되돌릴 수 없다"],
@@ -35,8 +44,8 @@ export function judge(input) {
   }
 
   const command = input?.tool_input?.command;
-  if (input.tool_name === "Bash" && typeof command !== "string") {
-    return { reason: "Bash 호출인데 command 를 읽을 수 없다" };
+  if (SHELL_TOOLS.has(input.tool_name) && typeof command !== "string") {
+    return { reason: `${input.tool_name} 호출인데 command 를 읽을 수 없다` };
   }
   if (typeof command !== "string") return null;
 

--- a/.claude/hooks/guard.test.mjs
+++ b/.claude/hooks/guard.test.mjs
@@ -81,12 +81,51 @@ test("아는 구멍: 변수 치환은 셸이 한다", () => {
   assert.equal(judge(bash('eval "$DANGEROUS_CMD"')), null);
 });
 
-test("아는 구멍: PowerShell 은 아직 대상이 아니다", () => {
-  // settings.json 의 matcher 가 Bash 뿐이라 PowerShell 툴은 훅 자체가 안 뜬다.
-  // judge 에 직접 넣어도 Bash 문법 패턴이라 걸리지 않는다.
-  const ps = {
-    tool_name: "PowerShell",
-    tool_input: { command: "Remove-Item -Recurse -Force C:\\build" },
-  };
-  assert.equal(judge(ps), null);
+// --- PowerShell -----------------------------------------------------------
+//
+// 이 PC 의 주 셸이 PowerShell 이다. Bash 만 보면 `Remove-Item -Recurse` 로 그냥 지나간다.
+// 툴을 바꾸는 것만으로 벗어날 수 있으면 가드가 없는 것과 같다.
+
+const pwsh = (command) => ({ tool_name: "PowerShell", tool_input: { command } });
+
+test("PowerShell 의 재귀 삭제를 막는다", () => {
+  const blocked = [
+    "Remove-Item -Recurse -Force C:\\build",
+    "Remove-Item -Force -Recurse C:\\build",
+    "Remove-Item -Rec C:\\build",       // PowerShell 은 파라미터 축약을 허용한다
+    "ri -Recurse C:\\build",
+    "rmdir -Recurse C:\\build",
+  ];
+  for (const c of blocked) {
+    assert.ok(judge(pwsh(c)), `막아야 한다: ${c}`);
+  }
+});
+
+test("PowerShell 에서도 git·SQL·운영 패턴이 그대로 걸린다", () => {
+  // 명령 문자열이 같으므로 별도 패턴이 필요 없다.
+  for (const c of [
+    "git push origin main",
+    "git reset --hard HEAD~1",
+    "psql -c 'DROP TABLE users'",
+    "bash deploy.prod.sh",
+  ]) {
+    assert.ok(judge(pwsh(c)), `막아야 한다: ${c}`);
+  }
+});
+
+test("PowerShell 정상 명령은 통과시킨다", () => {
+  const allowed = [
+    "Remove-Item C:\\build\\tmp\\scratch.txt", // -Recurse 가 없다
+    "Get-ChildItem -Recurse -Filter *.java",   // 삭제가 아니다
+    "Select-String -Pattern 'Remove-Item' -Path notes.md",
+    "./gradlew compileJava",
+    "git push origin feature/eventboard",
+  ];
+  for (const c of allowed) {
+    assert.equal(judge(pwsh(c)), null, `통과해야 한다: ${c}`);
+  }
+});
+
+test("PowerShell 도 fail-closed 다", () => {
+  assert.ok(judge({ tool_name: "PowerShell" }), "command 가 없으면 차단");
 });

--- a/.claude/hooks/guard.test.mjs
+++ b/.claude/hooks/guard.test.mjs
@@ -1,0 +1,92 @@
+// 가드가 "막는다고 적어둔 것"을 실제로 막나.
+//
+// 이 파일이 있는 이유: 2026-08-04 이전의 가드는 `$CLAUDE_TOOL_INPUT` 환경변수를 읽었는데
+// 훅 입력은 stdin 으로 들어온다. 변수가 늘 비어 grep 이 실패했고, 가드는 **아무것도 막지
+// 않으면서 막는 것처럼 보였다.** 조용히 죽은 가드는 없는 가드보다 위험하다 —
+// 막힌다고 믿고 위험한 작업을 하기 때문이다.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { judge } from "./guard.mjs";
+
+const bash = (command) => ({ tool_name: "Bash", tool_input: { command } });
+
+test("파괴적 명령을 막는다", () => {
+  const blocked = [
+    "rm -rf /tmp/x",
+    "rm -fr /tmp/x",
+    "rm -Rf /tmp/x",
+    "git push --force origin feature/x",
+    "git push -f origin feature/x",
+    "git reset --hard HEAD~3",
+    "psql -c 'DROP TABLE users'",
+    "psql -c 'TRUNCATE users'",
+  ];
+  for (const c of blocked) {
+    assert.ok(judge(bash(c)), `막아야 한다: ${c}`);
+  }
+});
+
+test("운영 배포 경로를 막는다", () => {
+  const blocked = [
+    "bash deploy.prod.sh",
+    "docker-compose -f docker-compose-prod.yml up -d",
+    "git push origin main",
+    "git push origin HEAD:main",
+    "git push -u origin main", // 기존 패턴은 `\S+\s+main` 이라 -u 가 끼면 새어나갔다
+  ];
+  for (const c of blocked) {
+    assert.ok(judge(bash(c)), `막아야 한다: ${c}`);
+  }
+});
+
+test("정상 명령은 통과시킨다", () => {
+  const allowed = [
+    "git push origin feature/eventboard",
+    "git push -u origin fix/deploy-image-prune-order",
+    "./gradlew compileJava compileTestJava",
+    "git log --oneline -20",
+    "docker-compose -f docker-compose-dev.yml up -d",
+    "bash deploy.dev.sh",
+    "rm build/tmp/scratch",       // -rf 가 아니다
+    "rm -r build/tmp",            // -f 가 없다
+    "git reset HEAD~1",           // --hard 가 아니다
+    "git branch --merged develop",
+    "git push origin feature/main-menu", // 브랜치 이름에 main 이 들어갈 뿐이다
+  ];
+  for (const c of allowed) {
+    assert.equal(judge(bash(c)), null, `통과해야 한다: ${c}`);
+  }
+});
+
+test("입력이 깨졌으면 통과가 아니라 차단한다 (fail-closed)", () => {
+  // 판정할 수 없으면 막는다. 조용히 통과시키면 가드가 없는 것과 같다.
+  assert.ok(judge(null), "null 입력은 차단");
+  assert.ok(judge("not an object"), "문자열 입력은 차단");
+  assert.ok(judge({ tool_name: "Bash" }), "Bash 인데 command 가 없으면 차단");
+});
+
+// --- 여기부터는 "막히지 않는다"를 고정한다 -------------------------------
+//
+// 가드는 명령 **문자열만** 본다. 문자열에 드러나지 않으면 판정할 방법이 없다.
+// 이걸 정규식으로 막으려 하면 정상 명령까지 잡혀 가드를 못 쓰게 된다.
+// 그래서 막는 대신 **아는 구멍으로 고정**한다 — 막힌다고 오해하는 것이 모르는 것보다 위험하다.
+
+test("아는 구멍: 스크립트 안의 내용은 보이지 않는다", () => {
+  assert.equal(judge(bash("bash scripts/cleanup.sh")), null);
+  assert.equal(judge(bash("./gradlew someTaskThatDeploys")), null);
+});
+
+test("아는 구멍: 변수 치환은 셸이 한다", () => {
+  assert.equal(judge(bash("P=push; git $P --force origin main")), null);
+  assert.equal(judge(bash('eval "$DANGEROUS_CMD"')), null);
+});
+
+test("아는 구멍: PowerShell 은 아직 대상이 아니다", () => {
+  // settings.json 의 matcher 가 Bash 뿐이라 PowerShell 툴은 훅 자체가 안 뜬다.
+  // judge 에 직접 넣어도 Bash 문법 패턴이라 걸리지 않는다.
+  const ps = {
+    tool_name: "PowerShell",
+    tool_input: { command: "Remove-Item -Recurse -Force C:\\build" },
+  };
+  assert.equal(judge(ps), null);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|PowerShell",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,11 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'rm\\s+-rf|git\\s+push\\s+--force|git\\s+push\\s+.*\\s-f\\b|git\\s+reset\\s+--hard|DROP\\s+TABLE|TRUNCATE\\s'; then echo 'BLOCKED: 위험한 명령어가 감지되었습니다.' >&2; exit 1; fi"
-          },
-          {
-            "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'deploy\\.prod\\.sh|docker-compose-prod\\.yml|git\\s+push\\s+\\S+\\s+(HEAD:)?main\\b'; then echo 'BLOCKED: 운영 배포는 머지 즉시 자동 실행됩니다. 사용자 확인 없이 실행하지 마세요.' >&2; exit 1; fi"
+            "command": "node .claude/hooks/guard.mjs"
           }
         ]
       }


### PR DESCRIPTION
## 문제

`.claude/settings.json` 의 `PreToolUse` 가드 두 개가 **아무것도 막지 못하고 있었다.**

```bash
if echo "$CLAUDE_TOOL_INPUT" | grep -qE 'rm\s+-rf|git\s+push\s+--force|...'; then
```

훅 입력은 **stdin 의 JSON** 으로 들어온다. `$CLAUDE_TOOL_INPUT` 은 존재하지 않는 변수라 늘 빈 문자열이었고, `grep` 이 항상 실패해 `exit 0` 으로 통과했다.

재현:

```console
$ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | sh -c '<기존 가드>'
exit=0    # 0 = 통과. 차단되지 않는다.
```

`rm -rf`·`git push --force`·`git reset --hard`·`DROP TABLE`·`TRUNCATE`, 그리고 운영 배포 경로(`deploy.prod.sh`·`docker-compose-prod.yml`·`git push origin main`)가 전부 무방비였다.

**조용히 죽은 가드는 없는 가드보다 위험하다** — 막힌다고 믿고 위험한 작업을 하기 때문이다.

## 변경

`.claude/hooks/guard.mjs` 로 옮기고 stdin 을 파싱한다. `jq` 가 없는 환경이 있어 node 를 쓴다.

- 판정을 `judge()` 하나에 모아 테스트가 붙게 했다. CLI 는 입출력만 한다.
- 판정 불가(입력이 객체가 아님·JSON 파싱 실패)면 **통과가 아니라 차단**한다.
- 차단은 `hookSpecificOutput.permissionDecision: "deny"` 로 사유와 함께 돌려준다.

기존 패턴의 구멍도 메웠다.

| 새던 것 | 이유 |
|---|---|
| `rm -fr` · `rm -Rf` | 플래그 순서·대소문자를 바꾸면 빠져나갔다 |
| `git push -u origin main` | 패턴이 `push \S+ main` 이라 플래그가 끼면 새어나갔다 |

`feature/main-menu` 처럼 **이름에 main 이 들어갈 뿐인 브랜치는 통과**시킨다(ref 끝이 main 일 때만 차단).

## 검증

```console
$ node --test .claude/hooks/guard.test.mjs
ℹ tests 7   ℹ pass 7   ℹ fail 0
```

단위 테스트가 `judge()` 를 검사하고, **CLI 배선도 따로 확인했다** — 이전 가드를 죽인 건 로직이 아니라 배선이었기 때문이다.

```console
$ echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"}}' | node .claude/hooks/guard.mjs
{"hookSpecificOutput":{...,"permissionDecision":"deny","permissionDecisionReason":"BLOCKED: `rm -rf` 는 되돌릴 수 없다..."}}

$ echo 'not json' | node .claude/hooks/guard.mjs        # fail-closed
{"hookSpecificOutput":{...,"permissionDecision":"deny",...}}
```

## 막지 못하는 것 — 테스트로 고정했다

가드는 명령 **문자열만** 본다. 정규식으로 더 막으려 하면 정상 명령까지 잡혀 못 쓰게 된다. 그래서 막는 대신 **아는 구멍으로 고정**한다.

| 새는 형태 | 왜 못 막나 |
|---|---|
| `bash scripts/cleanup.sh` | 스크립트 안의 내용은 문자열에 없다 |
| `P=push; git $P --force origin main` | 변수 치환은 셸이 한다 |
| PowerShell 툴 | `matcher` 가 `Bash` 뿐이라 훅 자체가 안 뜬다 |

**세 번째는 열어둘지 결정이 필요하다.** 이 PC 의 주 셸이 PowerShell 이라 실질적인 구멍이지만, 커버리지 확대는 이 PR 의 범위 밖으로 두고 별도로 논의한다.

실제 방어선은 가드가 아니다. 가드는 1차 방어이고, 되돌릴 수 없는 작업은 사용자 확인이 최종 방어선이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C6y8HJTXGsbKsdaHw6fQa
