### PR TITLE
fix: 6개월간 실패 상태였던 테스트 6건 수정

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
@@ -20,14 +20,15 @@ import inha.gdgoc.domain.user.repository.UserRepository;
 import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
 import inha.gdgoc.global.util.MajorNormalizer;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 public class RecruitCoreApplicationService {
 
     private static final Instant RECRUITMENT_DEADLINE = Instant.parse("2026-03-14T14:59:59Z");
@@ -37,6 +38,38 @@ public class RecruitCoreApplicationService {
     private final RecruitCoreSessionResolver recruitCoreSessionResolver;
     private final MajorNormalizer majorNormalizer;
     private final S3Service s3Service;
+    private final Clock clock;
+
+    // 시각을 주입받는다. `Instant.now()` 를 직접 부르면 마감일이 지나는 순간
+    // 테스트가 통째로 무너지고, 마감 동작 자체를 검증할 방법도 없다.
+    // SemesterCalculator·RecruitCoreSessionResolver 와 같은 방식이다.
+    @Autowired
+    public RecruitCoreApplicationService(
+        RecruitCoreApplicationRepository repository,
+        UserRepository userRepository,
+        RecruitCoreSessionResolver recruitCoreSessionResolver,
+        MajorNormalizer majorNormalizer,
+        S3Service s3Service
+    ) {
+        this(repository, userRepository, recruitCoreSessionResolver, majorNormalizer, s3Service,
+            Clock.system(ZoneId.of("Asia/Seoul")));
+    }
+
+    public RecruitCoreApplicationService(
+        RecruitCoreApplicationRepository repository,
+        UserRepository userRepository,
+        RecruitCoreSessionResolver recruitCoreSessionResolver,
+        MajorNormalizer majorNormalizer,
+        S3Service s3Service,
+        Clock clock
+    ) {
+        this.repository = repository;
+        this.userRepository = userRepository;
+        this.recruitCoreSessionResolver = recruitCoreSessionResolver;
+        this.majorNormalizer = majorNormalizer;
+        this.s3Service = s3Service;
+        this.clock = clock;
+    }
 
     @Transactional(readOnly = true)
     public RecruitCoreApplicantDetailResponse getApplicantDetail(Long id) {
@@ -151,7 +184,7 @@ public class RecruitCoreApplicationService {
     }
 
     private void validateRecruitmentOpen() {
-        if (Instant.now().isAfter(RECRUITMENT_DEADLINE)) {
+        if (Instant.now(clock).isAfter(RECRUITMENT_DEADLINE)) {
             throw new RecruitCoreClosedException(RECRUITMENT_DEADLINE);
         }
     }

--- a/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
@@ -17,20 +17,24 @@ import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreMyApplicationRespo
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreAlreadyAppliedException;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreApplicationNotFoundException;
+import inha.gdgoc.domain.recruit.core.exception.RecruitCoreClosedException;
 import inha.gdgoc.domain.recruit.core.repository.RecruitCoreApplicationRepository;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCoreResultStatus;
+import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.domain.user.repository.UserRepository;
 import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.util.MajorNormalizer;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -39,6 +43,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 class RecruitCoreApplicationServiceTest {
 
     private static final String SESSION = "2026-1";
+
+    // 마감일(2026-03-14T14:59:59Z)을 기준으로 앞뒤를 고정한다.
+    // 벽시계를 쓰면 마감일이 지나는 순간 이 클래스 전체가 무너진다 — 실제로 그랬다.
+    private static final Instant BEFORE_DEADLINE = Instant.parse("2026-03-01T00:00:00Z");
+    private static final Instant AFTER_DEADLINE = Instant.parse("2026-03-15T00:00:00Z");
 
     @Mock
     private RecruitCoreApplicationRepository repository;
@@ -49,12 +58,28 @@ class RecruitCoreApplicationServiceTest {
     @Mock
     private RecruitCoreSessionResolver recruitCoreSessionResolver;
 
-    @InjectMocks
+    @Mock
+    private MajorNormalizer majorNormalizer;
+
+    @Mock
+    private S3Service s3Service;
+
     private RecruitCoreApplicationService service;
 
     @BeforeEach
     void setUp() {
         lenient().when(recruitCoreSessionResolver.currentSession()).thenReturn(SESSION);
+        service = serviceAt(BEFORE_DEADLINE);
+    }
+
+    private RecruitCoreApplicationService serviceAt(Instant now) {
+        return new RecruitCoreApplicationService(
+            repository,
+            userRepository,
+            recruitCoreSessionResolver,
+            majorNormalizer,
+            s3Service,
+            Clock.fixed(now, ZoneOffset.UTC));
     }
 
     @Test
@@ -87,6 +112,7 @@ class RecruitCoreApplicationServiceTest {
         RecruitCoreApplication saved = createApplication(55L, user, SESSION);
         when(repository.findByUserIdAndSession(1L, SESSION)).thenReturn(Optional.empty());
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(majorNormalizer.normalize("컴퓨터공학과")).thenReturn("컴퓨터공학과");
         when(repository.save(any())).thenReturn(saved);
 
         RecruitCoreApplicationCreateResponse response = service.submit(1L, request);
@@ -164,6 +190,24 @@ class RecruitCoreApplicationServiceTest {
 
         assertThat(response.name()).isEqualTo("홍길동");
         assertThat(response.email()).isEqualTo("hong@inha.edu");
+    }
+
+    @Test
+    void checkEligibility_afterDeadline_throwsClosedException() {
+        assertThatThrownBy(() -> serviceAt(AFTER_DEADLINE).checkEligibility(1L))
+            .isInstanceOf(RecruitCoreClosedException.class);
+    }
+
+    @Test
+    void prefill_afterDeadline_throwsClosedException() {
+        assertThatThrownBy(() -> serviceAt(AFTER_DEADLINE).prefill(1L))
+            .isInstanceOf(RecruitCoreClosedException.class);
+    }
+
+    @Test
+    void submit_afterDeadline_throwsClosedException() {
+        assertThatThrownBy(() -> serviceAt(AFTER_DEADLINE).submit(1L, sampleRequest()))
+            .isInstanceOf(RecruitCoreClosedException.class);
     }
 
     private RecruitCoreApplicationCreateRequest sampleRequest() {

--- a/src/test/java/inha/gdgoc/domain/recruit/member/notification/service/RecruitMemberMemoNotificationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/notification/service/RecruitMemberMemoNotificationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -101,6 +102,12 @@ class RecruitMemberMemoNotificationServiceTest {
                 .build();
 
         when(notificationRepository.findPendingBatchForUpdate(anyInt())).thenReturn(List.of(success, fail));
+        // 성공 경로도 명시적으로 스텁한다. strict stubs 에서는 스텁이 걸린 메서드를
+        // 인자가 안 맞는 채로 호출하면 PotentialStubbingProblem 이 던져지는데,
+        // 서비스의 catch(Exception) 가 그것을 "메일 실패"로 삼켜 SENT 가 되지 않는다.
+        doNothing()
+                .when(mailService)
+                .sendPlainMail(eq("ok@test.com"), anyString(), anyString(), anyString());
         doThrow(new RuntimeException("smtp error"))
                 .when(mailService)
                 .sendPlainMail(eq("fail@test.com"), anyString(), anyString(), anyString());


### PR DESCRIPTION
## 배경

CI 가 `./gradlew test | tee test.log` 형태라 종료 코드가 `tee` 의 것이 된다. 그래서 **테스트가 깨진 채로도 워크플로는 계속 초록불**이었고, `Test Results` 체크에만 `6 fail, 29 pass` 로 드러나 있었다.

## 1. 마감일 하드코딩 — 5건

```java
private static final Instant RECRUITMENT_DEADLINE = Instant.parse("2026-03-14T14:59:59Z");

private void validateRecruitmentOpen() {
    if (Instant.now().isAfter(RECRUITMENT_DEADLINE)) {   // ← 벽시계
        throw new RecruitCoreClosedException(RECRUITMENT_DEADLINE);
    }
}
```

마감일이 지나면서 `checkEligibility`·`prefill`·`submit` 이 전부 `RecruitCoreClosedException` 을 던지고, 이를 호출하는 테스트 5건이 통째로 무너졌다. **날짜가 바뀌었을 뿐 코드는 그대로인데 테스트가 깨지는** 구조였다.

시각을 주입받도록 바꿨다. `SemesterCalculator`·`RecruitCoreSessionResolver` 가 **이미 쓰고 있는 방식**(무인자 생성자 → `Clock` 생성자 위임)을 그대로 따랐으므로 새 빈은 만들지 않는다. 생성자가 둘이 되어 스프링이 모호해지므로 주입용 생성자에 `@Autowired` 를 달았다.

**동작은 바뀌지 않는다.** 기본 `Clock` 이 기존과 동일한 `Clock.system(ZoneId.of("Asia/Seoul"))` 이다.

> 운영에서 코어 지원 API 가 마감된 상태 자체는 그대로다. 마감일을 옮기거나 설정으로 빼는 건 별개 결정이라 이 PR 에 넣지 않았다.

테스트는 마감 전후를 고정하고, **마감 이후 실제로 닫히는지 검증하는 테스트 3건을 새로 추가**했다. 이전에는 마감 동작을 검증할 방법이 아예 없었다.

## 2. Mockito strict stubs — 1건

`RecruitMemberMemoNotificationServiceTest` 는 `sendPlainMail` 에 `fail@test.com` 스텁만 걸어 두었다. `MockitoExtension` 은 strict stubs 가 기본이라, **스텁이 걸린 메서드를 인자가 맞지 않는 채로 호출하면 `PotentialStubbingProblem` 을 던진다.**

그 예외를 서비스의 `catch (Exception ex)` 가 "메일 발송 실패"로 삼켰다. 그래서 성공해야 할 건이 `markSent` 대신 `markFailed` 를 타고 `PENDING` 으로 남았다.

```
WARN ... send failed. id=1, email=ok@test.com, attempt=1/3, error=
    "ok@test.com",          ← Mockito 의 PotentialStubbingProblem 메시지
```

프로덕션 코드 결함이 아니라 테스트 결함이다. 성공 경로도 명시적으로 스텁해 해결했다.

## 검증

```console
$ ./gradlew test
합계: 테스트 38건, 실패 0, 에러 0
```

기존 35건 + 신규 3건. `@SpringBootTest` 인 `EventBoardSecurityTest`·`GdgocApplicationTests` 가 통과하므로 **생성자 변경 후에도 스프링 컨텍스트가 정상 기동**한다.

## 다음 단계 (이 PR 아님)

이제 실패가 0 이므로 `CLAUDE.md` 가 예고한 대로 **CI 게이트를 살릴 수 있다.**

> 수정하려면 스텝에 `set -o pipefail` 을 추가하면 되지만, 그러면 아래 기존 실패로 모든 PR 이 막힌다. **기존 실패를 먼저 정리한 뒤 게이트를 살릴 것.**

`ci.yml` 의 두 스텝(`build`·`test`)이 모두 `| tee` 다. 게이트를 켜면 앞으로 테스트가 깨진 PR 은 실제로 막히므로, 팀 합의가 필요해 별도 PR 로 둔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C6y8HJTXGsbKsdaHw6fQa
