### PR TITLE
feat: 코어 모집 기간을 설정값으로 분리하고 공개 조회 API 추가

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/core/controller/RecruitCoreController.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/controller/RecruitCoreController.java
@@ -5,6 +5,7 @@ import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicantDetailRes
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicationCreateResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreEligibilityResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreMyApplicationResponse;
+import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePeriodResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePrefillResponse;
 import inha.gdgoc.domain.recruit.core.service.RecruitCoreApplicationService;
 import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
@@ -31,6 +32,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecruitCoreController {
 
     private final RecruitCoreApplicationService service;
+
+    // 인증을 걸지 않는다. 모집 시작 전에도 200 이어야 웹이 로그인을 요구하지 않고
+    // "아직 시작 전" 안내를 띄울 수 있다.
+    @Operation(summary = "모집 기간 조회 (공개)")
+    @GetMapping("/period")
+    public ResponseEntity<RecruitCorePeriodResponse> period() {
+        return ResponseEntity.ok(service.getPeriod());
+    }
 
     @Operation(summary = "지원 가능 여부 확인", security = {@SecurityRequirement(name = "BearerAuth")})
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCorePeriodResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCorePeriodResponse.java
@@ -1,0 +1,12 @@
+package inha.gdgoc.domain.recruit.core.dto.response;
+
+import inha.gdgoc.domain.recruit.core.enums.RecruitCorePeriodStatus;
+import java.time.Instant;
+
+public record RecruitCorePeriodResponse(
+    String session,
+    Instant openAt,
+    Instant closeAt,
+    RecruitCorePeriodStatus status
+) {
+}

--- a/src/main/java/inha/gdgoc/domain/recruit/core/enums/RecruitCorePeriodStatus.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/enums/RecruitCorePeriodStatus.java
@@ -1,0 +1,7 @@
+package inha.gdgoc.domain.recruit.core.enums;
+
+public enum RecruitCorePeriodStatus {
+    BEFORE_OPEN,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreApplicationErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreApplicationErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum RecruitCoreApplicationErrorCode {
+    RECRUITMENT_NOT_OPEN("RECRUITMENT_NOT_OPEN", "코어 지원 기간이 아직 시작되지 않았습니다.", HttpStatus.FORBIDDEN),
     RECRUITMENT_CLOSED("RECRUITMENT_CLOSED", "코어 지원 기간이 종료되었습니다.", HttpStatus.FORBIDDEN),
     ALREADY_APPLIED("ALREADY_APPLIED", "이미 지원이 완료되었습니다.", HttpStatus.CONFLICT),
     APPLICATION_NOT_FOUND("APPLICATION_NOT_FOUND", "제출된 운영진 지원서가 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreControllerExceptionHandler.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreControllerExceptionHandler.java
@@ -40,6 +40,19 @@ public class RecruitCoreControllerExceptionHandler {
         return ResponseEntity.status(code.getStatus()).body(body);
     }
 
+    @ExceptionHandler(RecruitCoreNotOpenException.class)
+    public ResponseEntity<RecruitCoreApplicationErrorResponse> handleNotOpen(
+        RecruitCoreNotOpenException ex
+    ) {
+        log.debug("RecruitCoreNotOpenException: {}", ex.getMessage());
+        var code = ex.getErrorCode();
+        RecruitCoreApplicationErrorResponse body = RecruitCoreApplicationErrorResponse.of(
+            code.getCode(),
+            code.getMessage()
+        );
+        return ResponseEntity.status(code.getStatus()).body(body);
+    }
+
     @ExceptionHandler(RecruitCoreApplicationNotFoundException.class)
     public ResponseEntity<RecruitCoreApplicationErrorResponse> handleNotFound(
         RecruitCoreApplicationNotFoundException ex

--- a/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreNotOpenException.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreNotOpenException.java
@@ -1,0 +1,17 @@
+package inha.gdgoc.domain.recruit.core.exception;
+
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public class RecruitCoreNotOpenException extends RuntimeException {
+
+    private final RecruitCoreApplicationErrorCode errorCode;
+    private final Instant openAt;
+
+    public RecruitCoreNotOpenException(Instant openAt) {
+        super(RecruitCoreApplicationErrorCode.RECRUITMENT_NOT_OPEN.getMessage());
+        this.errorCode = RecruitCoreApplicationErrorCode.RECRUITMENT_NOT_OPEN;
+        this.openAt = openAt;
+    }
+}

--- a/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
@@ -8,10 +8,12 @@ import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreEligibilityRespons
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreMyApplicationResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePrefillResponse;
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
+import inha.gdgoc.domain.recruit.core.enums.RecruitCorePeriodStatus;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCoreResultStatus;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreAlreadyAppliedException;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreApplicationNotFoundException;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreClosedException;
+import inha.gdgoc.domain.recruit.core.exception.RecruitCoreNotOpenException;
 import inha.gdgoc.domain.recruit.core.repository.RecruitCoreApplicationRepository;
 import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.entity.User;
@@ -22,36 +24,49 @@ import inha.gdgoc.global.exception.GlobalErrorCode;
 import inha.gdgoc.global.util.MajorNormalizer;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RecruitCoreApplicationService {
 
-    private static final Instant RECRUITMENT_DEADLINE = Instant.parse("2026-03-14T14:59:59Z");
-
     private final RecruitCoreApplicationRepository repository;
     private final UserRepository userRepository;
     private final RecruitCoreSessionResolver recruitCoreSessionResolver;
     private final MajorNormalizer majorNormalizer;
     private final S3Service s3Service;
+    private final Instant openAt;
+    private final Instant closeAt;
     private final Clock clock;
 
     // 시각을 주입받는다. `Instant.now()` 를 직접 부르면 마감일이 지나는 순간
     // 테스트가 통째로 무너지고, 마감 동작 자체를 검증할 방법도 없다.
     // SemesterCalculator·RecruitCoreSessionResolver 와 같은 방식이다.
+    //
+    // 기간도 코드가 아니라 설정에서 받는다. 코드에 박으면 마감일이 지나는 순간
+    // 아무도 모르게 API 가 막힌다 — 실제로 2026-03-14 부터 5개월간 그랬다.
+    // 다음 모집은 환경변수만 바꾸면 된다.
+    //
+    // Instant 가 아니라 String 으로 받는 이유: Instant.parse() 는 'Z' 형식만 받아
+    // '+09:00' 을 거부한다. .env 에 KST 를 그대로 적을 수 있어야 오프셋 계산 실수가 안 난다.
     @Autowired
     public RecruitCoreApplicationService(
         RecruitCoreApplicationRepository repository,
         UserRepository userRepository,
         RecruitCoreSessionResolver recruitCoreSessionResolver,
         MajorNormalizer majorNormalizer,
-        S3Service s3Service
+        S3Service s3Service,
+        @Value("${app.recruit.core.open-at}") String openAt,
+        @Value("${app.recruit.core.close-at}") String closeAt
     ) {
         this(repository, userRepository, recruitCoreSessionResolver, majorNormalizer, s3Service,
+            OffsetDateTime.parse(openAt).toInstant(),
+            OffsetDateTime.parse(closeAt).toInstant(),
             Clock.system(ZoneId.of("Asia/Seoul")));
     }
 
@@ -61,13 +76,22 @@ public class RecruitCoreApplicationService {
         RecruitCoreSessionResolver recruitCoreSessionResolver,
         MajorNormalizer majorNormalizer,
         S3Service s3Service,
+        Instant openAt,
+        Instant closeAt,
         Clock clock
     ) {
+        if (!openAt.isBefore(closeAt)) {
+            throw new IllegalArgumentException(
+                "app.recruit.core.open-at 은 close-at 보다 앞서야 한다: openAt=" + openAt
+                    + ", closeAt=" + closeAt);
+        }
         this.repository = repository;
         this.userRepository = userRepository;
         this.recruitCoreSessionResolver = recruitCoreSessionResolver;
         this.majorNormalizer = majorNormalizer;
         this.s3Service = s3Service;
+        this.openAt = openAt;
+        this.closeAt = closeAt;
         this.clock = clock;
     }
 
@@ -184,9 +208,24 @@ public class RecruitCoreApplicationService {
     }
 
     private void validateRecruitmentOpen() {
-        if (Instant.now(clock).isAfter(RECRUITMENT_DEADLINE)) {
-            throw new RecruitCoreClosedException(RECRUITMENT_DEADLINE);
+        RecruitCorePeriodStatus status = getPeriodStatus();
+        if (status == RecruitCorePeriodStatus.BEFORE_OPEN) {
+            throw new RecruitCoreNotOpenException(openAt);
         }
+        if (status == RecruitCorePeriodStatus.CLOSED) {
+            throw new RecruitCoreClosedException(closeAt);
+        }
+    }
+
+    public RecruitCorePeriodStatus getPeriodStatus() {
+        Instant now = Instant.now(clock);
+        if (now.isBefore(openAt)) {
+            return RecruitCorePeriodStatus.BEFORE_OPEN;
+        }
+        if (now.isAfter(closeAt)) {
+            return RecruitCorePeriodStatus.CLOSED;
+        }
+        return RecruitCorePeriodStatus.OPEN;
     }
 
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
@@ -6,6 +6,7 @@ import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicantDetailRes
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicationCreateResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreEligibilityResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreMyApplicationResponse;
+import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePeriodResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePrefillResponse;
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCorePeriodStatus;
@@ -215,6 +216,15 @@ public class RecruitCoreApplicationService {
         if (status == RecruitCorePeriodStatus.CLOSED) {
             throw new RecruitCoreClosedException(closeAt);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitCorePeriodResponse getPeriod() {
+        return new RecruitCorePeriodResponse(
+            recruitCoreSessionResolver.currentSession(),
+            openAt,
+            closeAt,
+            getPeriodStatus());
     }
 
     public RecruitCorePeriodStatus getPeriodStatus() {

--- a/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
+++ b/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                     "/api/v1/recruit/member/apply/**",
                     "/api/v1/recruit/member/check/**",
                     "/api/v1/recruit/member/memo",
+                    "/api/v1/recruit/core/period",
                     "/api/v1/fileupload",
                     "/api/v1/manito/verify")
                 .permitAll()

--- a/src/main/java/inha/gdgoc/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/inha/gdgoc/global/security/TokenAuthenticationFilter.java
@@ -45,7 +45,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             || uri.startsWith("/api/v1/game/")
             || uri.startsWith("/api/v1/apply/")
             || uri.startsWith("/api/v1/check/")
-            || uri.startsWith("/api/v1/recruit/member/memo");
+            || uri.startsWith("/api/v1/recruit/member/memo")
+            // startsWith 가 아니라 equals 다. startsWith 면 /period/... 하위까지 열린다.
+            || uri.equals("/api/v1/recruit/core/period");
     }
 
     @Override

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -67,6 +67,12 @@ app:
     password: ${ADMIN_LOGIN_PASSWORD}
   mail:
     recruit-from: ${APP_MAIL_RECRUIT_FROM:}
+  recruit:
+    core:
+      # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
+      # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
+      open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -67,6 +67,12 @@ app:
     password: ${ADMIN_LOGIN_PASSWORD}
   mail:
     recruit-from: ${APP_MAIL_RECRUIT_FROM:}
+  recruit:
+    core:
+      # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
+      # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
+      open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -67,6 +67,12 @@ app:
     password: ${ADMIN_LOGIN_PASSWORD}
   mail:
     recruit-from: ${APP_MAIL_RECRUIT_FROM:}
+  recruit:
+    core:
+      # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
+      # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
+      open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/test/java/inha/gdgoc/domain/recruit/core/RecruitCoreSecurityTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/core/RecruitCoreSecurityTest.java
@@ -1,0 +1,56 @@
+package inha.gdgoc.domain.recruit.core;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 코어 리크루팅 엔드포인트의 인증 경계를 검증한다.
+ *
+ * <p>기간 조회만 공개이고 나머지는 인증이 필요하다. 공개 경로는 SecurityConfig 와
+ * TokenAuthenticationFilter 양쪽에 등록해야 하는데, 한쪽만 고치면 통과하지 못한다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class RecruitCoreSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void period_isPubliclyAccessible() throws Exception {
+        mockMvc.perform(get("/api/v1/recruit/core/period"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").exists());
+    }
+
+    @Test
+    void eligibility_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/recruit/core/eligibility"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void prefill_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/recruit/core/prefill"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * 공개 경로를 startsWith 로 등록하면 하위 경로까지 열린다. 이 리포에서
+     * {@code /api/v1/board/events/*} 가 관리자용 {@code /deleted} 까지 공개해버린 전례가 있다.
+     */
+    @Test
+    void periodSubPath_isNotPubliclyAccessible() throws Exception {
+        mockMvc.perform(get("/api/v1/recruit/core/period/anything"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
@@ -14,6 +14,7 @@ import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicantDetailRes
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreEligibilityResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicationCreateResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreMyApplicationResponse;
+import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePeriodResponse;
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCorePeriodStatus;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreAlreadyAppliedException;
@@ -252,6 +253,25 @@ class RecruitCoreApplicationServiceTest {
     void getPeriodStatus_afterClose_returnsClosed() {
         assertThat(serviceAt(AFTER_CLOSE).getPeriodStatus())
             .isEqualTo(RecruitCorePeriodStatus.CLOSED);
+    }
+
+    @Test
+    void getPeriod_returnsSessionAndBoundsAndStatus() {
+        RecruitCorePeriodResponse response = serviceAt(DURING_OPEN).getPeriod();
+
+        assertThat(response.session()).isEqualTo(SESSION);
+        assertThat(response.openAt()).isEqualTo(OPEN_AT);
+        assertThat(response.closeAt()).isEqualTo(CLOSE_AT);
+        assertThat(response.status()).isEqualTo(RecruitCorePeriodStatus.OPEN);
+    }
+
+    @Test
+    void getPeriod_beforeOpen_doesNotThrow() {
+        // 기간 조회는 게이트 앞에 있다. 시작 전에도 200 이어야 웹이 로그인을
+        // 요구하지 않고 안내를 띄울 수 있다.
+        RecruitCorePeriodResponse response = serviceAt(BEFORE_OPEN).getPeriod();
+
+        assertThat(response.status()).isEqualTo(RecruitCorePeriodStatus.BEFORE_OPEN);
     }
 
     @Test

--- a/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
@@ -15,9 +15,11 @@ import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreEligibilityRespons
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicationCreateResponse;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreMyApplicationResponse;
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
+import inha.gdgoc.domain.recruit.core.enums.RecruitCorePeriodStatus;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreAlreadyAppliedException;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreApplicationNotFoundException;
 import inha.gdgoc.domain.recruit.core.exception.RecruitCoreClosedException;
+import inha.gdgoc.domain.recruit.core.exception.RecruitCoreNotOpenException;
 import inha.gdgoc.domain.recruit.core.repository.RecruitCoreApplicationRepository;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCoreResultStatus;
 import inha.gdgoc.domain.resource.service.S3Service;
@@ -44,10 +46,14 @@ class RecruitCoreApplicationServiceTest {
 
     private static final String SESSION = "2026-1";
 
-    // 마감일(2026-03-14T14:59:59Z)을 기준으로 앞뒤를 고정한다.
-    // 벽시계를 쓰면 마감일이 지나는 순간 이 클래스 전체가 무너진다 — 실제로 그랬다.
-    private static final Instant BEFORE_DEADLINE = Instant.parse("2026-03-01T00:00:00Z");
-    private static final Instant AFTER_DEADLINE = Instant.parse("2026-03-15T00:00:00Z");
+    // 기간은 테스트가 스스로 정한다. 운영 기본값(app.recruit.core.*)을 참조하면
+    // 모집 일정이 바뀔 때마다 이 클래스가 다시 무너진다 — 실제로 그랬다.
+    private static final Instant OPEN_AT = Instant.parse("2026-08-09T15:00:00Z");
+    private static final Instant CLOSE_AT = Instant.parse("2026-08-30T14:59:59Z");
+
+    private static final Instant BEFORE_OPEN = Instant.parse("2026-08-01T00:00:00Z");
+    private static final Instant DURING_OPEN = Instant.parse("2026-08-20T00:00:00Z");
+    private static final Instant AFTER_CLOSE = Instant.parse("2026-09-01T00:00:00Z");
 
     @Mock
     private RecruitCoreApplicationRepository repository;
@@ -69,7 +75,7 @@ class RecruitCoreApplicationServiceTest {
     @BeforeEach
     void setUp() {
         lenient().when(recruitCoreSessionResolver.currentSession()).thenReturn(SESSION);
-        service = serviceAt(BEFORE_DEADLINE);
+        service = serviceAt(DURING_OPEN);
     }
 
     private RecruitCoreApplicationService serviceAt(Instant now) {
@@ -79,6 +85,8 @@ class RecruitCoreApplicationServiceTest {
             recruitCoreSessionResolver,
             majorNormalizer,
             s3Service,
+            OPEN_AT,
+            CLOSE_AT,
             Clock.fixed(now, ZoneOffset.UTC));
     }
 
@@ -194,20 +202,65 @@ class RecruitCoreApplicationServiceTest {
 
     @Test
     void checkEligibility_afterDeadline_throwsClosedException() {
-        assertThatThrownBy(() -> serviceAt(AFTER_DEADLINE).checkEligibility(1L))
+        assertThatThrownBy(() -> serviceAt(AFTER_CLOSE).checkEligibility(1L))
             .isInstanceOf(RecruitCoreClosedException.class);
     }
 
     @Test
     void prefill_afterDeadline_throwsClosedException() {
-        assertThatThrownBy(() -> serviceAt(AFTER_DEADLINE).prefill(1L))
+        assertThatThrownBy(() -> serviceAt(AFTER_CLOSE).prefill(1L))
             .isInstanceOf(RecruitCoreClosedException.class);
     }
 
     @Test
     void submit_afterDeadline_throwsClosedException() {
-        assertThatThrownBy(() -> serviceAt(AFTER_DEADLINE).submit(1L, sampleRequest()))
+        assertThatThrownBy(() -> serviceAt(AFTER_CLOSE).submit(1L, sampleRequest()))
             .isInstanceOf(RecruitCoreClosedException.class);
+    }
+
+    @Test
+    void checkEligibility_beforeOpen_throwsNotOpen() {
+        assertThatThrownBy(() -> serviceAt(BEFORE_OPEN).checkEligibility(1L))
+            .isInstanceOf(RecruitCoreNotOpenException.class);
+    }
+
+    @Test
+    void prefill_beforeOpen_throwsNotOpen() {
+        assertThatThrownBy(() -> serviceAt(BEFORE_OPEN).prefill(1L))
+            .isInstanceOf(RecruitCoreNotOpenException.class);
+    }
+
+    @Test
+    void submit_beforeOpen_throwsNotOpen() {
+        assertThatThrownBy(() -> serviceAt(BEFORE_OPEN).submit(1L, sampleRequest()))
+            .isInstanceOf(RecruitCoreNotOpenException.class);
+    }
+
+    @Test
+    void getPeriodStatus_beforeOpen_returnsBeforeOpen() {
+        assertThat(serviceAt(BEFORE_OPEN).getPeriodStatus())
+            .isEqualTo(RecruitCorePeriodStatus.BEFORE_OPEN);
+    }
+
+    @Test
+    void getPeriodStatus_duringOpen_returnsOpen() {
+        assertThat(serviceAt(DURING_OPEN).getPeriodStatus())
+            .isEqualTo(RecruitCorePeriodStatus.OPEN);
+    }
+
+    @Test
+    void getPeriodStatus_afterClose_returnsClosed() {
+        assertThat(serviceAt(AFTER_CLOSE).getPeriodStatus())
+            .isEqualTo(RecruitCorePeriodStatus.CLOSED);
+    }
+
+    @Test
+    void constructor_whenOpenAtNotBeforeCloseAt_throws() {
+        assertThatThrownBy(() -> new RecruitCoreApplicationService(
+            repository, userRepository, recruitCoreSessionResolver, majorNormalizer, s3Service,
+            CLOSE_AT, OPEN_AT, Clock.fixed(DURING_OPEN, ZoneOffset.UTC)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("open-at");
     }
 
     private RecruitCoreApplicationCreateRequest sampleRequest() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -51,6 +51,12 @@ spring:
 app:
   s3:
     bucket: test-bucket
+  recruit:
+    core:
+      # 컨텍스트 기동용 고정값. 기간 동작은 RecruitCoreApplicationServiceTest 가
+      # 자기 상수로 검증하므로 여기 값이 무엇인지는 중요하지 않다.
+      open-at: 2026-08-10T00:00:00+09:00
+      close-at: 2026-08-30T23:59:59+09:00
 
 google:
   client-id: test-client-id


### PR DESCRIPTION
## 배경

코어 모집 마감일이 `RecruitCoreApplicationService` 에 상수로 박혀 있어, 2026-03-14 이후 **5개월간 아무도 모르게 운영 API 가 막혀 있었다.** `eligibility`·`prefill`·`submit` 이 전부 403 을 반환하는 상태였다.

2026-2 코어 모집이 **8/10 에 시작**한다. 이번에도 날짜만 바꾸면 2차 모집 때 같은 작업을 반복하고 재배포(다운타임)가 필요하므로, 기간을 설정 밖으로 뺀다.

`c125e4e` 가 이미 `Clock` 을 주입 가능하게 만들어 두었고 마감일 값은 "별개 결정"으로 남겼는데, 이 PR 이 그 결정이다.

## 변경

**기간을 설정값으로**
- `app.recruit.core.open-at` / `close-at` 신설. 환경변수 `RECRUIT_CORE_OPEN_AT` / `RECRUIT_CORE_CLOSE_AT` 로 덮어쓴다.
- `String` 으로 받아 `OffsetDateTime.parse()` 한다. `Instant.parse()` 는 `Z` 형식만 받아 `+09:00` 을 거부하는데, `.env` 에 KST 를 그대로 적을 수 있어야 오프셋 계산 실수가 안 난다.
- `open-at >= close-at` 이면 **기동 실패**. 잘못된 기간으로 조용히 뜨는 것보다 낫다.
- 프로파일 파일 **넷 모두**에 넣었다. `application-test.yml` 을 빠뜨리면 `@ActiveProfiles("test")` 인 `@SpringBootTest` 가 플레이스홀더를 못 찾는다.

**시작 전 / 마감 후 구분**
- 기존에는 `RECRUITMENT_CLOSED` 하나뿐이라 웹이 다른 안내를 띄울 수 없었다.
- `RECRUITMENT_NOT_OPEN` (403) 을 추가하고 `RecruitCorePeriodStatus` 로 `BEFORE_OPEN` / `OPEN` / `CLOSED` 를 구분한다.

**공개 기간 조회 API**
- `GET /api/v1/recruit/core/period` — 인증 불필요.
- 시작 전에도 200 이어야 웹이 로그인을 요구하지 않고 "아직 시작 전" 안내를 띄울 수 있다.
- ⚠️ `SecurityConfig` 와 `TokenAuthenticationFilter` **양쪽에** 등록해야 한다. 한쪽만 고치면 시큐리티는 통과해도 필터가 토큰을 요구한다.
- 필터에는 `startsWith` 가 아니라 `equals` 를 쓴다. 이 리포에서 `/api/v1/board/events/*` 가 관리자용 `/deleted` 까지 공개해버린 전례가 있다.

## 검증

```
./gradlew test  →  51 tests / 0 failed
```

베이스라인 38건에서 13건 늘었다.

- `RecruitCoreApplicationServiceTest` +9 — `BEFORE_OPEN` 3종, `getPeriodStatus` 3종, `getPeriod` 2종, 잘못된 기간 기동 실패 1종
- `RecruitCoreSecurityTest` +4 (신규) — 인증 경계 검증

테스트가 고정하는 기간은 **운영 기본값이 아니라 테스트 자체 상수**다. 운영 날짜를 참조하면 다음 모집 때 또 깨진다.

`periodSubPath_isNotPubliclyAccessible` 이 `/period/anything` 에 401 을 기대해, `equals` 가장자리가 실제로 막히는지 확인한다.

## 스키마 변경 없음

Flyway 마이그레이션이 없다. 롤백은 코드 되돌리기로 끝난다. 기간만 잘못 넣었다면 배포를 되돌릴 필요도 없이 `.env` 를 고치고 컨테이너만 재기동하면 된다.

## 머지 후

```bash
curl -s -o /dev/null -w "%{http_code}\n" \
  "https://dev-api.gdgocinha.com/api/v1/recruit/core/period"
```

`200` 이면 반영 완료, `401` 이면 아직 구버전이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LLvZ5krbJny7G7Yrr5syj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 인증 없이 모집 기간과 현재 상태를 조회할 수 있는 공개 API를 추가했습니다.
  - 모집 상태를 시작 전, 모집 중, 마감으로 구분해 제공합니다.
  - 모집 시작·종료 시각과 세션 정보를 함께 확인할 수 있습니다.
- **개선**
  - 모집 기간을 설정으로 관리할 수 있어 환경별 일정 변경이 가능합니다.
  - 모집 시작 전 요청에는 안내 메시지와 함께 적절한 오류 응답을 제공합니다.
  - 모집 기간 외 지원 요청을 상태에 맞게 처리하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->