### PR TITLE
fix: 공지 게시판 조회를 회원 전용으로 막는다

### DIFF
--- a/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
+++ b/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
@@ -40,10 +40,10 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/v1/auth/logout").permitAll()
+                // 행사 게시판만 공개다. 공지·자유는 회원 전용이라 여기 넣지 않는다 —
+                // anyRequest().authenticated() 가 받는다. NoticeBoardSecurityTest 가 지킨다.
                 .requestMatchers(HttpMethod.GET, "/api/v1/board/events").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/board/events/{id:[0-9]+}").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/v1/board/notices").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/v1/board/notices/{id:[0-9]+}").permitAll()
                 .requestMatchers(
                     "/swagger-ui/**",
                     "/v3/api-docs/**",

--- a/src/test/java/inha/gdgoc/domain/board/notice/NoticeBoardSecurityTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/notice/NoticeBoardSecurityTest.java
@@ -1,0 +1,47 @@
+package inha.gdgoc.domain.board.notice;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 공지 게시판 엔드포인트의 인증 경계를 검증한다.
+ *
+ * <p>공지는 회원 전용이다. 행사 게시판과 달리 목록·상세 조회에도 인증이 필요하다.
+ * SecurityConfig 에 GET permitAll 이 들어 있던 적이 있어 비로그인에게도 열려 있었고,
+ * 프론트의 로그인 게이트만으로는 API 직접 호출을 막지 못했다.
+ *
+ * <p>행사 게시판이 공개로 남아 있는지는 {@code EventBoardSecurityTest} 가 지킨다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class NoticeBoardSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void list_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/board/notices"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void detail_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/board/notices/999999"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void pinnedList_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/board/notices/pinned"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## #️⃣ Related Issue
> 없음 (배포본 확인 중 발견)

## 📝 PR Description

`SecurityConfig` 에 `/api/v1/board/notices` GET `permitAll` 이 들어 있어 **비로그인에게도
공지 목록·상세가 열려 있었다.** 공개해야 하는 것은 행사 게시판뿐이다.

```java
- .requestMatchers(HttpMethod.GET, "/api/v1/board/notices").permitAll()
- .requestMatchers(HttpMethod.GET, "/api/v1/board/notices/{id:[0-9]+}").permitAll()
```

두 줄을 빼면 `anyRequest().authenticated()` 가 받는다.

프론트에도 로그인 게이트를 넣었지만(웹 PR GDGoCINHA/24-2_GDGoC_Web#342) **그것만으로는
API 직접 호출을 막지 못한다.** 실제로 배포본에서 토큰 없이 `GET /api/v1/board/notices` 가
200 을 돌려줬다.

### 테스트

권한 경계가 바뀌었으므로 `NoticeBoardSecurityTest` 를 추가한다(CLAUDE.md 의
"권한·가시성 로직을 수정하면 반드시 테스트를 추가한다").

| 테스트 | 기대 |
|---|---|
| `list_requiresAuthentication` | `GET /api/v1/board/notices` → 401 |
| `detail_requiresAuthentication` | `GET /api/v1/board/notices/999999` → 401 |
| `pinnedList_requiresAuthentication` | `GET /api/v1/board/notices/pinned` → 401 |

행사 게시판이 공개로 남아 있는지는 기존 `EventBoardSecurityTest` 가 계속 지킨다.
둘을 함께 두면 "전부 닫기"와 "전부 열기" 양쪽 회귀가 잡힌다.

## 💬 Reviewer Request

**⚠️ 배포 순서를 지켜야 합니다.**

웹 PR #342 가 **먼저** 반영돼야 합니다. 지금 배포된 프론트는 공지를 토큰 없이
조회하므로, 서버를 먼저 닫으면 **로그인한 사용자에게도 공지가 열리지 않습니다.**

1. 웹 #342 머지 → dev 배포 확인
2. 이 PR 머지

## 검증

```
./gradlew compileJava compileTestJava   → BUILD SUCCESSFUL
./gradlew test                          → 110건 전부 통과 (실패 0 · 오류 0)
```

테스트 결과는 종료 코드가 아니라 `build/test-results/test/*.xml` 을 집계해 확인했습니다.
이 리포는 파이프라인 종료 코드로 테스트 실패를 감지하지 못합니다(CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 공지 게시판의 목록·상세·고정 공지 조회는 이제 로그인한 사용자만 이용할 수 있습니다.
  * 행사 게시판의 목록 및 상세 조회는 비로그인 상태에서도 계속 이용할 수 있습니다.

* **버그 수정**
  * 공지 게시판 API의 비로그인 접근 제한을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->