### PR TITLE
feat: 자유게시판 API

### DIFF
--- a/src/main/java/inha/gdgoc/domain/board/free/controller/FreeBoardController.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/controller/FreeBoardController.java
@@ -1,0 +1,96 @@
+package inha.gdgoc.domain.board.free.controller;
+
+import static inha.gdgoc.domain.board.free.controller.message.FreeBoardMessage.*;
+
+import inha.gdgoc.domain.board.common.enums.SearchType;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCreateRequest;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardDetailResponse;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardSummaryResponse;
+import inha.gdgoc.domain.board.free.service.FreeBoardService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.dto.response.PageMeta;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 자유게시판.
+ *
+ * <p>조회는 회원 전용이다 — SecurityConfig 의 permitAll 에 이 경로를 넣지 않아 anyRequest().authenticated()
+ * 가 받는다. 행사 게시판만 공개다.
+ *
+ * <p>작성은 MEMBER 이상이다. 공지·행사가 CORE 이상인 것과 다르다. 수정·삭제는 여기서 MEMBER 로 한 번 거르고,
+ * '작성자 본인 또는 ORGANIZER 이상'인지는 서비스가 판정한다 — 본인 여부는 어노테이션으로 표현할 수 없다.
+ */
+@RestController
+@RequestMapping("/api/v1/board/free")
+@RequiredArgsConstructor
+@Validated
+public class FreeBoardController {
+
+  private final FreeBoardService freeBoardService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<Page<FreeBoardSummaryResponse>, PageMeta>> listPosts(
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "15") @Min(1) @Max(100) int size,
+      @RequestParam(defaultValue = "TITLE_AND_CONTENT") SearchType searchType,
+      @RequestParam(required = false) String keyword) {
+
+    Page<FreeBoardSummaryResponse> posts =
+        freeBoardService.listPosts(page, size, searchType, keyword);
+
+    return ResponseEntity.ok(ApiResponse.ok(FREE_LIST_RETRIEVED, posts, PageMeta.of(posts)));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<FreeBoardDetailResponse, Void>> getPost(@PathVariable Long id) {
+    return ResponseEntity.ok(ApiResponse.ok(FREE_RETRIEVED, freeBoardService.getPost(id)));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @PostMapping
+  public ResponseEntity<ApiResponse<Long, Void>> createPost(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @Valid @RequestBody FreeBoardCreateRequest req) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(FREE_CREATED, freeBoardService.createPost(req, me.getUserId())));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @PatchMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void, Void>> updatePost(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long id,
+      @Valid @RequestBody FreeBoardUpdateRequest req) {
+    freeBoardService.updatePost(id, req, me.getUserId(), me.getRole());
+    return ResponseEntity.ok(ApiResponse.ok(FREE_UPDATED));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void, Void>> deletePost(
+      @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long id) {
+    freeBoardService.deletePost(id, me.getUserId(), me.getRole());
+    return ResponseEntity.ok(ApiResponse.ok(FREE_DELETED));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/controller/message/FreeBoardMessage.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/controller/message/FreeBoardMessage.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.domain.board.free.controller.message;
+
+public class FreeBoardMessage {
+
+  public static final String FREE_LIST_RETRIEVED = "자유게시판 목록을 조회했습니다.";
+  public static final String FREE_RETRIEVED = "자유게시판 글을 조회했습니다.";
+  public static final String FREE_CREATED = "자유게시판 글 작성이 완료되었습니다.";
+  public static final String FREE_UPDATED = "자유게시판 글 수정이 완료되었습니다.";
+  public static final String FREE_DELETED = "자유게시판 글 삭제가 완료되었습니다.";
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardCreateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardCreateRequest.java
@@ -1,0 +1,12 @@
+package inha.gdgoc.domain.board.free.dto.request;
+
+import inha.gdgoc.domain.board.common.dto.AttachmentEntry;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record FreeBoardCreateRequest(
+    @NotBlank @Size(max = 255) String title,
+    @NotBlank String content,
+    @Valid List<AttachmentEntry> attachments) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardUpdateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardUpdateRequest.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.domain.board.free.dto.request;
+
+import inha.gdgoc.domain.board.common.dto.AttachmentEntry;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/** 모든 필드가 선택이다. null 인 필드는 바꾸지 않는다. */
+public record FreeBoardUpdateRequest(
+    @Size(max = 255) String title, String content, @Valid List<AttachmentEntry> attachments) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardDetailResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardDetailResponse.java
@@ -1,0 +1,22 @@
+package inha.gdgoc.domain.board.free.dto.response;
+
+import inha.gdgoc.domain.board.common.dto.AttachmentResponse;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 상세 응답.
+ *
+ * <p>행사·공지와 달리 authorId 를 함께 준다. 수정·삭제는 '작성자 본인 또는 ORGANIZER 이상'인데, 이 값이 없으면
+ * 프론트가 본인 여부를 판정할 수 없어 권한 없는 사용자에게도 버튼을 보여주고 눌러야 403 을 만나게 된다.
+ */
+public record FreeBoardDetailResponse(
+    Long id,
+    String title,
+    String content,
+    Long authorId,
+    String authorName,
+    int viewCount,
+    List<AttachmentResponse> attachments,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardSummaryResponse.java
@@ -1,0 +1,7 @@
+package inha.gdgoc.domain.board.free.dto.response;
+
+import java.time.Instant;
+
+/** 목록 한 행. */
+public record FreeBoardSummaryResponse(
+    Long id, String title, String authorName, int viewCount, Instant createdAt) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/entity/FreeBoard.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/entity/FreeBoard.java
@@ -1,0 +1,62 @@
+package inha.gdgoc.domain.board.free.entity;
+
+import inha.gdgoc.domain.board.common.entity.BoardEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 자유게시판 글.
+ *
+ * <p>공지와 달리 분류(category)와 임시저장(isPublished)이 없다. 분류는 운영진이 공지를 갈래별로 묶으려고 둔 것이고,
+ * 임시저장은 공개 시점을 고르는 기능이라 회원이 쓰는 자유게시판에는 쓰이지 않는다.
+ */
+@Entity
+@Table(name = "free_board")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FreeBoard extends BoardEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private int viewCount;
+
+  @OneToMany(mappedBy = "freeBoard", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<FreeBoardAttachment> attachments = new ArrayList<>();
+
+  public static FreeBoard create(String title, String content, Long authorId, String authorName) {
+    FreeBoard post = new FreeBoard();
+    post.initBoard(title, content, authorId, authorName);
+    post.viewCount = 0;
+    return post;
+  }
+
+  @Override
+  public void addFileAttachment(String fileKey, String fileName, Long fileSize, int sortOrder) {
+    this.attachments.add(
+        FreeBoardAttachment.createFile(this, fileKey, fileName, fileSize, sortOrder));
+  }
+
+  @Override
+  public void addLinkAttachment(String url, int sortOrder) {
+    this.attachments.add(FreeBoardAttachment.createLink(this, url, sortOrder));
+  }
+
+  public void update(String title, String content) {
+    updateTitle(title);
+    updateContent(content);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/entity/FreeBoardAttachment.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/entity/FreeBoardAttachment.java
@@ -1,0 +1,44 @@
+package inha.gdgoc.domain.board.free.entity;
+
+import inha.gdgoc.domain.board.common.entity.BoardAttachment;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "free_board_attachment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FreeBoardAttachment extends BoardAttachment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "free_board_id", nullable = false)
+  private FreeBoard freeBoard;
+
+  public static FreeBoardAttachment createFile(
+      FreeBoard freeBoard, String fileKey, String fileName, Long fileSize, int sortOrder) {
+    FreeBoardAttachment attachment = new FreeBoardAttachment();
+    attachment.freeBoard = freeBoard;
+    attachment.initFile(fileKey, fileName, fileSize, sortOrder);
+    return attachment;
+  }
+
+  public static FreeBoardAttachment createLink(FreeBoard freeBoard, String url, int sortOrder) {
+    FreeBoardAttachment attachment = new FreeBoardAttachment();
+    attachment.freeBoard = freeBoard;
+    attachment.initLink(url, sortOrder);
+    return attachment;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardJpaRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardJpaRepository.java
@@ -1,0 +1,17 @@
+package inha.gdgoc.domain.board.free.repository;
+
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FreeBoardJpaRepository extends JpaRepository<FreeBoard, Long> {
+
+  Optional<FreeBoard> findByIdAndDeletedAtIsNull(Long id);
+
+  @Modifying
+  @Query("UPDATE FreeBoard f SET f.viewCount = f.viewCount + 1 WHERE f.id = :id")
+  void increaseViewCount(@Param("id") Long id);
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardQueryDslRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardQueryDslRepository.java
@@ -1,0 +1,17 @@
+package inha.gdgoc.domain.board.free.repository;
+
+import inha.gdgoc.domain.board.common.enums.SearchType;
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FreeBoardQueryDslRepository {
+
+  /**
+   * 삭제되지 않은 글을 최신순으로 준다.
+   *
+   * <p>공지의 findVisibleNotices 와 달리 userRole 을 받지 않는다. 자유게시판에는 임시저장이 없어 역할에 따라 보이는
+   * 글이 달라지지 않는다 — 회원이면 모두 같은 목록을 본다.
+   */
+  Page<FreeBoard> findVisiblePosts(SearchType searchType, String keyword, Pageable pageable);
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepository.java
@@ -1,0 +1,13 @@
+package inha.gdgoc.domain.board.free.repository;
+
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import java.util.Optional;
+
+public interface FreeBoardRepository extends FreeBoardQueryDslRepository {
+
+  Optional<FreeBoard> findById(Long id);
+
+  FreeBoard save(FreeBoard post);
+
+  void increaseViewCount(Long id);
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepositoryImpl.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepositoryImpl.java
@@ -1,0 +1,77 @@
+package inha.gdgoc.domain.board.free.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import inha.gdgoc.domain.board.common.enums.SearchType;
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import inha.gdgoc.domain.board.free.entity.QFreeBoard;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FreeBoardRepositoryImpl implements FreeBoardRepository {
+
+  private final FreeBoardJpaRepository jpaRepository;
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<FreeBoard> findById(Long id) {
+    return jpaRepository.findByIdAndDeletedAtIsNull(id);
+  }
+
+  @Override
+  public FreeBoard save(FreeBoard post) {
+    return jpaRepository.save(post);
+  }
+
+  @Override
+  public void increaseViewCount(Long id) {
+    jpaRepository.increaseViewCount(id);
+  }
+
+  @Override
+  public Page<FreeBoard> findVisiblePosts(
+      SearchType searchType, String keyword, Pageable pageable) {
+
+    QFreeBoard post = QFreeBoard.freeBoard;
+
+    BooleanExpression where = post.deletedAt.isNull();
+
+    BooleanExpression search = searchCondition(post, searchType, keyword);
+    if (search != null) {
+      where = where.and(search);
+    }
+
+    List<FreeBoard> content =
+        queryFactory
+            .selectFrom(post)
+            .where(where)
+            .orderBy(post.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total = queryFactory.select(post.count()).from(post).where(where).fetchOne();
+
+    return new PageImpl<>(content, pageable, total == null ? 0 : total);
+  }
+
+  private BooleanExpression searchCondition(
+      QFreeBoard post, SearchType searchType, String keyword) {
+    if (keyword == null || keyword.isBlank()) return null;
+
+    return switch (searchType) {
+      case TITLE -> post.title.containsIgnoreCase(keyword);
+      case CONTENT -> post.content.containsIgnoreCase(keyword);
+      case TITLE_AND_CONTENT ->
+          post.title.containsIgnoreCase(keyword).or(post.content.containsIgnoreCase(keyword));
+      case AUTHOR -> post.authorName.containsIgnoreCase(keyword);
+    };
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/service/FreeBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/service/FreeBoardService.java
@@ -1,0 +1,137 @@
+package inha.gdgoc.domain.board.free.service;
+
+import inha.gdgoc.domain.board.common.enums.SearchType;
+import inha.gdgoc.domain.board.common.service.AttachmentPolicy;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCreateRequest;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardDetailResponse;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardSummaryResponse;
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import inha.gdgoc.domain.board.free.repository.FreeBoardRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FreeBoardService {
+
+  private final FreeBoardRepository freeBoardRepository;
+  private final UserRepository userRepository;
+  private final AttachmentPolicy attachmentPolicy;
+
+  public Page<FreeBoardSummaryResponse> listPosts(
+      int page, int size, SearchType searchType, String keyword) {
+    return freeBoardRepository
+        .findVisiblePosts(searchType, keyword, PageRequest.of(page, size))
+        .map(this::toSummaryResponse);
+  }
+
+  /**
+   * 상세를 조회하며 조회수를 1 올린다.
+   *
+   * <p>엔티티를 더티체킹으로 올리면 @LastModifiedDate 가 함께 갱신되어 "마지막으로 열어본 시각"이 수정 시각을 덮어써
+   * 버린다. 그래서 조회수는 벌크 UPDATE 로 따로 올린다. DTO 를 먼저 만들고 그 다음에 벌크 UPDATE 를 호출하는 순서를
+   * 지켜야 한다 — clearAutomatically 로 영속성 컨텍스트를 비우면 post 가 detach 되어 첨부 지연 로딩이
+   * LazyInitializationException 으로 죽는다. (NoticeBoardService.getNotice 와 같은 이유다.)
+   */
+  @Transactional
+  public FreeBoardDetailResponse getPost(Long id) {
+    FreeBoard post =
+        freeBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    // 벌크 UPDATE 는 로딩된 엔티티에 반영되지 않으므로, 이번 조회를 포함한 값을 보여주려면 +1 을 직접 넘긴다.
+    FreeBoardDetailResponse response = toDetailResponse(post, post.getViewCount() + 1);
+    freeBoardRepository.increaseViewCount(id);
+    return response;
+  }
+
+  @Transactional
+  public Long createPost(FreeBoardCreateRequest req, Long authorId) {
+    User author =
+        userRepository
+            .findById(authorId)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    FreeBoard post = FreeBoard.create(req.title(), req.content(), authorId, author.getName());
+
+    attachmentPolicy.apply(post, req.attachments());
+
+    return freeBoardRepository.save(post).getId();
+  }
+
+  @Transactional
+  public void updatePost(Long id, FreeBoardUpdateRequest req, Long userId, UserRole userRole) {
+    FreeBoard post =
+        freeBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    requireAuthorOrOrganizer(post, userId, userRole);
+
+    post.update(req.title(), req.content());
+
+    if (req.attachments() != null) {
+      post.getAttachments().clear();
+      attachmentPolicy.apply(post, req.attachments());
+    }
+  }
+
+  /** soft delete 한다. 복구 화면은 아직 없으므로 되살리려면 DB 에서 deleted_at 을 비워야 한다. */
+  @Transactional
+  public void deletePost(Long id, Long userId, UserRole userRole) {
+    FreeBoard post =
+        freeBoardRepository
+            .findById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    requireAuthorOrOrganizer(post, userId, userRole);
+
+    post.softDelete();
+  }
+
+  /**
+   * 자유게시판의 수정·삭제 경계다. 작성자 본인이거나 ORGANIZER 이상이어야 한다.
+   *
+   * <p>공지와 규칙이 같지만 뜻이 다르다. 공지는 CORE 이상만 글을 쓸 수 있어 '작성자'가 곧 운영진이고, 자유게시판은
+   * MEMBER 도 쓸 수 있어 이 검사가 회원끼리의 경계가 된다.
+   */
+  private void requireAuthorOrOrganizer(FreeBoard post, Long userId, UserRole userRole) {
+    if (UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) return;
+    if (!post.getAuthorId().equals(userId)) {
+      throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
+    }
+  }
+
+  private FreeBoardSummaryResponse toSummaryResponse(FreeBoard post) {
+    return new FreeBoardSummaryResponse(
+        post.getId(),
+        post.getTitle(),
+        post.getAuthorName(),
+        post.getViewCount(),
+        post.getCreatedAt());
+  }
+
+  private FreeBoardDetailResponse toDetailResponse(FreeBoard post, int viewCount) {
+    return new FreeBoardDetailResponse(
+        post.getId(),
+        post.getTitle(),
+        post.getContent(),
+        post.getAuthorId(),
+        post.getAuthorName(),
+        viewCount,
+        attachmentPolicy.toResponses(post.getAttachments()),
+        post.getCreatedAt(),
+        post.getUpdatedAt());
+  }
+}

--- a/src/main/resources/db/migration/V20260806_5__create_free_board.sql
+++ b/src/main/resources/db/migration/V20260806_5__create_free_board.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS free_board (
+    id           BIGSERIAL     PRIMARY KEY,
+    title        VARCHAR(255)  NOT NULL,
+    content      TEXT          NOT NULL,
+    author_id    BIGINT        NOT NULL REFERENCES users(id),
+    author_name  VARCHAR(100)  NOT NULL,
+    view_count   INT           NOT NULL DEFAULT 0,
+    deleted_at   TIMESTAMPTZ            DEFAULT NULL,
+    created_at   TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_free_board_author_id  ON free_board(author_id);
+CREATE INDEX IF NOT EXISTS idx_free_board_deleted_at ON free_board(deleted_at) WHERE deleted_at IS NOT NULL;

--- a/src/main/resources/db/migration/V20260806_6__create_free_board_attachment.sql
+++ b/src/main/resources/db/migration/V20260806_6__create_free_board_attachment.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS free_board_attachment (
+    id             BIGSERIAL     PRIMARY KEY,
+    free_board_id  BIGINT        NOT NULL REFERENCES free_board(id) ON DELETE CASCADE,
+    kind           VARCHAR(16)   NOT NULL,
+    file_key       VARCHAR(512),
+    file_name      VARCHAR(255),
+    file_size      BIGINT,
+    url            VARCHAR(2048),
+    sort_order     INT           NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_free_board_attachment_kind CHECK (
+        (kind = 'FILE' AND file_key IS NOT NULL AND file_name IS NOT NULL AND url IS NULL)
+     OR (kind = 'LINK' AND url IS NOT NULL AND file_key IS NULL AND file_name IS NULL AND file_size IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_free_board_attachment_board_id
+    ON free_board_attachment(free_board_id);

--- a/src/test/java/inha/gdgoc/domain/board/free/FreeBoardSecurityTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/free/FreeBoardSecurityTest.java
@@ -1,0 +1,51 @@
+package inha.gdgoc.domain.board.free;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 자유게시판 엔드포인트의 인증 경계를 검증한다.
+ *
+ * <p>자유게시판은 회원 전용이다. 공개인 게시판은 행사 하나뿐이므로 SecurityConfig 의 permitAll 에
+ * {@code /api/v1/board/free} 가 들어가면 안 된다. 이 테스트가 그 실수를 잡는다 — 공지에서 실제로 한 번
+ * 났던 사고다.
+ *
+ * <p>여기서 검증하는 것은 '비로그인 차단'까지다. 작성 MEMBER 이상, 수정·삭제 본인 또는 ORGANIZER 이상은
+ * 각각 {@code @Authorize} 와 {@code FreeBoardService} 가 담당하며 이 테스트의 범위가 아니다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class FreeBoardSecurityTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void list_requiresAuthentication() throws Exception {
+    mockMvc.perform(get("/api/v1/board/free")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void detail_requiresAuthentication() throws Exception {
+    mockMvc.perform(get("/api/v1/board/free/999999")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void create_requiresAuthentication() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/board/free")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"t\",\"content\":\"c\"}"))
+        .andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
## 무엇

자유게시판 서버 API. 목록·상세·작성·수정·삭제와 첨부(파일/링크)까지 공지 게시판과 같은 구조로 붙였다.

`/api/v1/board/free`

| 메서드 | 경로 | 권한 |
|---|---|---|
| GET | `/api/v1/board/free` | 회원(로그인) |
| GET | `/api/v1/board/free/{id}` | 회원(로그인) |
| POST | `/api/v1/board/free` | MEMBER 이상 |
| PATCH | `/api/v1/board/free/{id}` | 작성자 본인 또는 ORGANIZER 이상 |
| DELETE | `/api/v1/board/free/{id}` | 작성자 본인 또는 ORGANIZER 이상 |

## 왜 이렇게

**분류·임시저장을 뺐다.** 공지의 `category` 는 운영진이 공지를 갈래별로 묶으려고 둔 것이고, `is_published` 는 공개 시점을 고르는 기능이다. 회원이 자유롭게 쓰는 게시판에는 둘 다 쓰일 자리가 없다.

**권한이 공지·행사와 다르다.** 공지·행사는 작성이 CORE 이상이라 '작성자 = 운영진'이었다. 자유게시판은 MEMBER 도 쓰므로 수정·삭제 검사가 처음으로 **회원끼리의 경계**가 된다. 본인 여부는 어노테이션으로 표현할 수 없어 컨트롤러에서 `@Authorize(atLeast = MEMBER)` 로 한 번 거르고, 본인/ORGANIZER 판정은 `FreeBoardService.requireAuthorOrOrganizer` 가 한다.

**조회는 `permitAll` 에 넣지 않았다.** 공개인 게시판은 행사 하나뿐이다. `anyRequest().authenticated()` 가 받는다. 공지에서 실제로 이 실수가 났었으므로(#338) `FreeBoardSecurityTest` 가 401 을 고정한다.

**상세 응답에 `authorId` 를 담는다.** 행사·공지 상세에는 이 값이 없어서 웹이 수정·삭제 버튼을 누구에게 보여야 할지 판단하지 못한다. 지금은 모두에게 버튼을 띄우고 눌러야 403 을 받는다. 자유게시판은 작성자가 회원 누구나라 이 문제가 훨씬 자주 드러나므로 처음부터 내려준다. (행사·공지 쪽 같은 문제는 이 PR 범위 밖이다.)

**조회수는 벌크 UPDATE 다.** 더티체킹으로 올리면 `@LastModifiedDate` 가 함께 갱신되어 "마지막으로 열어본 시각"이 수정 시각을 덮어쓴다. DTO 를 먼저 만들고 그 다음에 벌크 UPDATE 를 호출하는 순서를 지켜야 한다 — `clearAutomatically` 가 영속성 컨텍스트를 비우면 첨부 지연 로딩이 `LazyInitializationException` 으로 죽는다. `NoticeBoardService.getNotice` 와 같은 이유이고 주석에 남겼다.

## 마이그레이션

- `V20260806_5__create_free_board.sql`
- `V20260806_6__create_free_board_attachment.sql`

이미 적용된 `V20260806_1~4` 다음 번호다. 기존 `feature/freeboard` 브랜치의 `V20260707` 은 이미 적용된 버전보다 앞이라 Flyway out-of-order 가 된다 — 그래서 그 브랜치를 머지하지 않고 새로 썼다.

## 검증

```
./gradlew compileJava compileTestJava   # BUILD SUCCESSFUL
./gradlew test --tests "*FreeBoard*"    # tests=3 failures=0 errors=0
```

테스트 프로필은 Flyway 를 끄고 `ddl-auto: create-drop` 을 쓰므로 마이그레이션 SQL 자체는 테스트가 검증하지 않는다. 컬럼명·타입·NOT NULL·CHECK 를 엔티티 매핑과 손으로 대조했다(`BoardEntity`, `BaseEntity`, `BoardAttachment` 기준).

## 남은 것

- 웹 화면 4종(목록·상세·작성·수정)은 이 PR 에 없다. DTO 가 확정됐으니 이어서 붙인다.
- 파일 첨부는 서버 PR #336(`feature/board-common`)이 머지돼야 실제로 동작한다. 링크 첨부는 지금도 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
