### PR TITLE
feat: 자유게시판 댓글·휴지통과 공지 상세 authorId

### DIFF
--- a/src/main/java/inha/gdgoc/domain/board/free/controller/FreeBoardCommentController.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/controller/FreeBoardCommentController.java
@@ -1,0 +1,81 @@
+package inha.gdgoc.domain.board.free.controller;
+
+import static inha.gdgoc.domain.board.free.controller.message.FreeBoardMessage.*;
+
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCommentCreateRequest;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCommentUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardCommentResponse;
+import inha.gdgoc.domain.board.free.service.FreeBoardCommentService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 자유게시판 댓글. 권한은 글과 같다 — 조회는 회원 전용, 작성은 MEMBER 이상, 수정·삭제는 작성자 본인 또는
+ * ORGANIZER 이상이다.
+ *
+ * <p>수정·삭제 경로에 글 id 를 두지 않는다. 댓글 id 만으로 대상이 정해지고, 글 id 를 함께 받으면 둘이 어긋났을 때의
+ * 처리를 또 정해야 한다. 목록·작성만 글에 매단다.
+ */
+@RestController
+@RequestMapping("/api/v1/board/free")
+@RequiredArgsConstructor
+@Validated
+public class FreeBoardCommentController {
+
+  private final FreeBoardCommentService freeBoardCommentService;
+
+  @GetMapping("/{postId}/comments")
+  public ResponseEntity<ApiResponse<List<FreeBoardCommentResponse>, Void>> listComments(
+      @PathVariable Long postId) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(FREE_COMMENT_LIST_RETRIEVED, freeBoardCommentService.listComments(postId)));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @PostMapping("/{postId}/comments")
+  public ResponseEntity<ApiResponse<Long, Void>> createComment(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long postId,
+      @Valid @RequestBody FreeBoardCommentCreateRequest req) {
+
+    Long id = freeBoardCommentService.createComment(postId, req, me.getUserId());
+    return ResponseEntity.ok(ApiResponse.ok(FREE_COMMENT_CREATED, id));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @PatchMapping("/comments/{commentId}")
+  public ResponseEntity<ApiResponse<Void, Void>> updateComment(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long commentId,
+      @Valid @RequestBody FreeBoardCommentUpdateRequest req) {
+
+    freeBoardCommentService.updateComment(commentId, req, me.getUserId(), me.getRole());
+    return ResponseEntity.ok(ApiResponse.ok(FREE_COMMENT_UPDATED));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @DeleteMapping("/comments/{commentId}")
+  public ResponseEntity<ApiResponse<Void, Void>> deleteComment(
+      @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long commentId) {
+
+    freeBoardCommentService.deleteComment(commentId, me.getUserId(), me.getRole());
+    return ResponseEntity.ok(ApiResponse.ok(FREE_COMMENT_DELETED));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/controller/FreeBoardController.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/controller/FreeBoardController.java
@@ -5,6 +5,7 @@ import static inha.gdgoc.domain.board.free.controller.message.FreeBoardMessage.*
 import inha.gdgoc.domain.board.common.enums.SearchType;
 import inha.gdgoc.domain.board.free.dto.request.FreeBoardCreateRequest;
 import inha.gdgoc.domain.board.free.dto.request.FreeBoardUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardDeletedSummaryResponse;
 import inha.gdgoc.domain.board.free.dto.response.FreeBoardDetailResponse;
 import inha.gdgoc.domain.board.free.dto.response.FreeBoardSummaryResponse;
 import inha.gdgoc.domain.board.free.service.FreeBoardService;
@@ -92,5 +93,32 @@ public class FreeBoardController {
       @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long id) {
     freeBoardService.deletePost(id, me.getUserId(), me.getRole());
     return ResponseEntity.ok(ApiResponse.ok(FREE_DELETED));
+  }
+
+  /**
+   * 휴지통. 공지·행사가 CORE 이상인 것과 달리 MEMBER 이상이다 — 자유게시판은 MEMBER 도 글을 쓰므로 실수로 지운
+   * 자기 글을 본인이 되살릴 수 있어야 한다. 남의 글이 섞이지 않도록 ORGANIZER 미만에게는 자기 글만 보인다.
+   */
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @GetMapping("/deleted")
+  public ResponseEntity<ApiResponse<Page<FreeBoardDeletedSummaryResponse>, PageMeta>>
+      listDeletedPosts(
+          @AuthenticationPrincipal CustomUserDetails me,
+          @RequestParam(defaultValue = "0") @Min(0) int page,
+          @RequestParam(defaultValue = "15") @Min(1) @Max(100) int size) {
+
+    Page<FreeBoardDeletedSummaryResponse> result =
+        freeBoardService.listDeletedPosts(page, size, me.getUserId(), me.getRole());
+
+    return ResponseEntity.ok(
+        ApiResponse.ok(FREE_DELETED_LIST_RETRIEVED, result, PageMeta.of(result)));
+  }
+
+  @Authorize(@Condition(atLeast = UserRole.MEMBER))
+  @PostMapping("/{id}/restore")
+  public ResponseEntity<ApiResponse<Void, Void>> restorePost(
+      @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long id) {
+    freeBoardService.restorePost(id, me.getUserId(), me.getRole());
+    return ResponseEntity.ok(ApiResponse.ok(FREE_RESTORED));
   }
 }

--- a/src/main/java/inha/gdgoc/domain/board/free/controller/message/FreeBoardMessage.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/controller/message/FreeBoardMessage.java
@@ -7,4 +7,11 @@ public class FreeBoardMessage {
   public static final String FREE_CREATED = "자유게시판 글 작성이 완료되었습니다.";
   public static final String FREE_UPDATED = "자유게시판 글 수정이 완료되었습니다.";
   public static final String FREE_DELETED = "자유게시판 글 삭제가 완료되었습니다.";
+  public static final String FREE_DELETED_LIST_RETRIEVED = "삭제된 자유게시판 글 목록을 조회했습니다.";
+  public static final String FREE_RESTORED = "자유게시판 글을 복원했습니다.";
+
+  public static final String FREE_COMMENT_LIST_RETRIEVED = "댓글 목록을 조회했습니다.";
+  public static final String FREE_COMMENT_CREATED = "댓글 작성이 완료되었습니다.";
+  public static final String FREE_COMMENT_UPDATED = "댓글 수정이 완료되었습니다.";
+  public static final String FREE_COMMENT_DELETED = "댓글 삭제가 완료되었습니다.";
 }

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardCommentCreateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardCommentCreateRequest.java
@@ -1,0 +1,13 @@
+package inha.gdgoc.domain.board.free.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 댓글 작성.
+ *
+ * <p>parentId 가 있으면 대댓글이다. 대댓글의 id 를 넘겨도 되고, 그때는 그 대댓글의 부모에 붙는다 — 깊이는 항상
+ * 1단계다({@code FreeBoardComment.resolveParent}).
+ */
+public record FreeBoardCommentCreateRequest(
+    @NotBlank @Size(max = 1000) String content, Long parentId) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardCommentUpdateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/request/FreeBoardCommentUpdateRequest.java
@@ -1,0 +1,7 @@
+package inha.gdgoc.domain.board.free.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** 댓글 수정. 내용만 바꾼다 — 부모는 옮기지 않는다. */
+public record FreeBoardCommentUpdateRequest(@NotBlank @Size(max = 1000) String content) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardCommentResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardCommentResponse.java
@@ -1,0 +1,51 @@
+package inha.gdgoc.domain.board.free.dto.response;
+
+import inha.gdgoc.domain.board.free.entity.FreeBoardComment;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 댓글 한 건. 최상위 댓글만 replies 를 갖고, 대댓글의 replies 는 항상 빈 배열이다 — 깊이가 1단계다.
+ *
+ * <p>삭제된 댓글은 자식이 남아 있을 때만 응답에 실린다. 그때 content·authorId·authorName 은 전부 null 이다.
+ * 지운 사람이 누구였는지까지 남길 이유가 없다. 화면 문구('삭제된 댓글입니다')는 클라이언트가 정한다.
+ */
+public record FreeBoardCommentResponse(
+    Long id,
+    Long parentId,
+    String content,
+    Long authorId,
+    String authorName,
+    boolean deleted,
+    Instant createdAt,
+    Instant updatedAt,
+    List<FreeBoardCommentResponse> replies) {
+
+  public static FreeBoardCommentResponse of(
+      FreeBoardComment comment, List<FreeBoardCommentResponse> replies) {
+
+    if (comment.isDeleted()) {
+      return new FreeBoardCommentResponse(
+          comment.getId(),
+          comment.getParent() == null ? null : comment.getParent().getId(),
+          null,
+          null,
+          null,
+          true,
+          comment.getCreatedAt(),
+          comment.getUpdatedAt(),
+          replies);
+    }
+
+    return new FreeBoardCommentResponse(
+        comment.getId(),
+        comment.getParent() == null ? null : comment.getParent().getId(),
+        comment.getContent(),
+        comment.getAuthorId(),
+        comment.getAuthorName(),
+        false,
+        comment.getCreatedAt(),
+        comment.getUpdatedAt(),
+        replies);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardDeletedSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/dto/response/FreeBoardDeletedSummaryResponse.java
@@ -1,0 +1,12 @@
+package inha.gdgoc.domain.board.free.dto.response;
+
+import java.time.Instant;
+
+/** 삭제 목록 한 행. deletedAt 이 정렬 기준이라 응답에도 노출한다. */
+public record FreeBoardDeletedSummaryResponse(
+    Long id,
+    String title,
+    String authorName,
+    int viewCount,
+    Instant createdAt,
+    Instant deletedAt) {}

--- a/src/main/java/inha/gdgoc/domain/board/free/entity/FreeBoardComment.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/entity/FreeBoardComment.java
@@ -1,0 +1,100 @@
+package inha.gdgoc.domain.board.free.entity;
+
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 자유게시판 댓글. 대댓글은 1단계까지만이다.
+ *
+ * <p>깊이를 한 단계로 묶은 이유는 두 가지다. 무한 중첩은 화면에서 들여쓰기가 감당이 안 되고, 조회할 때 재귀가 필요해
+ * 쿼리가 복잡해진다. parent 가 있으면 대댓글, 없으면 댓글이고 그 이상은 없다 — 대댓글에 다는 답글도 같은 부모에
+ * 붙인다({@code resolveParent} 참고).
+ *
+ * <p>삭제는 soft delete 다. 자식이 달린 댓글을 지워도 행은 남는다. 트리에서 부모가 사라지면 자식이 갈 곳이 없어
+ * 화면에서 통째로 사라지기 때문이다. 대신 내용을 감추고 '삭제된 댓글입니다'로 보이게 한다.
+ */
+@Entity
+@Table(name = "free_board_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FreeBoardComment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "free_board_id", nullable = false)
+  private FreeBoard freeBoard;
+
+  /** null 이면 최상위 댓글이다. 값이 있으면 그 댓글에 달린 대댓글이고, 그 아래는 없다. */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private FreeBoardComment parent;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Column(name = "author_id", nullable = false)
+  private Long authorId;
+
+  /** 작성 시점 스냅샷. 회원이 탈퇴해도 작성자가 사라지지 않는다. 글과 같은 규칙이다. */
+  @Column(name = "author_name", nullable = false, length = 100)
+  private String authorName;
+
+  @Column private Instant deletedAt;
+
+  public static FreeBoardComment create(
+      FreeBoard freeBoard,
+      FreeBoardComment parent,
+      String content,
+      Long authorId,
+      String authorName) {
+    FreeBoardComment comment = new FreeBoardComment();
+    comment.freeBoard = freeBoard;
+    comment.parent = resolveParent(parent);
+    comment.content = content;
+    comment.authorId = authorId;
+    comment.authorName = authorName;
+    return comment;
+  }
+
+  /**
+   * 깊이를 1단계로 고정한다.
+   *
+   * <p>대댓글에 답글을 달면 그 대댓글의 부모(=최상위 댓글)에 붙인다. 요청을 거부하지 않는 이유는, 화면에서 대댓글에도
+   * '답글' 버튼이 보이는 편이 자연스럽고 사용자는 깊이를 신경 쓸 이유가 없기 때문이다.
+   */
+  private static FreeBoardComment resolveParent(FreeBoardComment parent) {
+    if (parent == null) return null;
+    return parent.parent == null ? parent : parent.parent;
+  }
+
+  public void update(String content) {
+    this.content = content;
+  }
+
+  public void softDelete() {
+    this.deletedAt = Instant.now();
+  }
+
+  public boolean isDeleted() {
+    return deletedAt != null;
+  }
+
+  public boolean isReply() {
+    return parent != null;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardCommentJpaRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardCommentJpaRepository.java
@@ -1,0 +1,26 @@
+package inha.gdgoc.domain.board.free.repository;
+
+import inha.gdgoc.domain.board.free.entity.FreeBoardComment;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FreeBoardCommentJpaRepository extends JpaRepository<FreeBoardComment, Long> {
+
+  /**
+   * 글 하나의 댓글을 전부 작성순으로 준다. 삭제된 것도 포함한다 — 자식이 달린 삭제 댓글은 자리를 남겨야 트리가
+   * 끊기지 않는다. 걸러내는 판단은 서비스가 한다.
+   *
+   * <p>parent 를 함께 가져온다. 트리를 세울 때 부모 id 를 읽는데, 지연 로딩이면 댓글 수만큼 쿼리가 나간다.
+   */
+  @Query(
+      "SELECT c FROM FreeBoardComment c LEFT JOIN FETCH c.parent"
+          + " WHERE c.freeBoard.id = :postId ORDER BY c.createdAt ASC")
+  List<FreeBoardComment> findAllByPostId(@Param("postId") Long postId);
+
+  Optional<FreeBoardComment> findByIdAndDeletedAtIsNull(Long id);
+
+  boolean existsByParentIdAndDeletedAtIsNull(Long parentId);
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardJpaRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardJpaRepository.java
@@ -11,6 +11,8 @@ public interface FreeBoardJpaRepository extends JpaRepository<FreeBoard, Long> {
 
   Optional<FreeBoard> findByIdAndDeletedAtIsNull(Long id);
 
+  Optional<FreeBoard> findByIdAndDeletedAtIsNotNull(Long id);
+
   @Modifying
   @Query("UPDATE FreeBoard f SET f.viewCount = f.viewCount + 1 WHERE f.id = :id")
   void increaseViewCount(@Param("id") Long id);

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardQueryDslRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardQueryDslRepository.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.board.free.repository;
 
 import inha.gdgoc.domain.board.common.enums.SearchType;
 import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import inha.gdgoc.domain.user.enums.UserRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -14,4 +15,12 @@ public interface FreeBoardQueryDslRepository {
    * 글이 달라지지 않는다 — 회원이면 모두 같은 목록을 본다.
    */
   Page<FreeBoard> findVisiblePosts(SearchType searchType, String keyword, Pageable pageable);
+
+  /**
+   * 삭제된 글을 삭제 시각 최신순으로 준다.
+   *
+   * <p>ORGANIZER 이상은 전부 보고, 그 아래는 자기가 쓴 글만 본다. 자유게시판은 MEMBER 도 글을 쓰므로 이 필터가 없으면
+   * 휴지통이 남의 삭제글까지 드러낸다. 공지의 findDeletedNotices 와 같은 규칙이다.
+   */
+  Page<FreeBoard> findDeletedPosts(Long userId, UserRole userRole, Pageable pageable);
 }

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepository.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepository.java
@@ -7,6 +7,9 @@ public interface FreeBoardRepository extends FreeBoardQueryDslRepository {
 
   Optional<FreeBoard> findById(Long id);
 
+  /** 복원 대상은 이미 삭제된 글이라 findById 로는 찾을 수 없다. */
+  Optional<FreeBoard> findDeletedById(Long id);
+
   FreeBoard save(FreeBoard post);
 
   void increaseViewCount(Long id);

--- a/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepositoryImpl.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/repository/FreeBoardRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import inha.gdgoc.domain.board.common.enums.SearchType;
 import inha.gdgoc.domain.board.free.entity.FreeBoard;
 import inha.gdgoc.domain.board.free.entity.QFreeBoard;
+import inha.gdgoc.domain.user.enums.UserRole;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,11 @@ public class FreeBoardRepositoryImpl implements FreeBoardRepository {
   @Override
   public Optional<FreeBoard> findById(Long id) {
     return jpaRepository.findByIdAndDeletedAtIsNull(id);
+  }
+
+  @Override
+  public Optional<FreeBoard> findDeletedById(Long id) {
+    return jpaRepository.findByIdAndDeletedAtIsNotNull(id);
   }
 
   @Override
@@ -53,6 +59,30 @@ public class FreeBoardRepositoryImpl implements FreeBoardRepository {
             .selectFrom(post)
             .where(where)
             .orderBy(post.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total = queryFactory.select(post.count()).from(post).where(where).fetchOne();
+
+    return new PageImpl<>(content, pageable, total == null ? 0 : total);
+  }
+
+  @Override
+  public Page<FreeBoard> findDeletedPosts(Long userId, UserRole userRole, Pageable pageable) {
+
+    QFreeBoard post = QFreeBoard.freeBoard;
+
+    BooleanExpression where = post.deletedAt.isNotNull();
+    if (!UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) {
+      where = where.and(post.authorId.eq(userId));
+    }
+
+    List<FreeBoard> content =
+        queryFactory
+            .selectFrom(post)
+            .where(where)
+            .orderBy(post.deletedAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/src/main/java/inha/gdgoc/domain/board/free/service/FreeBoardCommentService.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/service/FreeBoardCommentService.java
@@ -1,0 +1,139 @@
+package inha.gdgoc.domain.board.free.service;
+
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCommentCreateRequest;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCommentUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardCommentResponse;
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import inha.gdgoc.domain.board.free.entity.FreeBoardComment;
+import inha.gdgoc.domain.board.free.repository.FreeBoardCommentJpaRepository;
+import inha.gdgoc.domain.board.free.repository.FreeBoardRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FreeBoardCommentService {
+
+  private final FreeBoardCommentJpaRepository commentRepository;
+  private final FreeBoardRepository freeBoardRepository;
+  private final UserRepository userRepository;
+
+  /**
+   * 글 하나의 댓글을 트리로 준다. 페이지네이션은 없다 — 자유게시판 한 글의 댓글이 한 화면에 다 들어가지 않을 만큼
+   * 쌓이면 그때 넣는다.
+   *
+   * <p>삭제된 댓글의 처리가 이 메서드의 핵심이다. 자식이 남은 최상위 댓글은 지워도 자리를 남긴다(내용은 감춘다).
+   * 자식이 없으면 목록에서 아예 뺀다. 대댓글은 자식이 없으므로 지우면 항상 사라진다.
+   */
+  public List<FreeBoardCommentResponse> listComments(Long postId) {
+    requireVisiblePost(postId);
+
+    List<FreeBoardComment> all = commentRepository.findAllByPostId(postId);
+
+    Map<Long, List<FreeBoardComment>> childrenByParent = new LinkedHashMap<>();
+    List<FreeBoardComment> roots = new ArrayList<>();
+    for (FreeBoardComment comment : all) {
+      if (comment.isReply()) {
+        childrenByParent
+            .computeIfAbsent(comment.getParent().getId(), key -> new ArrayList<>())
+            .add(comment);
+      } else {
+        roots.add(comment);
+      }
+    }
+
+    List<FreeBoardCommentResponse> result = new ArrayList<>();
+    for (FreeBoardComment root : roots) {
+      List<FreeBoardCommentResponse> replies =
+          childrenByParent.getOrDefault(root.getId(), List.of()).stream()
+              .filter(reply -> !reply.isDeleted())
+              .map(reply -> FreeBoardCommentResponse.of(reply, List.of()))
+              .toList();
+
+      // 지워졌는데 남은 대댓글도 없으면 보여줄 것이 없다.
+      if (root.isDeleted() && replies.isEmpty()) continue;
+
+      result.add(FreeBoardCommentResponse.of(root, replies));
+    }
+    return result;
+  }
+
+  @Transactional
+  public Long createComment(Long postId, FreeBoardCommentCreateRequest req, Long authorId) {
+    FreeBoard post = requireVisiblePost(postId);
+
+    // 부모를 먼저 본다. 어차피 거절할 요청이면 작성자 조회를 할 이유가 없다.
+    FreeBoardComment parent = req.parentId() == null ? null : requireParent(req.parentId(), postId);
+
+    User author =
+        userRepository
+            .findById(authorId)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    FreeBoardComment comment =
+        FreeBoardComment.create(post, parent, req.content(), authorId, author.getName());
+
+    return commentRepository.save(comment).getId();
+  }
+
+  @Transactional
+  public void updateComment(
+      Long commentId, FreeBoardCommentUpdateRequest req, Long userId, UserRole userRole) {
+    FreeBoardComment comment = requireVisibleComment(commentId);
+    requireAuthorOrOrganizer(comment, userId, userRole);
+    comment.update(req.content());
+  }
+
+  @Transactional
+  public void deleteComment(Long commentId, Long userId, UserRole userRole) {
+    FreeBoardComment comment = requireVisibleComment(commentId);
+    requireAuthorOrOrganizer(comment, userId, userRole);
+    comment.softDelete();
+  }
+
+  private FreeBoard requireVisiblePost(Long postId) {
+    return freeBoardRepository
+        .findById(postId)
+        .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+  }
+
+  private FreeBoardComment requireVisibleComment(Long commentId) {
+    return commentRepository
+        .findByIdAndDeletedAtIsNull(commentId)
+        .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+  }
+
+  /**
+   * 부모 댓글은 살아 있어야 하고 같은 글에 속해야 한다.
+   *
+   * <p>글 검사를 빼면 A 글의 댓글에 B 글의 댓글을 답글로 달 수 있다. id 만 바꿔 부르면 되므로 화면에서 막는 것으로는
+   * 부족하다.
+   */
+  private FreeBoardComment requireParent(Long parentId, Long postId) {
+    FreeBoardComment parent = requireVisibleComment(parentId);
+    if (!parent.getFreeBoard().getId().equals(postId)) {
+      throw new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND);
+    }
+    return parent;
+  }
+
+  /** 글과 같은 규칙이다. 작성자 본인이거나 ORGANIZER 이상이어야 한다. */
+  private void requireAuthorOrOrganizer(
+      FreeBoardComment comment, Long userId, UserRole userRole) {
+    if (UserRole.hasAtLeast(userRole, UserRole.ORGANIZER)) return;
+    if (!comment.getAuthorId().equals(userId)) {
+      throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
+    }
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/board/free/service/FreeBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/free/service/FreeBoardService.java
@@ -4,6 +4,7 @@ import inha.gdgoc.domain.board.common.enums.SearchType;
 import inha.gdgoc.domain.board.common.service.AttachmentPolicy;
 import inha.gdgoc.domain.board.free.dto.request.FreeBoardCreateRequest;
 import inha.gdgoc.domain.board.free.dto.request.FreeBoardUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardDeletedSummaryResponse;
 import inha.gdgoc.domain.board.free.dto.response.FreeBoardDetailResponse;
 import inha.gdgoc.domain.board.free.dto.response.FreeBoardSummaryResponse;
 import inha.gdgoc.domain.board.free.entity.FreeBoard;
@@ -101,6 +102,32 @@ public class FreeBoardService {
   }
 
   /**
+   * 삭제된 글 목록.
+   *
+   * <p>ORGANIZER 이상은 전부 보고 그 아래는 자기 글만 본다. 그 필터는 리포지토리가 건다 —
+   * findDeletedPosts 참고.
+   */
+  public Page<FreeBoardDeletedSummaryResponse> listDeletedPosts(
+      int page, int size, Long userId, UserRole userRole) {
+    return freeBoardRepository
+        .findDeletedPosts(userId, userRole, PageRequest.of(page, size))
+        .map(this::toDeletedSummaryResponse);
+  }
+
+  /** 목록에 남의 글이 섞이지 않더라도 id 를 직접 찍어 부를 수 있으므로 여기서 한 번 더 판정한다. */
+  @Transactional
+  public void restorePost(Long id, Long userId, UserRole userRole) {
+    FreeBoard post =
+        freeBoardRepository
+            .findDeletedById(id)
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    requireAuthorOrOrganizer(post, userId, userRole);
+
+    post.restore();
+  }
+
+  /**
    * 자유게시판의 수정·삭제 경계다. 작성자 본인이거나 ORGANIZER 이상이어야 한다.
    *
    * <p>공지와 규칙이 같지만 뜻이 다르다. 공지는 CORE 이상만 글을 쓸 수 있어 '작성자'가 곧 운영진이고, 자유게시판은
@@ -111,6 +138,16 @@ public class FreeBoardService {
     if (!post.getAuthorId().equals(userId)) {
       throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
     }
+  }
+
+  private FreeBoardDeletedSummaryResponse toDeletedSummaryResponse(FreeBoard post) {
+    return new FreeBoardDeletedSummaryResponse(
+        post.getId(),
+        post.getTitle(),
+        post.getAuthorName(),
+        post.getViewCount(),
+        post.getCreatedAt(),
+        post.getDeletedAt());
   }
 
   private FreeBoardSummaryResponse toSummaryResponse(FreeBoard post) {

--- a/src/main/java/inha/gdgoc/domain/board/notice/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/inha/gdgoc/domain/board/notice/dto/response/NoticeDetailResponse.java
@@ -5,11 +5,22 @@ import inha.gdgoc.domain.board.notice.enums.NoticeCategory;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * 상세 응답.
+ *
+ * <p>authorId 를 함께 준다. 수정·삭제는 '작성자 본인 또는 ORGANIZER 이상'인데({@code
+ * NoticeBoardService.requireAuthorOrOrganizer}), 이 값이 없으면 프론트가 본인 여부를 판정할 수 없어 권한 없는
+ * CORE 에게도 버튼을 보여주고 눌러야 403 을 만나게 된다.
+ *
+ * <p>행사 게시판에는 같은 필드를 두지 않았다. 그쪽 규칙은 '주최 팀 일치 또는 ORGANIZER 이상'이라 판정 기준이
+ * organizingTeam 이고 그 값은 이미 응답에 있다. 행사 상세는 공개 API 라 사용자 PK 를 비로그인에게 흘릴 이유도 없다.
+ */
 public record NoticeDetailResponse(
     Long id,
     NoticeCategory category,
     String title,
     String content,
+    Long authorId,
     String authorName,
     int viewCount,
     boolean isPublished,

--- a/src/main/java/inha/gdgoc/domain/board/notice/service/NoticeBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/notice/service/NoticeBoardService.java
@@ -178,6 +178,7 @@ public class NoticeBoardService {
         notice.getCategory(),
         notice.getTitle(),
         notice.getContent(),
+        notice.getAuthorId(),
         notice.getAuthorName(),
         viewCount,
         notice.isPublished(),

--- a/src/main/resources/db/migration/V20260807_1__create_free_board_comment.sql
+++ b/src/main/resources/db/migration/V20260807_1__create_free_board_comment.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS free_board_comment (
+    id             BIGSERIAL     PRIMARY KEY,
+    free_board_id  BIGINT        NOT NULL REFERENCES free_board(id) ON DELETE CASCADE,
+    parent_id      BIGINT                 REFERENCES free_board_comment(id) ON DELETE CASCADE,
+    content        TEXT          NOT NULL,
+    author_id      BIGINT        NOT NULL REFERENCES users(id),
+    author_name    VARCHAR(100)  NOT NULL,
+    deleted_at     TIMESTAMPTZ            DEFAULT NULL,
+    created_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 상세 화면이 글 하나의 댓글을 통째로 읽고 작성순으로 세운다.
+CREATE INDEX IF NOT EXISTS idx_free_board_comment_board_id
+    ON free_board_comment(free_board_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_free_board_comment_parent_id
+    ON free_board_comment(parent_id) WHERE parent_id IS NOT NULL;

--- a/src/test/java/inha/gdgoc/domain/board/free/FreeBoardSecurityTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/free/FreeBoardSecurityTest.java
@@ -40,6 +40,35 @@ class FreeBoardSecurityTest {
   }
 
   @Test
+  void commentList_requiresAuthentication() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/board/free/999999/comments"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void commentCreate_requiresAuthentication() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/board/free/999999/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\":\"c\"}"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void deletedList_requiresAuthentication() throws Exception {
+    mockMvc.perform(get("/api/v1/board/free/deleted")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void restore_requiresAuthentication() throws Exception {
+    mockMvc
+        .perform(post("/api/v1/board/free/999999/restore"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
   void create_requiresAuthentication() throws Exception {
     mockMvc
         .perform(

--- a/src/test/java/inha/gdgoc/domain/board/free/service/FreeBoardCommentServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/free/service/FreeBoardCommentServiceTest.java
@@ -1,0 +1,145 @@
+package inha.gdgoc.domain.board.free.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCommentCreateRequest;
+import inha.gdgoc.domain.board.free.dto.request.FreeBoardCommentUpdateRequest;
+import inha.gdgoc.domain.board.free.dto.response.FreeBoardCommentResponse;
+import inha.gdgoc.domain.board.free.entity.FreeBoard;
+import inha.gdgoc.domain.board.free.entity.FreeBoardComment;
+import inha.gdgoc.domain.board.free.repository.FreeBoardCommentJpaRepository;
+import inha.gdgoc.domain.board.free.repository.FreeBoardRepository;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/** 댓글 트리 구성과 삭제 처리, 권한 경계. */
+@ExtendWith(MockitoExtension.class)
+class FreeBoardCommentServiceTest {
+
+  @Mock private FreeBoardCommentJpaRepository commentRepository;
+  @Mock private FreeBoardRepository freeBoardRepository;
+  @Mock private UserRepository userRepository;
+
+  private FreeBoardCommentService service;
+  private FreeBoard post;
+
+  @BeforeEach
+  void setUp() {
+    service = new FreeBoardCommentService(commentRepository, freeBoardRepository, userRepository);
+    post = FreeBoard.create("제목", "본문", 1L, "글쓴이");
+    ReflectionTestUtils.setField(post, "id", 1L);
+  }
+
+  @Test
+  @DisplayName("대댓글에 답글을 달면 같은 최상위 댓글에 붙는다 — 깊이는 1단계다")
+  void replyToReplyIsFlattenedToTopLevel() {
+    FreeBoardComment root = comment(10L, null, "댓글", 1L);
+    FreeBoardComment reply = comment(11L, root, "대댓글", 2L);
+
+    FreeBoardComment replyToReply = FreeBoardComment.create(post, reply, "답글의 답글", 3L, "셋째");
+
+    assertThat(replyToReply.getParent()).isSameAs(root);
+    assertThat(replyToReply.isReply()).isTrue();
+  }
+
+  @Test
+  @DisplayName("삭제된 댓글도 대댓글이 남아 있으면 자리를 남기되 내용과 작성자를 감춘다")
+  void deletedRootWithRepliesBecomesTombstone() {
+    FreeBoardComment root = comment(10L, null, "지워질 댓글", 1L);
+    root.softDelete();
+    FreeBoardComment reply = comment(11L, root, "살아있는 대댓글", 2L);
+
+    when(freeBoardRepository.findById(1L)).thenReturn(Optional.of(post));
+    when(commentRepository.findAllByPostId(1L)).thenReturn(List.of(root, reply));
+
+    List<FreeBoardCommentResponse> result = service.listComments(1L);
+
+    assertThat(result).hasSize(1);
+    FreeBoardCommentResponse tombstone = result.get(0);
+    assertThat(tombstone.deleted()).isTrue();
+    assertThat(tombstone.content()).isNull();
+    assertThat(tombstone.authorId()).isNull();
+    assertThat(tombstone.authorName()).isNull();
+    assertThat(tombstone.replies()).hasSize(1);
+    assertThat(tombstone.replies().get(0).content()).isEqualTo("살아있는 대댓글");
+  }
+
+  @Test
+  @DisplayName("삭제된 댓글에 남은 대댓글이 없으면 목록에서 아예 빠진다")
+  void deletedRootWithoutRepliesDisappears() {
+    FreeBoardComment root = comment(10L, null, "지워질 댓글", 1L);
+    root.softDelete();
+    FreeBoardComment reply = comment(11L, root, "같이 지워진 대댓글", 2L);
+    reply.softDelete();
+
+    when(freeBoardRepository.findById(1L)).thenReturn(Optional.of(post));
+    when(commentRepository.findAllByPostId(1L)).thenReturn(List.of(root, reply));
+
+    assertThat(service.listComments(1L)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("남의 댓글은 ORGANIZER 미만이 수정할 수 없다")
+  void othersCommentCannotBeUpdatedByNonOrganizer() {
+    FreeBoardComment comment = comment(10L, null, "남의 댓글", 1L);
+    when(commentRepository.findByIdAndDeletedAtIsNull(10L)).thenReturn(Optional.of(comment));
+
+    assertThatThrownBy(
+            () ->
+                service.updateComment(
+                    10L, new FreeBoardCommentUpdateRequest("고쳐본다"), 99L, UserRole.CORE))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(GlobalErrorCode.FORBIDDEN_USER);
+  }
+
+  @Test
+  @DisplayName("ORGANIZER 는 남의 댓글도 삭제할 수 있다")
+  void organizerCanDeleteOthersComment() {
+    FreeBoardComment comment = comment(10L, null, "남의 댓글", 1L);
+    when(commentRepository.findByIdAndDeletedAtIsNull(10L)).thenReturn(Optional.of(comment));
+
+    service.deleteComment(10L, 99L, UserRole.ORGANIZER);
+
+    assertThat(comment.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("다른 글의 댓글을 부모로 지정하면 404 다")
+  void parentFromAnotherPostIsRejected() {
+    FreeBoard otherPost = FreeBoard.create("다른 글", "본문", 1L, "글쓴이");
+    ReflectionTestUtils.setField(otherPost, "id", 2L);
+
+    FreeBoardComment foreignParent = FreeBoardComment.create(otherPost, null, "남의 글 댓글", 1L, "갑");
+    ReflectionTestUtils.setField(foreignParent, "id", 20L);
+
+    when(freeBoardRepository.findById(1L)).thenReturn(Optional.of(post));
+    when(commentRepository.findByIdAndDeletedAtIsNull(20L)).thenReturn(Optional.of(foreignParent));
+
+    assertThatThrownBy(
+            () -> service.createComment(1L, new FreeBoardCommentCreateRequest("답글", 20L), 3L))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(GlobalErrorCode.RESOURCE_NOT_FOUND);
+  }
+
+  private FreeBoardComment comment(Long id, FreeBoardComment parent, String content, Long authorId) {
+    FreeBoardComment comment =
+        FreeBoardComment.create(post, parent, content, authorId, "작성자" + authorId);
+    ReflectionTestUtils.setField(comment, "id", id);
+    return comment;
+  }
+}


### PR DESCRIPTION
## 무엇

웹 후속 작업이 필요로 하는 서버 값·경로를 한 번에 담았다.

### 1. 자유게시판 댓글·대댓글

```
GET    /api/v1/board/free/{postId}/comments   회원(로그인)
POST   /api/v1/board/free/{postId}/comments   MEMBER+
PATCH  /api/v1/board/free/comments/{id}       본인 또는 ORGANIZER+
DELETE /api/v1/board/free/comments/{id}       본인 또는 ORGANIZER+
```

**대댓글은 1단계까지다.** 무한 중첩은 화면에서 들여쓰기가 감당이 안 되고 조회에 재귀가 필요하다. 대댓글에 답글을 달면 그 대댓글의 **부모에 붙인다** — 요청을 거부하지 않는 이유는 화면에서 대댓글에도 '답글'이 보이는 편이 자연스럽고 사용자가 깊이를 신경 쓸 이유가 없어서다.

**삭제된 댓글 처리가 이 기능의 핵심이다.** 자식이 남은 댓글을 지우면 행을 남기되 `content`·`authorId`·`authorName` 을 전부 `null` 로 내린다(`deleted: true`). 부모가 사라지면 자식이 갈 곳이 없어 화면에서 통째로 사라지기 때문이다. 남은 대댓글이 없으면 목록에서 아예 뺀다. 화면 문구('삭제된 댓글입니다')는 클라이언트가 정한다.

**부모 댓글이 같은 글에 속하는지 검사한다.** 그러지 않으면 id 만 바꿔 A 글의 댓글에 B 글의 댓글을 답글로 달 수 있다. 화면에서 막는 것으로는 부족하다.

수정·삭제 경로에 글 id 를 두지 않았다. 댓글 id 만으로 대상이 정해지고, 글 id 를 함께 받으면 둘이 어긋났을 때의 처리를 또 정해야 한다.

페이지네이션은 없다. 한 글의 댓글이 한 화면에 안 들어갈 만큼 쌓이면 그때 넣는다.

### 2. 자유게시판 휴지통

```
GET  /api/v1/board/free/deleted        MEMBER+
POST /api/v1/board/free/{id}/restore   MEMBER+
```

공지·행사가 CORE 이상인 것과 **다르다.** 자유게시판은 MEMBER 도 글을 쓰므로 실수로 지운 자기 글을 본인이 되살릴 수 있어야 한다. 대신 **ORGANIZER 미만에게는 자기 글만 보인다** — 필터 규칙은 공지의 `findDeletedNotices` 와 같다. 복원은 목록에 안 보이는 id 를 직접 찍을 수 있으므로 서비스에서 한 번 더 판정한다.

### 3. 공지 상세 응답에 `authorId`

수정·삭제가 '본인 또는 ORGANIZER+'(`requireAuthorOrOrganizer`)인데 이 값이 없어 웹이 본인 여부를 판정하지 못했다. 지금은 CORE 이상 전원에게 버튼을 보여주고 눌러야 403 이 난다.

**행사 게시판에는 넣지 않았다.** 그쪽 규칙은 `requireTeamAccess` 로 '주최 팀 일치 또는 ORGANIZER+'라 판정 기준이 `authorId` 가 아니라 `organizingTeam` 이고, 그 값은 **이미 응답에 있다.** 행사 상세는 공개 API 라 사용자 PK 를 비로그인에게 흘릴 이유도 없다.

## 마이그레이션

`V20260807_1__create_free_board_comment.sql` — 적용된 마지막인 `V20260806_6` 다음 번호다.

## 검증

```
./gradlew test    # 123건 / 실패 0 / 에러 0
```

- 새 테스트: `FreeBoardCommentServiceTest` 6건(깊이 평탄화, 삭제 댓글 자리 남김/사라짐, 권한, 다른 글 부모 거부), `FreeBoardSecurityTest` 7건으로 확장
- 테스트 프로필은 Flyway 를 끄고 `ddl-auto: create-drop` 을 쓰므로 **마이그레이션 SQL 은 테스트가 검증하지 않는다.** 컬럼·제약을 엔티티 매핑과 손으로 대조했다

**참고 — CLAUDE.md 의 "테스트 6건 기존 실패"는 지금 사실이 아니다.** 22개 테스트 클래스가 모두 실행됐고(결과 XML 과 소스가 일대일로 맞는다) 실패는 0건이다. 그 사이 develop 에 82개 커밋이 들어갔으니 그동안 고쳐진 것으로 보인다. 문서는 이 PR 에서 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 자유게시판 댓글 조회·작성·수정·삭제를 지원합니다.
  - 댓글과 1단계 대댓글을 트리 형태로 확인할 수 있습니다.
  - 삭제된 댓글은 상태에 따라 안전하게 표시되며, 내용과 작성자 정보가 보호됩니다.
  - 삭제된 게시글을 페이지 단위로 조회하고 복구할 수 있습니다.
  - 게시글 및 댓글 관리 기능에 권한 검증이 적용됩니다.

- **개선 사항**
  - 공지사항 상세 정보에 작성자 식별 정보가 포함됩니다.
  - 입력 댓글은 최대 1,000자까지 지원하며 필수 값이 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->