### PR TITLE
feat: 부원 모집에도 기간 게이트를 건다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
@@ -18,10 +18,12 @@ import inha.gdgoc.domain.recruit.member.dto.request.RecruitMemberMemoRequest;
 import inha.gdgoc.domain.recruit.member.dto.response.CheckEmailResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.CheckPhoneNumberResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.CheckStudentIdResponse;
+import inha.gdgoc.domain.recruit.member.dto.response.RecruitMemberPeriodResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.RecruitMemberSummaryResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.SpecifiedMemberResponse;
 import inha.gdgoc.domain.resource.dto.response.PresignedUploadResponse;
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.service.RecruitMemberPeriodService;
 import inha.gdgoc.domain.recruit.member.service.RecruitMemberService;
 import inha.gdgoc.global.dto.response.ApiResponse;
 import inha.gdgoc.global.dto.response.PageMeta;
@@ -70,6 +72,7 @@ public class RecruitMemberController {
                     + " T(inha.gdgoc.domain.user.enums.TeamType).HR))";
 
     private final RecruitMemberService recruitMemberService;
+    private final RecruitMemberPeriodService recruitMemberPeriodService;
 
     public record ProofFilePresignedUploadRequest(
             @NotBlank String fileName,
@@ -78,10 +81,21 @@ public class RecruitMemberController {
     ) {
     }
 
+    /**
+     * 부원 모집 기간. 코어의 {@code GET /api/v1/recruit/core/period} 와 같은 역할이다.
+     *
+     * <p>비로그인 방문자가 지원 화면에 들어오기 전에 본다. SecurityConfig 의 permitAll 에 넣어야 한다.
+     */
+    @GetMapping("/period")
+    public ResponseEntity<RecruitMemberPeriodResponse> period() {
+        return ResponseEntity.ok(recruitMemberPeriodService.getPeriod());
+    }
+
     @PostMapping(value = "/apply", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Void, Void>> recruitMemberAdd(
             @RequestBody Map<String, Object> applicationRequest
     ) {
+        recruitMemberPeriodService.validateOpen();
         recruitMemberService.addRecruitMember(applicationRequest, null);
 
         return ResponseEntity.ok(ApiResponse.ok(MEMBER_SAVE_SUCCESS));
@@ -92,15 +106,18 @@ public class RecruitMemberController {
             @RequestPart("request") Map<String, Object> applicationRequest,
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
+        recruitMemberPeriodService.validateOpen();
         recruitMemberService.addRecruitMember(applicationRequest, file);
 
         return ResponseEntity.ok(ApiResponse.ok(MEMBER_SAVE_SUCCESS));
     }
 
+    /** 증빙 파일도 지원의 일부다. 기간 밖에 업로드 URL 만 받아두는 길을 열어두지 않는다. */
     @PostMapping("/apply/proof-file/presigned-upload")
     public ResponseEntity<ApiResponse<PresignedUploadResponse, Void>> createProofFilePresignedUpload(
             @Valid @RequestBody ProofFilePresignedUploadRequest request
     ) {
+        recruitMemberPeriodService.validateOpen();
         PresignedUploadResponse response = recruitMemberService.createProofFilePresignedUpload(
                 request.fileName(),
                 request.contentType(),

--- a/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberPeriodResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberPeriodResponse.java
@@ -1,0 +1,16 @@
+package inha.gdgoc.domain.recruit.member.dto.response;
+
+import inha.gdgoc.domain.recruit.member.enums.RecruitMemberPeriodStatus;
+import java.time.Instant;
+
+/**
+ * 부원 모집 기간.
+ *
+ * <p>코어의 RecruitCorePeriodResponse 와 같은 모양이되 session 이 없다. 부원 모집은 회차 개념을 쓰지 않는다.
+ */
+public record RecruitMemberPeriodResponse(
+    Instant openAt,
+    Instant closeAt,
+    RecruitMemberPeriodStatus status
+) {
+}

--- a/src/main/java/inha/gdgoc/domain/recruit/member/enums/RecruitMemberPeriodStatus.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/enums/RecruitMemberPeriodStatus.java
@@ -1,0 +1,8 @@
+package inha.gdgoc.domain.recruit.member.enums;
+
+/** 코어의 RecruitCorePeriodStatus 와 같은 값이다. 화면이 두 모집을 같은 방식으로 다룰 수 있게 맞췄다. */
+public enum RecruitMemberPeriodStatus {
+    BEFORE_OPEN,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/inha/gdgoc/domain/recruit/member/exception/RecruitMemberErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/exception/RecruitMemberErrorCode.java
@@ -7,6 +7,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RecruitMemberErrorCode implements ErrorCode {
 
+    // 403 FORBIDDEN — 코어의 RECRUITMENT_NOT_OPEN·RECRUITMENT_CLOSED 와 같은 상태다.
+    RECRUIT_MEMBER_NOT_OPEN(HttpStatus.FORBIDDEN, "부원 모집 기간이 아직 시작되지 않았습니다."),
+    RECRUIT_MEMBER_CLOSED(HttpStatus.FORBIDDEN, "부원 모집 기간이 종료되었습니다."),
+
     // 409 CONFLICT
     RECRUIT_MEMBER_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 지원을 완료하였습니다."),
 

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodService.java
@@ -1,0 +1,101 @@
+package inha.gdgoc.domain.recruit.member.service;
+
+import inha.gdgoc.domain.recruit.member.dto.response.RecruitMemberPeriodResponse;
+import inha.gdgoc.domain.recruit.member.enums.RecruitMemberPeriodStatus;
+import inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 부원 모집 기간을 판정한다.
+ *
+ * <p>이 서비스가 생기기 전까지 부원 모집에는 기간 개념이 없었다. 화면은 상수로 일정을 적어 보여주기만 했고 서버는
+ * 언제든 지원을 받아, 오픈 전에도 지원이 됐다. 코어(RecruitCoreApplicationService)와 같은 방식으로 맞춘다.
+ *
+ * <p>시각과 기간을 모두 주입받는 이유도 코어와 같다. {@code Instant.now()} 를 직접 부르면 마감일이 지나는 순간
+ * 테스트가 무너지고 마감 동작을 검증할 방법이 없다. 기간을 코드에 박으면 다음 모집 때 배포가 필요하다.
+ *
+ * <p>Instant 가 아니라 String 으로 받는 이유: {@code Instant.parse()} 는 'Z' 형식만 받아 '+09:00' 을
+ * 거부한다. 설정에 KST 를 그대로 적을 수 있어야 오프셋 계산 실수가 안 난다.
+ */
+@Service
+public class RecruitMemberPeriodService {
+
+    private static final DateTimeFormatter KOREAN_DATE =
+        DateTimeFormatter.ofPattern("M월 d일 H시");
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final Instant openAt;
+    private final Instant closeAt;
+    private final Clock clock;
+
+    @Autowired
+    public RecruitMemberPeriodService(
+        @Value("${app.recruit.member.open-at}") String openAt,
+        @Value("${app.recruit.member.close-at}") String closeAt
+    ) {
+        this(
+            OffsetDateTime.parse(openAt).toInstant(),
+            OffsetDateTime.parse(closeAt).toInstant(),
+            Clock.system(KST));
+    }
+
+    public RecruitMemberPeriodService(Instant openAt, Instant closeAt, Clock clock) {
+        if (!openAt.isBefore(closeAt)) {
+            throw new IllegalArgumentException(
+                "app.recruit.member.open-at 은 close-at 보다 앞서야 한다: openAt=" + openAt
+                    + ", closeAt=" + closeAt);
+        }
+        this.openAt = openAt;
+        this.closeAt = closeAt;
+        this.clock = clock;
+    }
+
+    public RecruitMemberPeriodResponse getPeriod() {
+        return new RecruitMemberPeriodResponse(openAt, closeAt, getPeriodStatus());
+    }
+
+    public RecruitMemberPeriodStatus getPeriodStatus() {
+        Instant now = Instant.now(clock);
+        if (now.isBefore(openAt)) {
+            return RecruitMemberPeriodStatus.BEFORE_OPEN;
+        }
+        if (now.isAfter(closeAt)) {
+            return RecruitMemberPeriodStatus.CLOSED;
+        }
+        return RecruitMemberPeriodStatus.OPEN;
+    }
+
+    /**
+     * 기간 밖이면 막는다.
+     *
+     * <p>화면에서도 카드를 잠그지만 그건 안내일 뿐이다. 지원 API 는 인증 없이 열려 있어 주소를 직접 치면 그대로
+     * 들어온다 — 실제 차단은 여기서 한다.
+     */
+    public void validateOpen() {
+        RecruitMemberPeriodStatus status = getPeriodStatus();
+        if (status == RecruitMemberPeriodStatus.BEFORE_OPEN) {
+            throw new BusinessException(
+                RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_OPEN,
+                "부원 모집은 " + format(openAt) + "에 시작됩니다.");
+        }
+        if (status == RecruitMemberPeriodStatus.CLOSED) {
+            throw new BusinessException(
+                RecruitMemberErrorCode.RECRUIT_MEMBER_CLOSED,
+                "부원 모집이 " + format(closeAt) + "에 마감되었습니다.");
+        }
+    }
+
+    /** 오류 문구에 쓸 KST 표기. 보는 사람의 시간대와 무관하게 한국 시각으로 적는다. */
+    private String format(Instant instant) {
+        return ZonedDateTime.ofInstant(instant, KST).format(KOREAN_DATE);
+    }
+}

--- a/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
+++ b/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                     "/api/v1/recruit/member/check/**",
                     "/api/v1/recruit/member/memo",
                     "/api/v1/recruit/core/period",
+                    "/api/v1/recruit/member/period",
                     "/api/v1/fileupload",
                     "/api/v1/manito/verify")
                 .permitAll()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -73,6 +73,11 @@ app:
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
       open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
       close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
+    member:
+      # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
+      # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.
+      open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-08-17T00:00:00+09:00}
+      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2026-09-09T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -73,6 +73,11 @@ app:
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
       open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
       close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
+    member:
+      # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
+      # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.
+      open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-08-17T00:00:00+09:00}
+      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2026-09-09T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -73,6 +73,11 @@ app:
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
       open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
       close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
+    member:
+      # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
+      # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.
+      open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-08-17T00:00:00+09:00}
+      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2026-09-09T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodServiceTest.java
@@ -49,9 +49,18 @@ class RecruitMemberPeriodServiceTest {
     }
 
     @Test
+    @DisplayName("마감 시각 그 순간까지는 열려 있다")
+    void remainsOpenExactlyAtCloseAt() {
+        RecruitMemberPeriodService service = serviceAt("2026-09-09T14:59:59Z"); // KST 9/9 23:59:59
+
+        assertThat(service.getPeriodStatus()).isEqualTo(RecruitMemberPeriodStatus.OPEN);
+        assertThatCode(service::validateOpen).doesNotThrowAnyException();
+    }
+
+    @Test
     @DisplayName("마감 후에는 CLOSED 이고 지원이 막힌다")
     void afterCloseIsBlocked() {
-        RecruitMemberPeriodService service = serviceAt("2026-09-10T00:00:00Z");
+        RecruitMemberPeriodService service = serviceAt("2026-09-09T15:00:00Z"); // KST 9/10 00:00:00
 
         assertThat(service.getPeriodStatus()).isEqualTo(RecruitMemberPeriodStatus.CLOSED);
         assertThatThrownBy(service::validateOpen)

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodServiceTest.java
@@ -1,0 +1,81 @@
+package inha.gdgoc.domain.recruit.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inha.gdgoc.domain.recruit.member.enums.RecruitMemberPeriodStatus;
+import inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 부원 모집 기간 판정. 시각을 주입해 마감 전후를 실제로 검증한다. */
+class RecruitMemberPeriodServiceTest {
+
+    private static final Instant OPEN_AT =
+        OffsetDateTime.parse("2026-08-17T00:00:00+09:00").toInstant();
+    private static final Instant CLOSE_AT =
+        OffsetDateTime.parse("2026-09-09T23:59:59+09:00").toInstant();
+
+    private RecruitMemberPeriodService serviceAt(String isoInstant) {
+        Clock clock = Clock.fixed(Instant.parse(isoInstant), ZoneId.of("Asia/Seoul"));
+        return new RecruitMemberPeriodService(OPEN_AT, CLOSE_AT, clock);
+    }
+
+    @Test
+    @DisplayName("오픈 전에는 BEFORE_OPEN 이고 지원이 막힌다")
+    void beforeOpenIsBlocked() {
+        RecruitMemberPeriodService service = serviceAt("2026-08-16T14:59:59Z"); // KST 8/16 23:59:59
+
+        assertThat(service.getPeriodStatus()).isEqualTo(RecruitMemberPeriodStatus.BEFORE_OPEN);
+        assertThatThrownBy(service::validateOpen)
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_OPEN);
+    }
+
+    @Test
+    @DisplayName("오픈 시각이 되면 열린다")
+    void opensExactlyAtOpenAt() {
+        RecruitMemberPeriodService service = serviceAt("2026-08-16T15:00:00Z"); // KST 8/17 00:00:00
+
+        assertThat(service.getPeriodStatus()).isEqualTo(RecruitMemberPeriodStatus.OPEN);
+        assertThatCode(service::validateOpen).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("마감 후에는 CLOSED 이고 지원이 막힌다")
+    void afterCloseIsBlocked() {
+        RecruitMemberPeriodService service = serviceAt("2026-09-10T00:00:00Z");
+
+        assertThat(service.getPeriodStatus()).isEqualTo(RecruitMemberPeriodStatus.CLOSED);
+        assertThatThrownBy(service::validateOpen)
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(RecruitMemberErrorCode.RECRUIT_MEMBER_CLOSED);
+    }
+
+    @Test
+    @DisplayName("getPeriod 는 설정된 기간을 그대로 준다")
+    void periodExposesConfiguredWindow() {
+        RecruitMemberPeriodService service = serviceAt("2026-08-20T00:00:00Z");
+
+        assertThat(service.getPeriod().openAt()).isEqualTo(OPEN_AT);
+        assertThat(service.getPeriod().closeAt()).isEqualTo(CLOSE_AT);
+        assertThat(service.getPeriod().status()).isEqualTo(RecruitMemberPeriodStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("open 이 close 보다 뒤면 기동 시점에 막는다")
+    void invalidWindowIsRejected() {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-20T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+        assertThatThrownBy(() -> new RecruitMemberPeriodService(CLOSE_AT, OPEN_AT, clock))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -57,6 +57,10 @@ app:
       # 자기 상수로 검증하므로 여기 값이 무엇인지는 중요하지 않다.
       open-at: 2026-08-10T00:00:00+09:00
       close-at: 2026-08-30T23:59:59+09:00
+    member:
+      # 같은 이유의 고정값. 기간 동작은 RecruitMemberPeriodServiceTest 가 자기 상수로 검증한다.
+      open-at: 2026-08-17T00:00:00+09:00
+      close-at: 2026-09-09T23:59:59+09:00
 
 google:
   client-id: test-client-id


### PR DESCRIPTION
## 왜

일반 부원 모집 카드가 오픈일(8/17) 전인데도 열려 있었다. 코어 모집은 서버가 기간을 판정해 막고 있었지만 부원 쪽에는 그 로직 자체가 없었다. 화면 상수로 일정 문구만 보여줬을 뿐이라 지원 API 는 언제든 열려 있었다.

## 무엇을

코어와 같은 구조를 부원 쪽에 만들었다.

- `RecruitMemberPeriodService` — `app.recruit.member.open-at/close-at` 를 읽어 `BEFORE_OPEN` / `OPEN` / `CLOSED` 를 판정한다. `Clock` 을 주입받으므로 테스트가 시각을 고정할 수 있다.
- `GET /api/v1/recruit/member/period` (permitAll) — 화면이 카드 상태를 그리는 데 쓴다.
- `validateOpen()` 을 지원 관련 3개 엔드포인트 앞에 붙였다. 지원 제출 2개와 증빙 파일 presigned upload 다. **화면을 우회해도 막힌다.**
- 오픈 전이면 `RECRUIT_MEMBER_NOT_OPEN`, 마감 후면 `RECRUIT_MEMBER_CLOSED`. 둘 다 403 이고 메시지에 KST 시각이 들어간다.

`open-at` 이 `close-at` 보다 뒤면 생성자가 `IllegalArgumentException` 을 던진다. 환경변수를 잘못 넣으면 기동 시점에 죽는 편이 조용히 항상 닫혀 있는 것보다 낫다.

## 설정

기본값은 dev·prod·local 모두 `2026-08-17 00:00 KST` ~ `2026-09-09 23:59:59 KST` 이고 `RECRUIT_MEMBER_OPEN_AT` / `RECRUIT_MEMBER_CLOSE_AT` 로 덮을 수 있다.

**운영 상 알아둘 것:** 전에는 부원 모집이 "집중 기간 이후 상시 모집" 이라 서버 차단이 없었다. 이제 `close-at` 이 지나면 실제로 닫힌다. 상시로 두려면 `RECRUIT_MEMBER_CLOSE_AT` 을 뒤로 밀면 된다.

## 검증

`RecruitMemberPeriodServiceTest` 5건 — 오픈 직전 차단, 오픈 정각 통과, 마감 후 차단, `getPeriod` 노출값, 잘못된 기간 거부.

전체 스위트 128건 통과 (`failures=0 errors=0`).

## 배포 순서

**이 PR 이 먼저 dev 에 올라가야 한다.** Web 쪽 대응 PR 이 `/recruit/member/period` 를 호출한다. 순서가 뒤바뀌면 화면이 404 를 받아 `failed` 로 떨어지고 카드가 그냥 열린 상태로 보인다(제출은 서버가 막으므로 위험하진 않다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 부원 모집 기간과 현재 상태를 확인할 수 있는 API를 추가했습니다.
  * 모집 시작 전, 모집 중, 모집 종료 상태를 제공합니다.
  * 모집 기간이 열려 있을 때만 지원서 제출 및 증빙 파일 업로드를 진행할 수 있습니다.
  * 모집 기간 외 요청에는 상태에 맞는 안내 메시지를 표시합니다.

* **테스트**
  * 모집 기간별 상태와 지원 가능 여부 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->