### PR TITLE
fix: 코어 지원서 관리자 조회 첨부파일 S3 URL 변환

### DIFF
--- a/src/main/java/inha/gdgoc/domain/admin/recruit/core/service/RecruitCoreAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/admin/recruit/core/service/RecruitCoreAdminService.java
@@ -7,12 +7,14 @@ import inha.gdgoc.domain.admin.recruit.core.dto.response.RecruitCoreApplicationD
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCoreResultStatus;
 import inha.gdgoc.domain.recruit.core.repository.RecruitCoreApplicationRepository;
+import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.TeamType;
 import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecruitCoreAdminService {
 
     private final RecruitCoreApplicationRepository repository;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public Page<RecruitCoreApplication> searchApplications(
@@ -44,9 +47,28 @@ public class RecruitCoreAdminService {
         return repository.findAll(spec, pageable);
     }
 
+    // 저장된 fileUrls 는 S3 키다(웹이 presigned 업로드 후 key 를 보낸다).
+    // 키를 그대로 내려주면 대시보드의 링크가 상대 경로가 되어 첨부 파일이 열리지 않는다.
     @Transactional(readOnly = true)
     public RecruitCoreApplicantDetailResponse getApplicationDetail(Long applicationId) {
-        return RecruitCoreApplicantDetailResponse.from(getApplication(applicationId));
+        RecruitCoreApplication application = getApplication(applicationId);
+        return RecruitCoreApplicantDetailResponse.from(application, toS3FileUrls(application.getFileUrls()));
+    }
+
+    private List<String> toS3FileUrls(List<String> fileKeys) {
+        if (fileKeys == null || fileKeys.isEmpty()) {
+            return List.of();
+        }
+        return fileKeys.stream()
+            .map(this::toS3FileUrl)
+            .toList();
+    }
+
+    private String toS3FileUrl(String fileKey) {
+        if (fileKey.startsWith("http://") || fileKey.startsWith("https://")) {
+            return fileKey;
+        }
+        return s3Service.getS3FileUrl(fileKey);
     }
 
     @Transactional

--- a/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCoreApplicantDetailResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCoreApplicantDetailResponse.java
@@ -21,10 +21,8 @@ public record RecruitCoreApplicantDetailResponse(
     Instant updatedAt
 ) {
 
-    public static RecruitCoreApplicantDetailResponse from(RecruitCoreApplication entity) {
-        return from(entity, entity.getFileUrls());
-    }
-
+    // fileUrls 는 반드시 호출부에서 S3 URL 로 변환해 넘긴다.
+    // 엔티티에 저장된 값은 S3 키이므로, 그대로 내려주면 클라이언트에서 링크가 열리지 않는다.
     public static RecruitCoreApplicantDetailResponse from(RecruitCoreApplication entity, List<String> fileUrls) {
         return new RecruitCoreApplicantDetailResponse(
             entity.getId(),

--- a/src/test/java/inha/gdgoc/domain/admin/recruit/core/service/RecruitCoreAdminServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/admin/recruit/core/service/RecruitCoreAdminServiceTest.java
@@ -4,14 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import inha.gdgoc.domain.admin.recruit.core.dto.request.RecruitCoreApplicationAcceptRequest;
 import inha.gdgoc.domain.admin.recruit.core.dto.request.RecruitCoreApplicationRejectRequest;
 import inha.gdgoc.domain.admin.recruit.core.dto.response.RecruitCoreApplicationDecisionResponse;
+import inha.gdgoc.domain.recruit.core.dto.response.RecruitCoreApplicantDetailResponse;
 import inha.gdgoc.domain.recruit.core.entity.RecruitCoreApplication;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCoreResultStatus;
 import inha.gdgoc.domain.recruit.core.repository.RecruitCoreApplicationRepository;
+import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.TeamType;
 import inha.gdgoc.domain.user.enums.UserRole;
@@ -35,8 +38,40 @@ class RecruitCoreAdminServiceTest {
     @Mock
     private RecruitCoreApplicationRepository repository;
 
+    @Mock
+    private S3Service s3Service;
+
     @InjectMocks
     private RecruitCoreAdminService adminService;
+
+    // 관리자 상세 조회가 S3 키를 그대로 내려주면 대시보드의 <a href> 가 상대 경로가 되어
+    // 첨부 파일이 열리지 않는다. 본인 조회(RecruitCoreApplicationService) 는 변환하는데
+    // 관리자 경로만 빠져 있었다.
+    @Test
+    void getApplicationDetail_convertsS3KeyToUrl() {
+        String key = "user/12/recruitCore/3f9a-resume.pdf";
+        String url = "https://bucket.s3.ap-northeast-2.amazonaws.com/" + key;
+        RecruitCoreApplication application = createApplication(300L, createUser(1L), List.of(key));
+        when(repository.findById(300L)).thenReturn(Optional.of(application));
+        when(s3Service.getS3FileUrl(key)).thenReturn(url);
+
+        RecruitCoreApplicantDetailResponse response = adminService.getApplicationDetail(300L);
+
+        assertThat(response.fileUrls()).containsExactly(url);
+    }
+
+    // 이미 완전한 URL 로 저장된 과거 데이터는 다시 감싸지 않는다.
+    @Test
+    void getApplicationDetail_keepsAbsoluteUrlAsIs() {
+        String url = "https://cdn.example.com/legacy.pdf";
+        RecruitCoreApplication application = createApplication(301L, createUser(1L), List.of(url));
+        when(repository.findById(301L)).thenReturn(Optional.of(application));
+
+        RecruitCoreApplicantDetailResponse response = adminService.getApplicationDetail(301L);
+
+        assertThat(response.fileUrls()).containsExactly(url);
+        verifyNoInteractions(s3Service);
+    }
 
     @Test
     void searchApplications_buildsSpecificationAndDelegates() {
@@ -107,6 +142,10 @@ class RecruitCoreAdminServiceTest {
     }
 
     private RecruitCoreApplication createApplication(Long id, User user) {
+        return createApplication(id, user, List.of());
+    }
+
+    private RecruitCoreApplication createApplication(Long id, User user, List<String> fileUrls) {
         RecruitCoreApplication application = RecruitCoreApplication.builder()
             .user(user)
             .session("2026-1")
@@ -120,7 +159,7 @@ class RecruitCoreAdminServiceTest {
             .wish("wish")
             .strengths("strengths")
             .pledge("pledge")
-            .fileUrls(List.of())
+            .fileUrls(fileUrls)
             .resultStatus(RecruitCoreResultStatus.SUBMITTED)
             .build();
         setId(application, id);


### PR DESCRIPTION
## 배경

내일(8/10) 코어 모집이 열리는데, 관리자 대시보드에서 지원서 첨부파일이 열리지 않는 문제가 있었다.

## 원인

`RecruitCoreAdminService#getApplicationDetail` 만 `fileUrls` 를 S3 **키** 그대로 반환했다.
지원 시 웹은 presigned 업로드 후 key 를 보내므로 DB 에는 키가 저장된다.
그래서 대시보드의 `<a href>` 가 상대 경로가 되어 링크가 깨졌다.

본인 조회(`getApplicantDetailForViewer`)와 부원 모집(`normalizeProofFileUrl`)은 이미 변환하고 있었고, 관리자 경로만 빠져 있었다.

## 변경

- `RecruitCoreAdminService` 에 `S3Service` 주입 후 키 → URL 변환
- 변환을 건너뛰던 1-인자 `RecruitCoreApplicantDetailResponse.from(entity)` 오버로드 제거 (같은 실수 재발 방지)
- 재현 테스트 2건 추가 (키 변환 / 이미 절대 URL 인 값은 그대로)

## 검증

- 재현 테스트 실패 확인 → 수정 → 통과
- `./gradlew cleanTest test` **131건 전부 통과, 실패 0**
- 개발 서버 배포 반영 확인 (`/board/events` 200, `/auth/login` 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHxirdfnN9Wxrt9UHzBqVd