### PR TITLE
release: 코어 일정 정정 · 부원 학기 필터 · Y26_2 학기 상수 추가

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
@@ -21,6 +21,7 @@ import inha.gdgoc.domain.recruit.member.dto.response.CheckStudentIdResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.RecruitMemberPeriodResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.RecruitMemberSummaryResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.SpecifiedMemberResponse;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
 import inha.gdgoc.domain.resource.dto.response.PresignedUploadResponse;
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
 import inha.gdgoc.domain.recruit.member.service.RecruitMemberPeriodService;
@@ -207,6 +208,9 @@ public class RecruitMemberController {
             @Parameter(description = "검색어(이름 부분 일치). 없으면 전체 조회", example = "소연")
             @RequestParam(required = false) String question,
 
+            @Parameter(description = "지원 학기. 없으면 전체 조회", example = "Y26_2")
+            @RequestParam(required = false) AdmissionSemester admissionSemester,
+
             @Parameter(description = "페이지(0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") int page,
 
@@ -222,9 +226,8 @@ public class RecruitMemberController {
         Direction direction = "ASC".equalsIgnoreCase(dir) ? Direction.ASC : Direction.DESC;
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sort));
 
-        Page<RecruitMember> memberPage = (question == null || question.isBlank())
-                ? recruitMemberService.findAllMembersPage(pageable)
-                : recruitMemberService.searchMembersByNamePage(question, pageable);
+        Page<RecruitMember> memberPage =
+                recruitMemberService.searchMembers(question, admissionSemester, pageable);
 
         List<RecruitMemberSummaryResponse> list = memberPage
                 .map(RecruitMemberSummaryResponse::from)

--- a/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberSummaryResponse.java
@@ -1,6 +1,7 @@
 package inha.gdgoc.domain.recruit.member.dto.response;
 
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
 
 public record RecruitMemberSummaryResponse(
         Long id,
@@ -8,6 +9,9 @@ public record RecruitMemberSummaryResponse(
         String phoneNumber,
         String major,
         String studentId,
+        // 목록에서 학기를 걸러 볼 수 있어야 필터 결과를 확인할 수 있다.
+        // 웹은 전부터 이 필드를 읽고 있었으나 서버가 내려주지 않아 항상 비어 있었다.
+        AdmissionSemester admissionSemester,
         Boolean isPayed
 ) {
 
@@ -18,6 +22,7 @@ public record RecruitMemberSummaryResponse(
                 recruitMember.getPhoneNumber(),
                 recruitMember.getMajor(),
                 recruitMember.getStudentId(),
+                recruitMember.getAdmissionSemester(),
                 recruitMember.getIsPayed()
         );
     }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/enums/AdmissionSemester.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/enums/AdmissionSemester.java
@@ -1,5 +1,13 @@
 package inha.gdgoc.domain.recruit.member.enums;
 
+/**
+ * 지원 시점의 학기. {@link inha.gdgoc.global.util.SemesterCalculator} 가 현재 날짜로 계산해
+ * 이 enum 에서 상수를 찾는다.
+ *
+ * <p><b>상수가 없으면 지원서 제출과 메모 발송이 런타임에 실패한다.</b> 실제로 Y26_2 가 빠져 있어
+ * 2026-08 부터 그 상태였다. 미래 학기를 미리 채워 두는 이유다 — 해가 바뀌기 전에 이어서 추가한다.
+ */
 public enum AdmissionSemester {
-    Y21_2, Y22_1, Y22_2, Y23_1, Y23_2, Y24_1, Y24_2, Y25_1, Y25_2, Y26_1
+    Y21_2, Y22_1, Y22_2, Y23_1, Y23_2, Y24_1, Y24_2, Y25_1, Y25_2, Y26_1,
+    Y26_2, Y27_1, Y27_2, Y28_1, Y28_2, Y29_1, Y29_2
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
@@ -2,12 +2,11 @@ package inha.gdgoc.domain.recruit.member.repository;
 
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface RecruitMemberRepository extends JpaRepository<RecruitMember, Long> {
+public interface RecruitMemberRepository
+        extends JpaRepository<RecruitMember, Long>, JpaSpecificationExecutor<RecruitMember> {
     boolean existsByStudentId(String studentId);
     boolean existsByPhoneNumber(String phoneNumber);
     boolean existsByEmailIgnoreCase(String email);
-    Page<RecruitMember> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
@@ -18,6 +18,7 @@ import inha.gdgoc.domain.recruit.member.dto.response.CheckStudentIdResponse;
 import inha.gdgoc.domain.recruit.member.dto.response.SpecifiedMemberResponse;
 import inha.gdgoc.domain.recruit.member.entity.Answer;
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
 import inha.gdgoc.domain.recruit.member.enums.InputType;
 import inha.gdgoc.domain.recruit.member.enums.SurveyType;
 import inha.gdgoc.domain.recruit.member.exception.RecruitMemberException;
@@ -32,6 +33,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -168,14 +170,31 @@ public class RecruitMemberService {
         else m.markUnpaid();
     }
 
+    /**
+     * 이름 검색과 지원 학기를 조합해 조회한다. 둘 다 선택이며 없으면 전체를 본다.
+     *
+     * <p>조건이 늘 때마다 쿼리 메서드가 조합 수만큼 불어나므로 Specification 으로 둔다.
+     * 관리자 코어 지원서 조회(RecruitCoreAdminService)와 같은 방식이다.
+     */
     @Transactional(readOnly = true)
-    public Page<RecruitMember> findAllMembersPage(Pageable pageable) {
-        return recruitMemberRepository.findAll(pageable);
-    }
+    public Page<RecruitMember> searchMembers(
+            String name,
+            AdmissionSemester admissionSemester,
+            Pageable pageable
+    ) {
+        Specification<RecruitMember> spec = (root, query, builder) -> builder.conjunction();
 
-    @Transactional(readOnly = true)
-    public Page<RecruitMember> searchMembersByNamePage(String name, Pageable pageable) {
-        return recruitMemberRepository.findByNameContainingIgnoreCase(name, pageable);
+        if (name != null && !name.isBlank()) {
+            String keyword = "%" + name.trim().toLowerCase() + "%";
+            spec = spec.and((root, query, builder) ->
+                    builder.like(builder.lower(root.get("name")), keyword));
+        }
+        if (admissionSemester != null) {
+            spec = spec.and((root, query, builder) ->
+                    builder.equal(root.get("admissionSemester"), admissionSemester));
+        }
+
+        return recruitMemberRepository.findAll(spec, pageable);
     }
 
     private String normalizePhoneNumber(String phoneNumber) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -68,16 +68,18 @@ app:
   mail:
     recruit-from: ${APP_MAIL_RECRUIT_FROM:}
   recruit:
+    # 개발 서버는 지원 흐름을 아무 때나 눌러볼 수 있도록 상시 열어 둔다.
+    # 운영 일정은 application-prod.yml 이 따로 들고 있으므로 여기 값은 운영에 영향이 없다.
     core:
       # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
-      open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
-      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
+      open-at: ${RECRUIT_CORE_OPEN_AT:2026-01-01T00:00:00+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2027-12-31T23:59:59+09:00}
     member:
       # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
       # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.
-      open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-08-17T00:00:00+09:00}
-      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2026-09-09T23:59:59+09:00}
+      open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-01-01T00:00:00+09:00}
+      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2027-12-31T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -72,7 +72,7 @@ app:
       # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
       open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
-      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-23T23:59:59+09:00}
     member:
       # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
       # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberSemesterFilterTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberSemesterFilterTest.java
@@ -1,0 +1,96 @@
+package inha.gdgoc.domain.recruit.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
+import inha.gdgoc.domain.recruit.member.enums.EnrolledClassification;
+import inha.gdgoc.domain.recruit.member.enums.Gender;
+import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 부원 지원자 목록의 학기·이름 필터를 실제 조회로 검증한다.
+ *
+ * <p>전에는 전체 조회와 이름 검색뿐이라 역대 지원자가 한 목록에 섞여 나왔다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class RecruitMemberSemesterFilterTest {
+
+    private static final Pageable PAGE = PageRequest.of(0, 20);
+
+    @Autowired
+    private RecruitMemberService recruitMemberService;
+
+    @Autowired
+    private RecruitMemberRepository recruitMemberRepository;
+
+    @BeforeEach
+    void setUp() {
+        recruitMemberRepository.deleteAll();
+        recruitMemberRepository.save(member("김가나", "12200001", "01000000001", AdmissionSemester.Y26_2));
+        recruitMemberRepository.save(member("이다라", "12200002", "01000000002", AdmissionSemester.Y26_2));
+        recruitMemberRepository.save(member("김마바", "12200003", "01000000003", AdmissionSemester.Y26_1));
+    }
+
+    @Test
+    void 학기로_거르면_그_학기_지원자만_나온다() {
+        Page<RecruitMember> result =
+            recruitMemberService.searchMembers(null, AdmissionSemester.Y26_2, PAGE);
+
+        assertThat(result.getContent())
+            .extracting(RecruitMember::getName)
+            .containsExactlyInAnyOrder("김가나", "이다라");
+    }
+
+    @Test
+    void 이름과_학기를_함께_주면_둘_다_만족하는_지원자만_나온다() {
+        Page<RecruitMember> result =
+            recruitMemberService.searchMembers("김", AdmissionSemester.Y26_2, PAGE);
+
+        assertThat(result.getContent())
+            .extracting(RecruitMember::getName)
+            .containsExactly("김가나");
+    }
+
+    // 필터를 안 주면 예전과 똑같이 전체가 나와야 한다. 기존 화면이 깨지지 않는지 확인한다.
+    @Test
+    void 필터가_없으면_전체가_나온다() {
+        Page<RecruitMember> result = recruitMemberService.searchMembers(null, null, PAGE);
+
+        assertThat(result.getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    void 빈_검색어는_이름_조건으로_치지_않는다() {
+        Page<RecruitMember> result = recruitMemberService.searchMembers("   ", null, PAGE);
+
+        assertThat(result.getTotalElements()).isEqualTo(3);
+    }
+
+    private RecruitMember member(String name, String studentId, String phone, AdmissionSemester semester) {
+        return RecruitMember.builder()
+            .name(name)
+            .studentId(studentId)
+            .enrolledClassification(EnrolledClassification.FULL_REGISTRATION)
+            .phoneNumber(phone)
+            .email(studentId + "@inha.edu")
+            .gender(Gender.PRIVATE)
+            .birth(LocalDate.of(2003, 3, 1))
+            .major("CSE")
+            .isPayed(false)
+            .admissionSemester(semester)
+            .build();
+    }
+}

--- a/src/test/java/inha/gdgoc/global/util/SemesterCalculatorTest.java
+++ b/src/test/java/inha/gdgoc/global/util/SemesterCalculatorTest.java
@@ -1,0 +1,43 @@
+package inha.gdgoc.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class SemesterCalculatorTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private SemesterCalculator at(String isoInstant) {
+        return new SemesterCalculator(Clock.fixed(Instant.parse(isoInstant), KST));
+    }
+
+    @Test
+    void 상반기_7월까지는_1학기다() {
+        assertThat(at("2026-07-01T03:00:00Z").currentSemester())
+            .isEqualTo(AdmissionSemester.Y26_1);
+    }
+
+    // 부원 모집 오픈일(2026-08-17 KST). 8월은 2학기로 계산되어 Y26_2 를 찾는다.
+    // enum 에 상수가 없으면 여기서 RuntimeException 이 나고 지원서 제출이 통째로 실패한다.
+    @Test
+    void 부원_모집_오픈일에_학기계산이_성공해야_한다() {
+        assertThatCode(() -> at("2026-08-16T15:00:00Z").currentSemester())
+            .doesNotThrowAnyException();
+
+        assertThat(at("2026-08-16T15:00:00Z").currentSemester())
+            .isEqualTo(AdmissionSemester.Y26_2);
+    }
+
+    // 1월은 직전 해의 2학기로 친다. 해가 바뀔 때 상수가 비면 같은 사고가 난다.
+    @Test
+    void 이듬해_1월은_직전_해_2학기다() {
+        assertThat(at("2026-12-31T15:00:00Z").currentSemester())
+            .isEqualTo(AdmissionSemester.Y26_2);
+    }
+}


### PR DESCRIPTION
## 포함 커밋

| 커밋 | 내용 | 급한 정도 |
|---|---|---|
| `ffd28b4` | `AdmissionSemester` 에 `Y26_2`~`Y29_2` 추가 | **8/17 전 필수** |
| `44c5a07` | 개발 서버 모집 기간 상시 개방 (`application-dev.yml`) | 운영 무영향 |
| `12a1ef4` | 코어 서류 마감 8/30 → **8/23** 정정 | 8/10 전 |
| `81beeb2` | 부원 지원자 목록 학기 필터 | - |

## Y26_2 누락 (가장 급한 건)

`SemesterCalculator` 는 8월을 2학기로 계산해 `Y26_2` 를 찾는데 enum 에 상수가 없어
`RuntimeException` 이 났다.

- 메모 발송은 2026-08 부터 이미 실패 상태였다
- 부원 지원서 제출은 기간 게이트에 가려져 있었을 뿐, **8/17 모집이 열리는 순간 전부 500** 이 날 상황이었다

코어 모집은 `RecruitCoreSessionResolver` 가 문자열을 직접 만들어 이 enum 을 쓰지 않으므로 영향이 없다.

## 코어 일정 정정

확정 일정: 서류 8/10(월)~**8/23(일)**, 서류 결과 8/23(일), 면접 8/24(월)~8/30(일), 최종 8/31(월).
서버가 들고 있던 마감 8/30 은 면접 종료일이었다. 웹 `recruitSchedule.ts` 도 같은 작업에서 맞췄다.

## 부원 학기 필터

역대 지원자가 한 목록에 섞여 나왔다. `admissionSemester` 파라미터를 추가하고 이름·학기를
`Specification` 으로 조합한다. 목록 응답에 `admissionSemester` 도 실었다 — 웹은 전부터 이
필드를 읽고 있었으나 서버가 주지 않아 늘 비어 있었다.

## dev 기간 개방

`application-dev.yml` 만 바꿨다. 운영은 `application-prod.yml` 을 쓰므로 모집 일정에 영향이 없다.

## 검증

- `./gradlew cleanTest test` **138건 전부 통과, 실패 0**
- 개발 서버 배포·반영 확인 (`/board/events` 200, `/auth/login` 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHxirdfnN9Wxrt9UHzBqVd