### PR TITLE
코어 모집 마감을 9/8 로 연장

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -72,7 +72,7 @@ app:
       # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
       open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
-      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-30T23:59:59+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-09-08T23:59:59+09:00}
     member:
       # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
       # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -72,7 +72,7 @@ app:
       # 모집 기간. 코드가 아니라 여기서 바꾼다 — 2차 모집은 환경변수만 고치면 된다.
       # KST 오프셋을 그대로 쓴다 (OffsetDateTime.parse 로 읽는다).
       open-at: ${RECRUIT_CORE_OPEN_AT:2026-08-10T00:00:00+09:00}
-      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-08-23T23:59:59+09:00}
+      close-at: ${RECRUIT_CORE_CLOSE_AT:2026-09-08T23:59:59+09:00}
     member:
       # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
       # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.


### PR DESCRIPTION
## 요약

코어 모집 서류 지원 마감을 `2026-08-23` 에서 `2026-09-08 23:59:59` (KST) 로 미룬다.

변경된 코어 모집 일정 전체:

```
서류 모집   8. 10.(월) - 9. 8.(화)
서류 결과   9. 8.(화) 23:59
면접 진행   9. 9.(수) - 9. 13.(일)
최종 발표   9. 13.(일)
```

## 변경 범위

`application-prod.yml` 과 `application-local.yml` 의 `app.recruit.core.close-at` 만 바꾼다.

**`application-dev.yml` 은 건드리지 않는다.** 현재 값이 `2026-01-01 ~ 2027-12-31` 로, 실제 일정이 아니라 개발 중 지원 흐름을 막지 않으려고 넓게 열어 둔 값이다. 여기에 실제 일정을 넣으면 dev 테스트가 막힌다.

부원 모집(`app.recruit.member.*`)은 이번 변경 대상이 아니다.

## 서버 밖에서 함께 바뀌는 것

서류 결과 발표·면접 기간·최종 발표 날짜는 **서버가 갖고 있지 않다.** 웹의 `src/constant/recruitSchedule.ts` 가 유일한 출처라 그쪽도 같은 작업에서 고쳤다(별도 PR). 서버만 배포하면 게이팅은 9/8 로 늘어나지만 화면의 면접·발표 날짜는 8월로 남는다.

## 배포 후 확인

```bash
curl -s "https://api.gdgocinha.com/api/v1/recruit/core/period"
```

`closeAt` 이 `2026-09-08T14:59:59Z` (KST 9/8 23:59:59) 이면 반영된 것이다. 운영은 환경변수 오버라이드 없이 yml 기본값을 쓰는 것을 확인했다.

머지 시 CodeDeploy 가 도는 동안 다운타임이 있다(`docker-compose down` → `up`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KqZ35KmwzfReH9eCNnSEE