### PR TITLE
release: 부원 상시 모집 · 이메일당 학기 1회 제한 · 마이페이지 지원서 조회

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCoreApplicantDetailResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCoreApplicantDetailResponse.java
@@ -24,6 +24,21 @@ public record RecruitCoreApplicantDetailResponse(
     // fileUrls 는 반드시 호출부에서 S3 URL 로 변환해 넘긴다.
     // 엔티티에 저장된 값은 S3 키이므로, 그대로 내려주면 클라이언트에서 링크가 열리지 않는다.
     public static RecruitCoreApplicantDetailResponse from(RecruitCoreApplication entity, List<String> fileUrls) {
+        return from(entity, fileUrls, true);
+    }
+
+    /**
+     * {@code includeReview} 가 false 면 검토 정보를 뺀다.
+     *
+     * <p>지원자 본인도 이 DTO 로 자기 지원서를 본다(마이페이지). 검토자 ID 와 내부 메모는
+     * 합격/불합격 판단 근거라 지원자에게 보일 값이 아니다. 화면에서 안 그리는 것만으로는
+     * 부족하다 — 응답에 실려 나가면 개발자 도구로 그대로 읽힌다.
+     */
+    public static RecruitCoreApplicantDetailResponse from(
+        RecruitCoreApplication entity,
+        List<String> fileUrls,
+        boolean includeReview
+    ) {
         return new RecruitCoreApplicantDetailResponse(
             entity.getId(),
             entity.getSession(),
@@ -35,7 +50,7 @@ public record RecruitCoreApplicantDetailResponse(
             entity.getPledge(),
             fileUrls,
             entity.getResultStatus(),
-            RecruitCoreApplicationReviewResponse.from(entity),
+            includeReview ? RecruitCoreApplicationReviewResponse.from(entity) : null,
             entity.getCreatedAt(),
             entity.getUpdatedAt()
         );

--- a/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
@@ -179,7 +179,8 @@ public class RecruitCoreApplicationService {
         if (!privileged && !application.isOwnedBy(viewerId)) {
             throw new BusinessException(GlobalErrorCode.FORBIDDEN_USER);
         }
-        return RecruitCoreApplicantDetailResponse.from(application, toS3FileUrls(application.getFileUrls()));
+        return RecruitCoreApplicantDetailResponse.from(
+            application, toS3FileUrls(application.getFileUrls()), privileged);
     }
 
     private List<String> toS3FileUrls(List<String> fileKeys) {

--- a/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
@@ -26,6 +26,7 @@ import inha.gdgoc.domain.resource.dto.response.PresignedUploadResponse;
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
 import inha.gdgoc.domain.recruit.member.service.RecruitMemberPeriodService;
 import inha.gdgoc.domain.recruit.member.service.RecruitMemberService;
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
 import inha.gdgoc.global.dto.response.ApiResponse;
 import inha.gdgoc.global.dto.response.PageMeta;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,6 +47,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -162,6 +164,22 @@ public class RecruitMemberController {
         CheckEmailResponse response = recruitMemberService.isRegisteredEmail(request.getEmail());
 
         return ResponseEntity.ok(ApiResponse.ok(EMAIL_DUPLICATION_CHECK_SUCCESS, response));
+    }
+
+    /**
+     * 마이페이지에서 본인 지원서를 연다.
+     *
+     * <p>{@code /{memberId}} 보다 먼저 둔다. 세그먼트 수가 달라 충돌하지는 않지만 읽는 순서를 맞춘다.
+     */
+    @Operation(summary = "나의 부원 지원서 조회", security = {@SecurityRequirement(name = "BearerAuth")})
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/applications/me")
+    public ResponseEntity<ApiResponse<SpecifiedMemberResponse, Void>> getMyApplication(
+            @AuthenticationPrincipal CustomUserDetails me
+    ) {
+        SpecifiedMemberResponse response = recruitMemberService.findMyApplication(me.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.ok(MEMBER_RETRIEVED_SUCCESS, response));
     }
 
     @Operation(summary = "특정 멤버 가입 신청서 조회", security = {@SecurityRequirement(name = "BearerAuth")})

--- a/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/SpecifiedMemberResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/SpecifiedMemberResponse.java
@@ -3,10 +3,12 @@ package inha.gdgoc.domain.recruit.member.dto.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inha.gdgoc.domain.recruit.member.entity.Answer;
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
 import java.util.List;
 import java.time.Instant;
 
 public record SpecifiedMemberResponse(
+        Long id,
         String name,
         String enrolledClassification,
         String phoneNumber,
@@ -15,6 +17,7 @@ public record SpecifiedMemberResponse(
         String birth,
         String major,
         String studentId,
+        AdmissionSemester admissionSemester,
         boolean isPayed,
         Instant createdAt,
         Instant updatedAt,
@@ -27,6 +30,7 @@ public record SpecifiedMemberResponse(
             ObjectMapper objectMapper
     ) {
         return new SpecifiedMemberResponse(
+                member.getId(),
                 member.getName(),
                 member.getEnrolledClassification() != null ? member.getEnrolledClassification().name() : null,
                 member.getPhoneNumber(),
@@ -35,6 +39,7 @@ public record SpecifiedMemberResponse(
                 member.getBirth() != null ? member.getBirth().toString() : null,
                 member.getMajor(),
                 member.getStudentId(),
+                member.getAdmissionSemester(),
                 Boolean.TRUE.equals(member.getIsPayed()),
                 member.getCreatedAt(),
                 member.getUpdatedAt(),

--- a/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
@@ -1,6 +1,8 @@
 package inha.gdgoc.domain.recruit.member.repository;
 
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -9,4 +11,16 @@ public interface RecruitMemberRepository
     boolean existsByStudentId(String studentId);
     boolean existsByPhoneNumber(String phoneNumber);
     boolean existsByEmailIgnoreCase(String email);
+
+    /** 학기당 이메일 1회 제한. 코어의 {@code findByUserIdAndSession} 과 같은 역할이다. */
+    boolean existsByEmailIgnoreCaseAndAdmissionSemester(String email, AdmissionSemester admissionSemester);
+
+    /**
+     * 마이페이지에서 본인 지원서를 찾을 때 쓴다.
+     *
+     * <p>부원 지원은 비로그인으로 받으므로 계정과 지원서를 잇는 키가 이메일뿐이다.
+     * 로그인(@inha.edu 전용)과 지원 폼(도메인 @inha.edu 고정)이 같은 도메인이라 성립한다.
+     * 학기를 안 거는 이유는 지난 학기 지원서도 본인 것이면 보여야 하기 때문이다.
+     */
+    Optional<RecruitMember> findTopByEmailIgnoreCaseOrderByCreatedAtDesc(String email);
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
@@ -25,6 +25,10 @@ import inha.gdgoc.domain.recruit.member.exception.RecruitMemberException;
 import inha.gdgoc.domain.recruit.member.repository.AnswerRepository;
 import inha.gdgoc.domain.recruit.member.repository.RecruitMemberMemoRepository;
 import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
 import inha.gdgoc.global.util.SemesterCalculator;
 import inha.gdgoc.global.util.MajorNormalizer;
 import java.util.HashMap;
@@ -45,6 +49,7 @@ public class RecruitMemberService {
 
     private final RecruitMemberRepository recruitMemberRepository;
     private final RecruitMemberMemoRepository recruitMemberMemoRepository;
+    private final UserRepository userRepository;
     private final AnswerRepository answerRepository;
     private final ObjectMapper objectMapper;
     private final SemesterCalculator semesterCalculator;
@@ -72,8 +77,10 @@ public class RecruitMemberService {
         }
         normalizeProofFileUrl(answers);
 
-        RecruitMember member = memberRequest
-                .toEntity(semesterCalculator.currentSemester(), majorNormalizer);
+        AdmissionSemester semester = semesterCalculator.currentSemester();
+        validateNotAppliedThisSemester(memberRequest.getEmail(), semester);
+
+        RecruitMember member = memberRequest.toEntity(semester, majorNormalizer);
         recruitMemberRepository.save(member);
 
         List<Answer> answerEntities = answers.entrySet().stream()
@@ -153,10 +160,47 @@ public class RecruitMemberService {
     public SpecifiedMemberResponse findSpecifiedMember(Long id) {
         RecruitMember member = recruitMemberRepository.findById(id)
                 .orElseThrow(() -> new RecruitMemberException(RECRUIT_MEMBER_NOT_FOUND));
+
+        return toSpecifiedMemberResponse(member);
+    }
+
+    /**
+     * 로그인 사용자가 낸 부원 지원서를 돌려준다. 마이페이지에서 쓴다.
+     *
+     * <p>부원 지원은 비로그인으로 받아 계정과 이어지는 컬럼이 없다. 이메일이 유일한 연결 고리이며,
+     * 로그인은 @inha.edu 계정만, 지원 폼의 도메인도 @inha.edu 고정이라 이 매칭이 성립한다.
+     */
+    @Transactional(readOnly = true)
+    public SpecifiedMemberResponse findMyApplication(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+        RecruitMember member = recruitMemberRepository
+                .findTopByEmailIgnoreCaseOrderByCreatedAtDesc(user.getEmail().trim())
+                .orElseThrow(() -> new RecruitMemberException(RECRUIT_MEMBER_NOT_FOUND));
+
+        return toSpecifiedMemberResponse(member);
+    }
+
+    private SpecifiedMemberResponse toSpecifiedMemberResponse(RecruitMember member) {
         List<Answer> answers = answerRepository
                 .findByRecruitMemberAndSurveyType(member, SurveyType.RECRUIT);
 
         return SpecifiedMemberResponse.from(member, answers, objectMapper);
+    }
+
+    /**
+     * 이메일당 학기 1회. 코어의 {@code findByUserIdAndSession} 검사와 같은 규칙이다.
+     *
+     * <p>화면에서도 중복 확인 버튼으로 걸러내지만 그건 안내일 뿐이다. 지원 API 는 인증 없이 열려 있어
+     * 주소를 직접 치면 그대로 들어온다 — 실제 차단은 여기서 한다.
+     */
+    private void validateNotAppliedThisSemester(String email, AdmissionSemester semester) {
+        if (email == null || email.isBlank()) {
+            return;
+        }
+        if (recruitMemberRepository.existsByEmailIgnoreCaseAndAdmissionSemester(email.trim(), semester)) {
+            throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
+        }
     }
 
     @Transactional

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -75,9 +75,17 @@ app:
       close-at: ${RECRUIT_CORE_CLOSE_AT:2026-09-08T23:59:59+09:00}
     member:
       # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
-      # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.
+      # 오픈 전에도 지원이 됐다.
+      #
+      # 부원은 코어와 달리 **상시 모집**이다. 그래서 close-at 은 2026-2 학기가 끝나는 날까지
+      # 열어 둔다. 웹이 카드에 보여주는 '집중 모집 기간'(8/17 ~ 9/9)은 이 값이 아니라
+      # 웹 상수 src/constant/recruitSchedule.ts 의 MEMBER_SCHEDULE 이 출처다 — 표시 전용이며
+      # 게이팅과 무관하다. 일정이 바뀌면 그쪽도 함께 고친다.
+      #
+      # 2027-02-01 을 넘기면 SemesterCalculator 가 Y27_1 을 돌려주므로, 이번 학기 지원서를
+      # 한 학기로 모으려면 1월 말이 마지노선이다.
       open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-08-17T00:00:00+09:00}
-      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2026-09-09T23:59:59+09:00}
+      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2027-01-31T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -75,9 +75,17 @@ app:
       close-at: ${RECRUIT_CORE_CLOSE_AT:2026-09-08T23:59:59+09:00}
     member:
       # 부원 모집 기간. 코어와 같은 방식으로 서버가 판정한다 — 전에는 기간 개념이 없어
-      # 오픈 전에도 지원이 됐다. 웹의 src/constant/recruitSchedule.ts 와 값을 맞춘다.
+      # 오픈 전에도 지원이 됐다.
+      #
+      # 부원은 코어와 달리 **상시 모집**이다. 그래서 close-at 은 2026-2 학기가 끝나는 날까지
+      # 열어 둔다. 웹이 카드에 보여주는 '집중 모집 기간'(8/17 ~ 9/9)은 이 값이 아니라
+      # 웹 상수 src/constant/recruitSchedule.ts 의 MEMBER_SCHEDULE 이 출처다 — 표시 전용이며
+      # 게이팅과 무관하다. 일정이 바뀌면 그쪽도 함께 고친다.
+      #
+      # 2027-02-01 을 넘기면 SemesterCalculator 가 Y27_1 을 돌려주므로, 이번 학기 지원서를
+      # 한 학기로 모으려면 1월 말이 마지노선이다.
       open-at: ${RECRUIT_MEMBER_OPEN_AT:2026-08-17T00:00:00+09:00}
-      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2026-09-09T23:59:59+09:00}
+      close-at: ${RECRUIT_MEMBER_CLOSE_AT:2027-01-31T23:59:59+09:00}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationServiceTest.java
@@ -181,6 +181,33 @@ class RecruitCoreApplicationServiceTest {
         assertThat(detail.applicationId()).isEqualTo(99L);
     }
 
+    // 본인도 자기 지원서를 마이페이지에서 연다. 검토자·내부 메모까지 실어 보내면
+    // 화면에서 안 그려도 개발자 도구로 읽힌다.
+    @Test
+    void getApplicantDetailForViewer_whenOwner_hidesReview() {
+        RecruitCoreApplication application = createApplication(99L, createUser(1L), SESSION);
+        ReflectionTestUtils.setField(application, "reviewedBy", 7L);
+        ReflectionTestUtils.setField(application, "resultNote", "면접 태도 미흡");
+        when(repository.findById(99L)).thenReturn(Optional.of(application));
+
+        RecruitCoreApplicantDetailResponse detail =
+            service.getApplicantDetailForViewer(99L, 1L, UserRole.MEMBER);
+
+        assertThat(detail.review()).isNull();
+    }
+
+    @Test
+    void getApplicantDetailForViewer_whenPrivileged_keepsReview() {
+        RecruitCoreApplication application = createApplication(99L, createUser(2L), SESSION);
+        ReflectionTestUtils.setField(application, "resultNote", "면접 태도 미흡");
+        when(repository.findById(99L)).thenReturn(Optional.of(application));
+
+        RecruitCoreApplicantDetailResponse detail =
+            service.getApplicantDetailForViewer(99L, 1L, UserRole.LEAD);
+
+        assertThat(detail.review().resultNote()).isEqualTo("면접 태도 미흡");
+    }
+
     @Test
     void getApplicantDetailForViewer_whenUnauthorized_throwsException() {
         RecruitCoreApplication application = createApplication(99L, createUser(2L), SESSION);

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
@@ -1,0 +1,154 @@
+package inha.gdgoc.domain.recruit.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inha.gdgoc.domain.recruit.member.dto.response.SpecifiedMemberResponse;
+import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
+import inha.gdgoc.domain.recruit.member.enums.EnrolledClassification;
+import inha.gdgoc.domain.recruit.member.enums.Gender;
+import inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode;
+import inha.gdgoc.domain.recruit.member.exception.RecruitMemberException;
+import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 부원 지원의 "이메일당 학기 1회" 제한과 본인 지원서 조회를 검증한다.
+ *
+ * <p>전에는 서버가 중복을 전혀 보지 않았다. 화면의 중복 확인 버튼이 유일한 장치였고, 지원 API 는
+ * 인증 없이 열려 있어 주소를 직접 치면 같은 사람이 몇 번이든 지원할 수 있었다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class RecruitMemberApplicationLimitTest {
+
+    @Autowired
+    private RecruitMemberService recruitMemberService;
+
+    @Autowired
+    private RecruitMemberRepository recruitMemberRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        recruitMemberRepository.deleteAll();
+    }
+
+    @Test
+    void 같은_이메일로_같은_학기에_두_번_지원하면_막힌다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+
+        // 학번·전화번호를 바꿔도 이메일이 같으면 막혀야 한다.
+        assertThatThrownBy(() ->
+            recruitMemberService.addRecruitMember(payload("12200002", "01000000002", "hong@inha.edu"), null))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
+
+        assertThat(recruitMemberRepository.count()).isEqualTo(1);
+    }
+
+    // 이메일은 대소문자를 가리지 않는다. Hong@ 으로 다시 내는 우회를 막는다.
+    @Test
+    void 대소문자만_다른_이메일도_같은_지원으로_본다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+
+        assertThatThrownBy(() ->
+            recruitMemberService.addRecruitMember(payload("12200002", "01000000002", "HONG@inha.edu"), null))
+            .isInstanceOf(RecruitMemberException.class);
+    }
+
+    @Test
+    void 이메일이_다르면_지원할_수_있다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+        recruitMemberService.addRecruitMember(payload("12200002", "01000000002", "kim@inha.edu"), null);
+
+        assertThat(recruitMemberRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    void 마이페이지에서_계정_이메일과_같은_지원서를_본다() {
+        recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
+        User user = userRepository.save(user("hong@inha.edu"));
+
+        SpecifiedMemberResponse response = recruitMemberService.findMyApplication(user.getId());
+
+        assertThat(response.email()).isEqualTo("hong@inha.edu");
+        assertThat(response.studentId()).isEqualTo("12200001");
+        assertThat(response.admissionSemester()).isEqualTo(AdmissionSemester.Y26_2);
+    }
+
+    // 남의 지원서가 새어 나가면 안 된다. 이메일이 다르면 없는 것으로 본다.
+    @Test
+    void 지원_이력이_없으면_찾을_수_없다() {
+        recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
+        User user = userRepository.save(user("kim@inha.edu"));
+
+        assertThatThrownBy(() -> recruitMemberService.findMyApplication(user.getId()))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_FOUND);
+    }
+
+    private Map<String, Object> payload(String studentId, String phoneNumber, String email) {
+        Map<String, Object> member = new HashMap<>();
+        member.put("name", "홍길동");
+        member.put("studentId", studentId);
+        member.put("enrolledClassification", "재학");
+        member.put("phoneNumber", phoneNumber);
+        member.put("email", email);
+        member.put("gender", "남성");
+        member.put("birth", "2003.03.01");
+        member.put("major", "컴퓨터공학과");
+        member.put("isPayed", false);
+
+        Map<String, Object> answers = new HashMap<>();
+        answers.put("gdgInterest", List.of("BackEnd"));
+        answers.put("gdgWish", List.of("스터디"));
+        answers.put("gdgFeedback", "없습니다");
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("member", member);
+        payload.put("answers", answers);
+        return payload;
+    }
+
+    private RecruitMember member(String studentId, String phoneNumber, String email) {
+        return RecruitMember.builder()
+            .name("홍길동")
+            .studentId(studentId)
+            .enrolledClassification(EnrolledClassification.FULL_REGISTRATION)
+            .phoneNumber(phoneNumber)
+            .email(email)
+            .gender(Gender.PRIVATE)
+            .birth(LocalDate.of(2003, 3, 1))
+            .major("CSE")
+            .isPayed(false)
+            .admissionSemester(AdmissionSemester.Y26_2)
+            .build();
+    }
+
+    private User user(String email) {
+        return User.builder()
+            .name("홍길동")
+            .oauthSubject("oauth-" + email)
+            .major("CSE")
+            .studentId("12200001")
+            .phoneNumber("01000000001")
+            .email(email)
+            .build();
+    }
+}


### PR DESCRIPTION
## 무엇을 바꾸나

### 1. 부원 모집을 학기 말까지 상시로 연다
부원 모집은 원래 상시 모집이고 8/17~9/9 는 집중 모집 기간인데, 서버 `close-at` 이 9/9 라 그 이후 지원이 403 으로 막혔다. `application-prod.yml` 의 `close-at` 을 **2027-01-31** 로 옮긴다.

> 2027-02-01 을 넘기면 `SemesterCalculator` 가 `Y27_1` 을 돌려주므로, 이번 학기 지원서를 한 학기로 모으려면 1월 말이 마지노선이다.

### 2. 부원 지원을 이메일당 학기 1회로 제한
서버가 부원 지원의 중복을 전혀 보지 않았다. 화면의 중복 확인 버튼이 유일한 장치였고 지원 API 는 인증 없이 열려 있어 주소를 직접 치면 몇 번이든 지원할 수 있었다. 코어의 `(user, session)` 과 같은 규칙을 `(email, admissionSemester)` 로 건다.

### 3. 부원 지원서 본인 조회 `GET /api/v1/recruit/member/applications/me`
마이페이지에서 본인 지원서를 보기 위한 엔드포인트. 부원 지원은 비로그인으로 받아 계정과 이어지는 컬럼이 없어 **이메일로 잇는다** — 로그인이 `@inha.edu` 전용이고 지원 폼 도메인도 `@inha.edu` 고정이라 성립한다.

### 4. 코어 지원서 본인 조회에서 검토 정보 제외
`GET /recruit/core/applications/{id}` 는 본인도 열 수 있는데 검토자 ID 와 내부 합불 메모까지 실어 보내고 있었다. 마이페이지가 이 엔드포인트를 쓰기 시작하면 화면에 안 그려도 개발자 도구로 읽힌다. LEAD 미만 뷰어에게는 `review` 를 null 로 내린다.

## 검증

- `./gradlew cleanTest test` — **145건 전부 통과** (신규 7건 포함)
- dev 실측: 같은 이메일 2차 제출 → **409 `이미 지원을 완료하였습니다`**
- dev 실측: `OPTIONS /recruit/member/applications/me` → 200 + `Allow: GET,HEAD,OPTIONS` (대조군 `zzz/nope` → 404)

## 배포 순서

**이 PR 을 먼저 머지하고 Web 을 나중에 올린다.** 반대로 하면 Web 이 없는 API 를 부른다.

## 남는 것

- dev DB 에 검증용 테스트 지원서 1건 (`클로드테스트` / 학번 `99990001`). 운영에는 영향 없음.
- 진입 시점 차단(코어처럼 폼을 아예 안 여는 것)은 하지 않았다. 부원 지원이 비로그인이라 페이지 진입 시 신원을 알 수 없다. 제출 시점 409 로 막는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5AG5zJdauvLokhn5afovy