### PR TITLE
fix: 부원 지원을 학기마다 다시 받을 수 있게 한다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/member/entity/RecruitMember.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/entity/RecruitMember.java
@@ -14,6 +14,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +25,26 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 부원 지원서.
+ *
+ * <p>학번·전화번호의 유일성은 <b>학기 단위</b>다. 전에는 전역 UNIQUE 라 한 사람이 평생 한 번만
+ * 지원할 수 있었다 — 매 학기 회비를 받는 운영과 어긋났다. V20260818 마이그레이션이 복합으로 바꿨다.
+ *
+ * <p>ddl-auto 는 none 이라 운영 스키마는 마이그레이션이 만든다. 아래 선언은 문서이자
+ * 테스트용 H2 스키마의 출처다 — 마이그레이션과 어긋나면 테스트가 실제와 다른 것을 검증하게 된다.
+ */
 @Entity
+@Table(
+        name = "recruit_member",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uq_recruit_member_student_id_semester",
+                    columnNames = {"student_id", "admission_semester"}),
+            @UniqueConstraint(
+                    name = "uq_recruit_member_phone_number_semester",
+                    columnNames = {"phone_number", "admission_semester"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -38,14 +59,14 @@ public class RecruitMember extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "student_id", nullable = false, unique = true)
+    @Column(name = "student_id", nullable = false)
     private String studentId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "enrolled_classification", nullable = false)
     private EnrolledClassification enrolledClassification;
 
-    @Column(name = "phone_number", nullable = false, unique = true)
+    @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
     @Column(name = "email", nullable = false)

--- a/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
@@ -8,19 +8,31 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface RecruitMemberRepository
         extends JpaRepository<RecruitMember, Long>, JpaSpecificationExecutor<RecruitMember> {
-    boolean existsByStudentId(String studentId);
-    boolean existsByPhoneNumber(String phoneNumber);
-    boolean existsByEmailIgnoreCase(String email);
-
-    /** 학기당 이메일 1회 제한. 코어의 {@code findByUserIdAndSession} 과 같은 역할이다. */
-    boolean existsByEmailIgnoreCaseAndAdmissionSemester(String email, AdmissionSemester admissionSemester);
 
     /**
-     * 마이페이지에서 본인 지원서를 찾을 때 쓴다.
+     * 중복 판정은 전부 <b>학기 단위</b>다. 코어의 {@code findByUserIdAndSession} 과 같은 역할이다.
+     *
+     * <p>전에는 세 검사 모두 전역이라 지난 학기 지원자가 이번 학기에 다시 낼 수 없었다.
+     * 화면은 「중복된 학번입니다」로 막았고, 그걸 넘겨도 DB 의 전역 UNIQUE 가 500 을 냈다.
+     */
+    boolean existsByStudentIdAndAdmissionSemester(String studentId, AdmissionSemester admissionSemester);
+
+    boolean existsByPhoneNumberAndAdmissionSemester(String phoneNumber, AdmissionSemester admissionSemester);
+
+    boolean existsByEmailIgnoreCaseAndAdmissionSemester(String email, AdmissionSemester admissionSemester);
+
+    /** 부원 지원 알림(메모) 신청에서 쓴다. 그쪽은 학기 개념 없이 「이미 지원한 사람인가」만 본다. */
+    boolean existsByPhoneNumber(String phoneNumber);
+
+    /**
+     * 마이페이지에서 본인의 <b>이번 학기</b> 지원서를 찾을 때 쓴다.
      *
      * <p>부원 지원은 비로그인으로 받으므로 계정과 지원서를 잇는 키가 이메일뿐이다.
      * 로그인(@inha.edu 전용)과 지원 폼(도메인 @inha.edu 고정)이 같은 도메인이라 성립한다.
-     * 학기를 안 거는 이유는 지난 학기 지원서도 본인 것이면 보여야 하기 때문이다.
+     *
+     * <p>학기를 거는 이유: 지난 학기 지원서를 「신청 현황」에 띄우면 이번 학기에 낸 것으로 읽힌다.
+     * 실제로 2026-1 에 낸 지원서가 2026-2 화면에 그대로 보였다.
      */
-    Optional<RecruitMember> findTopByEmailIgnoreCaseOrderByCreatedAtDesc(String email);
+    Optional<RecruitMember> findByEmailIgnoreCaseAndAdmissionSemester(
+            String email, AdmissionSemester admissionSemester);
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
@@ -78,7 +78,7 @@ public class RecruitMemberService {
         normalizeProofFileUrl(answers);
 
         AdmissionSemester semester = semesterCalculator.currentSemester();
-        validateNotAppliedThisSemester(memberRequest.getEmail(), semester);
+        validateNotAppliedThisSemester(memberRequest, semester);
 
         RecruitMember member = memberRequest.toEntity(semester, majorNormalizer);
         recruitMemberRepository.save(member);
@@ -138,21 +138,26 @@ public class RecruitMemberService {
         recruitMemberMemoRepository.save(recruitMemberMemoRequest.toEntity());
     }
 
+    // 중복 확인 3종은 전부 이번 학기만 본다. 전역으로 보면 지난 학기 지원자가
+    // 「중복입니다」에 걸려 이번 학기 지원을 시작조차 못 한다.
     public CheckStudentIdResponse isRegisteredStudentId(String studentId) {
-        boolean exists = recruitMemberRepository.existsByStudentId(studentId);
+        boolean exists = recruitMemberRepository.existsByStudentIdAndAdmissionSemester(
+                studentId, semesterCalculator.currentSemester());
 
         return new CheckStudentIdResponse(exists);
     }
 
     public CheckPhoneNumberResponse isRegisteredPhoneNumber(String phoneNumber) {
         String cleanPhone = normalizePhoneNumber(phoneNumber);
-        boolean exists = recruitMemberRepository.existsByPhoneNumber(cleanPhone);
+        boolean exists = recruitMemberRepository.existsByPhoneNumberAndAdmissionSemester(
+                cleanPhone, semesterCalculator.currentSemester());
 
         return new CheckPhoneNumberResponse(exists);
     }
 
     public CheckEmailResponse isRegisteredEmail(String email) {
-        boolean exists = recruitMemberRepository.existsByEmailIgnoreCase(email.trim());
+        boolean exists = recruitMemberRepository.existsByEmailIgnoreCaseAndAdmissionSemester(
+                email.trim(), semesterCalculator.currentSemester());
 
         return new CheckEmailResponse(exists);
     }
@@ -165,7 +170,7 @@ public class RecruitMemberService {
     }
 
     /**
-     * 로그인 사용자가 낸 부원 지원서를 돌려준다. 마이페이지에서 쓴다.
+     * 로그인 사용자가 <b>이번 학기</b>에 낸 부원 지원서를 돌려준다. 마이페이지에서 쓴다.
      *
      * <p>부원 지원은 비로그인으로 받아 계정과 이어지는 컬럼이 없다. 이메일이 유일한 연결 고리이며,
      * 로그인은 @inha.edu 계정만, 지원 폼의 도메인도 @inha.edu 고정이라 이 매칭이 성립한다.
@@ -175,7 +180,8 @@ public class RecruitMemberService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
         RecruitMember member = recruitMemberRepository
-                .findTopByEmailIgnoreCaseOrderByCreatedAtDesc(user.getEmail().trim())
+                .findByEmailIgnoreCaseAndAdmissionSemester(
+                        user.getEmail().trim(), semesterCalculator.currentSemester())
                 .orElseThrow(() -> new RecruitMemberException(RECRUIT_MEMBER_NOT_FOUND));
 
         return toSpecifiedMemberResponse(member);
@@ -189,16 +195,31 @@ public class RecruitMemberService {
     }
 
     /**
-     * 이메일당 학기 1회. 코어의 {@code findByUserIdAndSession} 검사와 같은 규칙이다.
+     * 한 학기에 한 번만 받는다 — 이메일·학번·전화번호 중 하나라도 겹치면 막는다.
      *
      * <p>화면에서도 중복 확인 버튼으로 걸러내지만 그건 안내일 뿐이다. 지원 API 는 인증 없이 열려 있어
      * 주소를 직접 치면 그대로 들어온다 — 실제 차단은 여기서 한다.
+     *
+     * <p>학번·전화번호는 DB 에도 (값, 학기) 복합 UNIQUE 가 있다. 그것만 믿으면 중복 제출이
+     * 제약 위반 500 으로 나가므로, 여기서 먼저 걸러 409 로 답한다.
      */
-    private void validateNotAppliedThisSemester(String email, AdmissionSemester semester) {
-        if (email == null || email.isBlank()) {
-            return;
+    private void validateNotAppliedThisSemester(RecruitMemberRequest request, AdmissionSemester semester) {
+        String email = request.getEmail();
+        if (email != null && !email.isBlank()
+                && recruitMemberRepository.existsByEmailIgnoreCaseAndAdmissionSemester(email.trim(), semester)) {
+            throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
         }
-        if (recruitMemberRepository.existsByEmailIgnoreCaseAndAdmissionSemester(email.trim(), semester)) {
+
+        String studentId = request.getStudentId();
+        if (studentId != null && !studentId.isBlank()
+                && recruitMemberRepository.existsByStudentIdAndAdmissionSemester(studentId.trim(), semester)) {
+            throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
+        }
+
+        String phoneNumber = request.getPhoneNumber();
+        if (phoneNumber != null && !phoneNumber.isBlank()
+                && recruitMemberRepository.existsByPhoneNumberAndAdmissionSemester(
+                        normalizePhoneNumber(phoneNumber), semester)) {
             throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
         }
     }

--- a/src/main/resources/db/migration/V20260818__allow_recruit_member_reapply_per_semester.sql
+++ b/src/main/resources/db/migration/V20260818__allow_recruit_member_reapply_per_semester.sql
@@ -1,0 +1,25 @@
+-- 부원 지원을 학기마다 다시 받을 수 있게 한다.
+--
+-- recruit_member 는 생성 때부터 student_id·phone_number 에 전역 UNIQUE 를 달고 있었다.
+-- 그래서 한 사람은 평생 한 번만 지원할 수 있었다 — 학기가 바뀌어 다시 지원하면
+-- `duplicate key value violates unique constraint "recruit_member_student_id_key"` 로
+-- 500 이 났다(2026-08-18 dev 실측). 매 학기 회비를 받는 운영과 어긋난다.
+--
+-- 제약을 (값, 학기) 복합으로 바꾼다. 같은 학기 안의 중복은 그대로 막히고 학기가 다르면 통과한다.
+--
+-- 제약 이름은 database_schema.sql 이 컬럼 정의에 인라인 UNIQUE 를 써서 Postgres 가
+-- 자동으로 붙인 것이다(`{테이블}_{컬럼}_key`). dev 의 오류 메시지가 이 이름을 그대로 찍었다.
+-- 혹시 이름이 다르면 DROP 이 조용히 아무것도 안 하고 옛 제약이 남는다 — 그 경우
+-- 재지원이 여전히 500 이므로 배포 후 실제 제출로 확인한다.
+ALTER TABLE recruit_member DROP CONSTRAINT IF EXISTS recruit_member_student_id_key;
+ALTER TABLE recruit_member DROP CONSTRAINT IF EXISTS recruit_member_phone_number_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_recruit_member_student_id_semester
+    ON recruit_member (student_id, admission_semester);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_recruit_member_phone_number_semester
+    ON recruit_member (phone_number, admission_semester);
+
+-- 이메일에는 UNIQUE 를 걸지 않는다. 지금까지 제약이 없어 (email, admission_semester)
+-- 중복 행이 이미 쌓여 있을 수 있고, 그러면 이 마이그레이션이 실패해 앱이 뜨지 못한다.
+-- 학기당 1회 규칙은 RecruitMemberService 가 저장 전에 검사한다.

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
@@ -13,6 +13,7 @@ import inha.gdgoc.domain.recruit.member.exception.RecruitMemberException;
 import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.util.SemesterCalculator;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
@@ -25,15 +26,21 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 부원 지원의 "이메일당 학기 1회" 제한과 본인 지원서 조회를 검증한다.
+ * 부원 지원의 "학기당 1회" 제한과 본인 지원서 조회를 검증한다.
  *
  * <p>전에는 서버가 중복을 전혀 보지 않았다. 화면의 중복 확인 버튼이 유일한 장치였고, 지원 API 는
  * 인증 없이 열려 있어 주소를 직접 치면 같은 사람이 몇 번이든 지원할 수 있었다.
+ *
+ * <p>반대로 <b>학기가 바뀌어도 재지원이 안 되는</b> 문제도 있었다. 학번·전화번호에 전역 UNIQUE 가
+ * 걸려 있어 2026-1 지원자가 2026-2 에 다시 내면 제약 위반 500 이 났다. 이제 (값, 학기) 복합이다.
  */
 @ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class RecruitMemberApplicationLimitTest {
+
+    /** 실행 시점이 언제든 반드시 과거인 학기. enum 의 첫 상수라 현재 학기가 될 일이 없다. */
+    private static final AdmissionSemester PAST_SEMESTER = AdmissionSemester.Y21_2;
 
     @Autowired
     private RecruitMemberService recruitMemberService;
@@ -43,6 +50,9 @@ class RecruitMemberApplicationLimitTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private SemesterCalculator semesterCalculator;
 
     @BeforeEach
     void setUp() {
@@ -80,6 +90,71 @@ class RecruitMemberApplicationLimitTest {
         assertThat(recruitMemberRepository.count()).isEqualTo(2);
     }
 
+    // 학기가 바뀌면 같은 사람이 다시 낼 수 있어야 한다. 매 학기 회비를 받는 운영이 그렇다.
+    @Test
+    void 지난_학기에_지원했어도_이번_학기에_다시_지원할_수_있다() {
+        recruitMemberRepository.save(
+            member("12200001", "01000000001", "hong@inha.edu", PAST_SEMESTER));
+
+        // 같은 사람(학번·전화·이메일 전부 동일)이 이번 학기에 다시 낸다.
+        recruitMemberService.addRecruitMember(
+            payload("12200001", "01000000001", "hong@inha.edu"), null);
+
+        assertThat(recruitMemberRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    void 같은_학기에_학번이_겹치면_막힌다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "a@inha.edu"), null);
+
+        assertThatThrownBy(() ->
+            recruitMemberService.addRecruitMember(payload("12200001", "01000000002", "b@inha.edu"), null))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
+    }
+
+    @Test
+    void 같은_학기에_전화번호가_겹치면_막힌다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "a@inha.edu"), null);
+
+        assertThatThrownBy(() ->
+            recruitMemberService.addRecruitMember(payload("12200002", "01000000001", "b@inha.edu"), null))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
+    }
+
+    // 폼의 중복 확인도 이번 학기만 봐야 한다. 전역이면 지난 학기 지원자가 시작조차 못 한다.
+    @Test
+    void 중복_확인_3종은_지난_학기_지원서를_세지_않는다() {
+        recruitMemberRepository.save(
+            member("12200001", "01000000001", "hong@inha.edu", PAST_SEMESTER));
+
+        assertThat(recruitMemberService.isRegisteredStudentId("12200001").isExists()).isFalse();
+        assertThat(recruitMemberService.isRegisteredPhoneNumber("01000000001").isExists()).isFalse();
+        assertThat(recruitMemberService.isRegisteredEmail("hong@inha.edu").isExists()).isFalse();
+    }
+
+    @Test
+    void 중복_확인_3종은_이번_학기_지원서를_센다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+
+        assertThat(recruitMemberService.isRegisteredStudentId("12200001").isExists()).isTrue();
+        assertThat(recruitMemberService.isRegisteredPhoneNumber("01000000001").isExists()).isTrue();
+        assertThat(recruitMemberService.isRegisteredEmail("hong@inha.edu").isExists()).isTrue();
+    }
+
+    // 지난 학기 지원서를 「신청 현황」에 띄우면 이번 학기에 낸 것으로 읽힌다.
+    @Test
+    void 마이페이지는_지난_학기_지원서를_보여주지_않는다() {
+        recruitMemberRepository.save(
+            member("12200001", "01000000001", "hong@inha.edu", PAST_SEMESTER));
+        User user = userRepository.save(user("hong@inha.edu"));
+
+        assertThatThrownBy(() -> recruitMemberService.findMyApplication(user.getId()))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_FOUND);
+    }
+
     @Test
     void 마이페이지에서_계정_이메일과_같은_지원서를_본다() {
         recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
@@ -89,7 +164,7 @@ class RecruitMemberApplicationLimitTest {
 
         assertThat(response.email()).isEqualTo("hong@inha.edu");
         assertThat(response.studentId()).isEqualTo("12200001");
-        assertThat(response.admissionSemester()).isEqualTo(AdmissionSemester.Y26_2);
+        assertThat(response.admissionSemester()).isEqualTo(currentSemester());
     }
 
     // 남의 지원서가 새어 나가면 안 된다. 이메일이 다르면 없는 것으로 본다.
@@ -127,6 +202,15 @@ class RecruitMemberApplicationLimitTest {
     }
 
     private RecruitMember member(String studentId, String phoneNumber, String email) {
+        return member(studentId, phoneNumber, email, currentSemester());
+    }
+
+    private RecruitMember member(
+        String studentId,
+        String phoneNumber,
+        String email,
+        AdmissionSemester semester
+    ) {
         return RecruitMember.builder()
             .name("홍길동")
             .studentId(studentId)
@@ -137,8 +221,16 @@ class RecruitMemberApplicationLimitTest {
             .birth(LocalDate.of(2003, 3, 1))
             .major("CSE")
             .isPayed(false)
-            .admissionSemester(AdmissionSemester.Y26_2)
+            .admissionSemester(semester)
             .build();
+    }
+
+    /**
+     * 테스트가 날짜에 묶이지 않도록 서비스와 같은 계산기를 쓴다.
+     * 상수(Y26_2)를 박으면 학기가 넘어가는 순간 전부 무너진다.
+     */
+    private AdmissionSemester currentSemester() {
+        return semesterCalculator.currentSemester();
     }
 
     private User user(String email) {


### PR DESCRIPTION
## 문제

부원 지원은 **평생 1회**였다. 학기가 바뀌어도 재지원할 수 없다.

`recruit_member` 는 생성 때부터 `student_id`·`phone_number` 에 **전역 UNIQUE** 를 달고 있었다. 2026-1 지원자가 2026-2 에 다시 내면:

```
ERROR: duplicate key value violates unique constraint "recruit_member_student_id_key"
→ HTTP 500
```

(2026-08-18 dev 실측)

그 전에 폼의 중복 확인 3종도 전부 전역이라 「중복된 학번입니다」로 이미 막혀 있었다. 매 학기 회비를 받는 운영과 어긋난다.

**직전 릴리스(#346)의 「이메일당 학기 1회」는 이 구조에서 단독으로는 의미가 없었다.** 학기가 바뀌어 그 검사를 통과해도 바로 다음 INSERT 에서 제약 위반이 났다.

증상은 마이페이지에서 먼저 드러났다 — 2026-1 에 낸 지원서가 2026-2 화면에 그대로 보였다. 한 사람에게 지원서가 평생 한 건뿐이라 「지난 학기 것」이라는 구분 자체가 없었기 때문이다.

## 고친 것

1. **마이그레이션** `V20260818` — 전역 UNIQUE 를 `(값, 학기)` 복합 인덱스로 바꾼다.
2. **중복 확인 3종**(`check/student-id`·`check/phone-number`·`check/email`)을 현재 학기 범위로.
3. **제출 검증에 학번·전화번호 추가.** DB 제약만 믿으면 같은 학기 중복 제출이 500 으로 나간다. 먼저 걸러 409 로 답한다.
4. **마이페이지는 이번 학기 지원서만** 보여준다.

## 마이그레이션 안전성

- `DROP CONSTRAINT IF EXISTS` + `CREATE UNIQUE INDEX IF NOT EXISTS` — 4개 전부 멱등.
- **데이터로 인해 실패할 수 없다.** `student_id` 가 전역 유일했으므로 `(student_id, admission_semester)` 에 중복이 있을 수 없다. `phone_number` 도 같다.
- **이메일에는 UNIQUE 를 걸지 않았다.** 지금까지 제약이 없어 `(email, admission_semester)` 중복 행이 이미 있을 수 있고, 그러면 마이그레이션이 실패해 앱이 뜨지 못한다. 학기당 1회는 코드가 검사한다.
- 남는 위험은 **제약 이름이 예상과 다른 경우**뿐이다. 그러면 DROP 이 조용히 no-op 이 되고 재지원이 여전히 500 이다. 이름은 `database_schema.sql` 의 인라인 UNIQUE 를 Postgres 가 자동으로 붙인 것이고(`{테이블}_{컬럼}_key`), dev 오류 메시지가 이 이름을 그대로 찍었다. 운영도 같은 파일에서 만들어졌다.

## 검증

- `./gradlew cleanTest test` — **151건 전부 통과** (신규 6건)
- dev 실측: 같은 학번 + 다른 이메일 제출이 **500 → 409** 로 바뀜 (신버전 라이브)
- dev 실측: 마이그레이션 적용 후 앱 정상 기동, 기동 후 에러 없음, health 4종 정상

⚠️ **H2 테스트는 엔티티로 스키마를 만들므로 마이그레이션 SQL 자체는 검증되지 않는다.** 운영 반영 후 **실제 재지원 제출로 확인해야 한다** — 2026-1 지원 이력이 있는 계정으로 2026-2 지원이 통과하면 성공, 500 이면 제약 이름이 달랐던 것이므로 후속 마이그레이션이 필요하다.

## Web 변경

없음. 서버만 배포하면 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5AG5zJdauvLokhn5afovy