### PR TITLE
feat: 부원 지원자 목록에 제출 시각을 담는다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberSummaryResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberSummaryResponse.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.recruit.member.dto.response;
 
 import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
 import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
+import java.time.Instant;
 
 public record RecruitMemberSummaryResponse(
         Long id,
@@ -12,7 +13,10 @@ public record RecruitMemberSummaryResponse(
         // 목록에서 학기를 걸러 볼 수 있어야 필터 결과를 확인할 수 있다.
         // 웹은 전부터 이 필드를 읽고 있었으나 서버가 내려주지 않아 항상 비어 있었다.
         AdmissionSemester admissionSemester,
-        Boolean isPayed
+        Boolean isPayed,
+        // 목록의 기본 정렬이 createdAt DESC 인데 정작 값을 안 내려줘서, 화면은 순서만 알고
+        // 「언제 냈는지」는 지원자를 하나씩 열어야 알 수 있었다. 상세 응답에는 원래 있던 값이다.
+        Instant createdAt
 ) {
 
     public static RecruitMemberSummaryResponse from(RecruitMember recruitMember) {
@@ -23,7 +27,8 @@ public record RecruitMemberSummaryResponse(
                 recruitMember.getMajor(),
                 recruitMember.getStudentId(),
                 recruitMember.getAdmissionSemester(),
-                recruitMember.getIsPayed()
+                recruitMember.getIsPayed(),
+                recruitMember.getCreatedAt()
         );
     }
 }


### PR DESCRIPTION
## 문제

부원 지원자가 **언제 지원했는지 확인할 방법이 화면 어디에도 없었다.**

- 목록 응답(`RecruitMemberSummaryResponse`)에 `createdAt` 이 없다. 정작 **기본 정렬은 `createdAt DESC`** 라, 화면은 순서만 알고 시각은 모르는 상태였다.
- 상세 응답(`SpecifiedMemberResponse`)에는 원래 있지만, 웹의 상세 모달이 `createdAt` 을 표시에서 제외한다.

## 고친 것

`RecruitMemberSummaryResponse` 에 `createdAt` 을 담는다. 레코드 끝에 추가하므로 기존 필드 순서는 그대로다.

## 검증

`./gradlew cleanTest test` — 151건 전부 통과

## 배포 순서

**이 PR 을 먼저 머지하고 Web(#359)을 나중에 올린다.** 반대로 하면 컬럼은 생기는데 값이 안 와서 전부 `-` 로 보인다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5AG5zJdauvLokhn5afovy