### PR TITLE
feat: 회비 납부 부원 지원자 MEMBER 자동 승격 + 지원 로그 추가

### DIFF
--- a/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
+++ b/src/main/java/inha/gdgoc/domain/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import inha.gdgoc.domain.auth.dto.response.SignupNeededResponse;
 import inha.gdgoc.domain.auth.dto.response.TokenDto;
 import inha.gdgoc.domain.auth.entity.AdminCredential;
 import inha.gdgoc.domain.auth.repository.AdminCredentialRepository;
+import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.TeamType;
 import inha.gdgoc.domain.user.enums.UserRole;
@@ -22,6 +23,7 @@ import inha.gdgoc.global.config.jwt.TokenProvider;
 import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
 import inha.gdgoc.global.security.AccessGuard;
 import inha.gdgoc.global.util.MajorNormalizer;
+import inha.gdgoc.global.util.SemesterCalculator;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -53,6 +55,8 @@ public class AuthService {
   private final AccessGuard accessGuard;
   private final PasswordEncoder passwordEncoder;
   private final MajorNormalizer majorNormalizer;
+  private final RecruitMemberRepository recruitMemberRepository;
+  private final SemesterCalculator semesterCalculator;
 
   @Value("${google.client-id}")
   private String googleClientId;
@@ -89,6 +93,8 @@ public class AuthService {
       }
   
       log.info("기존 유저 로그인 - UserID: {}, Email: {}", user.getId(), user.getEmail());
+      // 지원서를 낸 뒤 처음 들어온 사람이 여기서 MEMBER 가 된다. 토큰·응답에 새 역할이 담기도록 발급 전에 한다.
+      promotePaidApplicantToMember(user);
       // 기존 유저 -> 토큰 발급 및 로그인 성공 응답
       TokenDto tokens = generateTokens(user);
       return LoginSuccessResponse.of(tokens, AuthUserResponse.from(user));
@@ -121,10 +127,44 @@ public class AuthService {
             .build();
 
     userRepository.save(newUser);
+    promotePaidApplicantToMember(newUser);
 
     // 토큰 발급
     TokenDto tokens = generateTokens(newUser);
     return LoginSuccessResponse.of(tokens, AuthUserResponse.from(newUser));
+  }
+
+  /**
+   * 회비를 낸 이번 학기 부원 지원자를 MEMBER 로 올린다.
+   *
+   * <p>부원 지원은 비로그인으로 받아 지원서에 계정을 가리키는 컬럼이 없다. 지원 시점에는 올릴 대상이
+   * 아직 없으므로, 로그인·가입하는 이 자리가 승격이 가능한 유일한 지점이다. 이메일이 둘을 잇는 키인 것은
+   * RecruitMemberService.findMyApplication 과 같다 — 로그인은 @inha.edu 전용이고 지원 폼도 같은
+   * 도메인만 받는다.
+   *
+   * <p>회비를 낸 사람만 올린다. 입금 확인은 운영진이 대시보드에서 하던 작업 그대로이고, 승격은 그 뒤
+   * 본인이 로그인할 때 따라온다. 학기가 바뀌어도 되돌리지 않는다 — 강등은 별도 정책이다.
+   *
+   * <p>지원 이력이 없거나 미납이면 GUEST 로 남는다. 승격 실패는 로그인을 막지 않는다.
+   */
+  private void promotePaidApplicantToMember(User user) {
+    if (user.getUserRole() != UserRole.GUEST) {
+      return;
+    }
+
+    String email = user.getEmail();
+    if (email == null || email.isBlank()) {
+      return;
+    }
+
+    recruitMemberRepository
+        .findByEmailIgnoreCaseAndAdmissionSemester(email.trim(), semesterCalculator.currentSemester())
+        .filter(application -> Boolean.TRUE.equals(application.getIsPayed()))
+        .ifPresent(application -> {
+          user.changeRole(UserRole.MEMBER);
+          userRepository.save(user);
+          log.info("부원 지원자 자동 승격 GUEST->MEMBER - UserID: {}, Email: {}", user.getId(), email);
+        });
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreControllerExceptionHandler.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/exception/RecruitCoreControllerExceptionHandler.java
@@ -16,7 +16,7 @@ public class RecruitCoreControllerExceptionHandler {
     public ResponseEntity<RecruitCoreApplicationErrorResponse> handleAlreadyApplied(
         RecruitCoreAlreadyAppliedException ex
     ) {
-        log.debug("RecruitCoreAlreadyAppliedException: {}", ex.getMessage());
+        log.info("RecruitCoreAlreadyAppliedException: {}", ex.getMessage());
         var code = ex.getErrorCode();
         RecruitCoreApplicationErrorResponse body = RecruitCoreApplicationErrorResponse.of(
             code.getCode(),
@@ -31,7 +31,7 @@ public class RecruitCoreControllerExceptionHandler {
     public ResponseEntity<RecruitCoreApplicationErrorResponse> handleClosed(
         RecruitCoreClosedException ex
     ) {
-        log.debug("RecruitCoreClosedException: {}", ex.getMessage());
+        log.info("RecruitCoreClosedException: {}", ex.getMessage());
         var code = ex.getErrorCode();
         RecruitCoreApplicationErrorResponse body = RecruitCoreApplicationErrorResponse.of(
             code.getCode(),
@@ -44,7 +44,7 @@ public class RecruitCoreControllerExceptionHandler {
     public ResponseEntity<RecruitCoreApplicationErrorResponse> handleNotOpen(
         RecruitCoreNotOpenException ex
     ) {
-        log.debug("RecruitCoreNotOpenException: {}", ex.getMessage());
+        log.info("RecruitCoreNotOpenException: {}", ex.getMessage());
         var code = ex.getErrorCode();
         RecruitCoreApplicationErrorResponse body = RecruitCoreApplicationErrorResponse.of(
             code.getCode(),
@@ -57,7 +57,7 @@ public class RecruitCoreControllerExceptionHandler {
     public ResponseEntity<RecruitCoreApplicationErrorResponse> handleNotFound(
         RecruitCoreApplicationNotFoundException ex
     ) {
-        log.debug("RecruitCoreApplicationNotFoundException: {}", ex.getMessage());
+        log.info("RecruitCoreApplicationNotFoundException: {}", ex.getMessage());
         var code = ex.getErrorCode();
         RecruitCoreApplicationErrorResponse body = RecruitCoreApplicationErrorResponse.of(
             code.getCode(),

--- a/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
@@ -23,6 +23,7 @@ import inha.gdgoc.domain.user.repository.UserRepository;
 import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
 import inha.gdgoc.global.util.MajorNormalizer;
+import lombok.extern.slf4j.Slf4j;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -33,6 +34,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 public class RecruitCoreApplicationService {
 
@@ -126,10 +128,15 @@ public class RecruitCoreApplicationService {
 
     @Transactional
     public RecruitCoreApplicationCreateResponse submit(Long userId, RecruitCoreApplicationCreateRequest request) {
+        log.info("[recruit-core] 지원 접수 - userId={}, studentId={}, name={}, team={}",
+            userId, request.snapshot().studentId(), request.snapshot().name(), request.team());
+
         validateRecruitmentOpen();
         String session = recruitCoreSessionResolver.currentSession();
         repository.findByUserIdAndSession(userId, session)
             .ifPresent(existing -> {
+                log.warn("[recruit-core] 지원 거절(중복) - userId={}, session={}, existingApplicationId={}",
+                    userId, session, existing.getId());
                 throw new RecruitCoreAlreadyAppliedException(session, existing.getId());
             });
 
@@ -156,6 +163,8 @@ public class RecruitCoreApplicationService {
             .build();
 
         RecruitCoreApplication saved = repository.save(application);
+        log.info("[recruit-core] 지원 완료 - applicationId={}, userId={}, session={}, studentId={}, name={}, team={}",
+            saved.getId(), userId, session, saved.getStudentId(), saved.getName(), saved.getTeam());
         return RecruitCoreApplicationCreateResponse.from(saved);
     }
 
@@ -209,12 +218,18 @@ public class RecruitCoreApplicationService {
             .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
     }
 
+    private void logRecruitmentClosed(String phase, Instant boundary) {
+        log.warn("[recruit-core] 지원 거절(기간) - phase={}, boundary={}", phase, boundary);
+    }
+
     private void validateRecruitmentOpen() {
         RecruitCorePeriodStatus status = getPeriodStatus();
         if (status == RecruitCorePeriodStatus.BEFORE_OPEN) {
+            logRecruitmentClosed("BEFORE_OPEN", openAt);
             throw new RecruitCoreNotOpenException(openAt);
         }
         if (status == RecruitCorePeriodStatus.CLOSED) {
+            logRecruitmentClosed("CLOSED", closeAt);
             throw new RecruitCoreClosedException(closeAt);
         }
     }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/exception/RecruitMemberErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/exception/RecruitMemberErrorCode.java
@@ -11,6 +11,9 @@ public enum RecruitMemberErrorCode implements ErrorCode {
     RECRUIT_MEMBER_NOT_OPEN(HttpStatus.FORBIDDEN, "부원 모집 기간이 아직 시작되지 않았습니다."),
     RECRUIT_MEMBER_CLOSED(HttpStatus.FORBIDDEN, "부원 모집 기간이 종료되었습니다."),
 
+    // 400 BAD REQUEST
+    RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN(HttpStatus.BAD_REQUEST, "인하대학교(@inha.edu) 이메일로만 지원할 수 있습니다."),
+
     // 409 CONFLICT
     RECRUIT_MEMBER_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 지원을 완료하였습니다."),
 

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -44,6 +45,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class RecruitMemberService {
@@ -73,15 +75,25 @@ public class RecruitMemberService {
             answers = buildAnswersFromNumberedPayload(requestPayload);
         }
 
+        log.info("[recruit-member] 지원 접수 - studentId={}, name={}, hasProofFile={}",
+                memberRequest.getStudentId(), memberRequest.getName(), file != null && !file.isEmpty());
+
         if (file != null && !file.isEmpty()) {
-            String key = uploadProofFile(file);
+            String key;
+            try {
+                key = uploadProofFile(file);
+            } catch (RuntimeException ex) {
+                log.warn("[recruit-member] 지원 실패(증빙 파일 업로드) - studentId={}, name={}, reason={}",
+                        memberRequest.getStudentId(), memberRequest.getName(), ex.toString());
+                throw ex;
+            }
             String proofFileUrl = s3Service.getS3FileUrl(key);
             answers.put("proofFileUrl", proofFileUrl);
         }
         normalizeProofFileUrl(answers);
 
         AdmissionSemester semester = semesterCalculator.currentSemester();
-        validateInhaEmail(memberRequest.getEmail());
+        validateInhaEmail(memberRequest);
         validateNotAppliedThisSemester(memberRequest, semester);
 
         RecruitMember member = memberRequest.toEntity(semester, majorNormalizer);
@@ -101,6 +113,18 @@ public class RecruitMemberService {
                 .toList();
 
         answerRepository.saveAll(answerEntities);
+
+        log.info("[recruit-member] 지원 완료 - applicationId={}, semester={}, studentId={}, name={}",
+                member.getId(), semester, member.getStudentId(), member.getName());
+    }
+
+    /** 이메일은 도메인만 남긴다. 어느 도메인으로 잘못 들어오는지가 진단에 필요한 전부다. */
+    private String domainOf(String email) {
+        if (email == null) {
+            return "none";
+        }
+        int at = email.lastIndexOf('@');
+        return at < 0 ? "malformed" : email.substring(at).toLowerCase();
     }
 
     private String uploadProofFile(MultipartFile file) {
@@ -205,9 +229,12 @@ public class RecruitMemberService {
      * 지원하면 나중에 로그인해도 영영 이어지지 않고 MEMBER 승격도 안 된다. 화면이 도메인을 고정하지만
      * 지원 API 는 인증 없이 열려 있어 주소를 직접 치면 그대로 들어온다 — 실제 차단은 여기서 한다.
      */
-    private void validateInhaEmail(String email) {
+    private void validateInhaEmail(RecruitMemberRequest request) {
+        String email = request.getEmail();
         String normalized = (email == null ? "" : email.trim().toLowerCase());
         if (!normalized.endsWith(INHA_EMAIL_DOMAIN)) {
+            log.warn("[recruit-member] 지원 거절(이메일 도메인) - domain={}, studentId={}, name={}",
+                    domainOf(email), request.getStudentId(), request.getName());
             throw new RecruitMemberException(RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN);
         }
     }
@@ -225,21 +252,28 @@ public class RecruitMemberService {
         String email = request.getEmail();
         if (email != null && !email.isBlank()
                 && recruitMemberRepository.existsByEmailIgnoreCaseAndAdmissionSemester(email.trim(), semester)) {
-            throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
+            rejectAsDuplicate("email", semester, request);
         }
 
         String studentId = request.getStudentId();
         if (studentId != null && !studentId.isBlank()
                 && recruitMemberRepository.existsByStudentIdAndAdmissionSemester(studentId.trim(), semester)) {
-            throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
+            rejectAsDuplicate("studentId", semester, request);
         }
 
         String phoneNumber = request.getPhoneNumber();
         if (phoneNumber != null && !phoneNumber.isBlank()
                 && recruitMemberRepository.existsByPhoneNumberAndAdmissionSemester(
                         normalizePhoneNumber(phoneNumber), semester)) {
-            throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
+            rejectAsDuplicate("phoneNumber", semester, request);
         }
+    }
+
+    /** 세 검사가 같은 에러코드를 던지므로, 어느 필드가 겹쳤는지는 로그에만 남는다. */
+    private void rejectAsDuplicate(String field, AdmissionSemester semester, RecruitMemberRequest request) {
+        log.warn("[recruit-member] 지원 거절(중복) - field={}, semester={}, studentId={}, name={}",
+                field, semester, request.getStudentId(), request.getName());
+        throw new RecruitMemberException(RECRUIT_MEMBER_ALREADY_APPLIED);
     }
 
     @Transactional

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.recruit.member.service;
 
 import static inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_FOUND;
 import static inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED;
+import static inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode.RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inha.gdgoc.domain.resource.enums.S3KeyType;
@@ -26,6 +27,7 @@ import inha.gdgoc.domain.recruit.member.repository.AnswerRepository;
 import inha.gdgoc.domain.recruit.member.repository.RecruitMemberMemoRepository;
 import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
 import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.domain.user.repository.UserRepository;
 import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
@@ -46,6 +48,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class RecruitMemberService {
     private static final long MAX_PROOF_FILE_SIZE = 10 * 1024 * 1024;
+    private static final String INHA_EMAIL_DOMAIN = "@inha.edu";
 
     private final RecruitMemberRepository recruitMemberRepository;
     private final RecruitMemberMemoRepository recruitMemberMemoRepository;
@@ -78,6 +81,7 @@ public class RecruitMemberService {
         normalizeProofFileUrl(answers);
 
         AdmissionSemester semester = semesterCalculator.currentSemester();
+        validateInhaEmail(memberRequest.getEmail());
         validateNotAppliedThisSemester(memberRequest, semester);
 
         RecruitMember member = memberRequest.toEntity(semester, majorNormalizer);
@@ -195,6 +199,20 @@ public class RecruitMemberService {
     }
 
     /**
+     * 지원 이메일은 @inha.edu 만 받는다.
+     *
+     * <p>이 이메일이 지원서와 계정을 잇는 유일한 키다 — 로그인은 @inha.edu 전용이라 다른 도메인으로
+     * 지원하면 나중에 로그인해도 영영 이어지지 않고 MEMBER 승격도 안 된다. 화면이 도메인을 고정하지만
+     * 지원 API 는 인증 없이 열려 있어 주소를 직접 치면 그대로 들어온다 — 실제 차단은 여기서 한다.
+     */
+    private void validateInhaEmail(String email) {
+        String normalized = (email == null ? "" : email.trim().toLowerCase());
+        if (!normalized.endsWith(INHA_EMAIL_DOMAIN)) {
+            throw new RecruitMemberException(RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN);
+        }
+    }
+
+    /**
      * 한 학기에 한 번만 받는다 — 이메일·학번·전화번호 중 하나라도 겹치면 막는다.
      *
      * <p>화면에서도 중복 확인 버튼으로 걸러내지만 그건 안내일 뿐이다. 지원 API 는 인증 없이 열려 있어
@@ -233,6 +251,42 @@ public class RecruitMemberService {
 
         if (isPayed) m.markPaid();
         else m.markUnpaid();
+
+        syncRoleWithPayment(m, isPayed);
+    }
+
+    /**
+     * 입금 체크를 계정 역할에 곧바로 반영한다.
+     *
+     * <p>승격 지점이 여기와 로그인 두 곳인 이유: 지원서에는 계정을 가리키는 컬럼이 없어, 아직 가입하지
+     * 않은 지원자는 여기서 올릴 대상이 없다. 그 사람은 첫 로그인 때 AuthService 가 올린다. 반대로
+     * 이미 가입한 사람은 여기서 올려야 재로그인 없이 바로 글을 쓸 수 있다. 두 자리가 서로의 빈틈을 메운다.
+     *
+     * <p><b>올릴 때는 GUEST 만, 내릴 때는 MEMBER 만</b> 건드린다. CORE 이상은 회비와 무관하게 임명된
+     * 자리라, 잘못 누른 체크 한 번으로 운영진이 GUEST 로 떨어지면 안 된다. GUEST·MEMBER 는 팀을 갖지
+     * 않으므로(isTeamAssignableRole 은 CORE·LEAD 만) 팀은 건드릴 것이 없다.
+     *
+     * <p>지난 학기 지원서의 입금 체크로 이번 학기 권한이 움직여서는 안 되므로 학기를 먼저 본다.
+     */
+    private void syncRoleWithPayment(RecruitMember application, boolean isPayed) {
+        if (application.getAdmissionSemester() != semesterCalculator.currentSemester()) {
+            return;
+        }
+
+        String email = application.getEmail();
+        if (email == null || email.isBlank()) {
+            return;
+        }
+
+        for (User user : userRepository.findByEmailIgnoreCase(email.trim())) {
+            if (isPayed && user.getUserRole() == UserRole.GUEST) {
+                user.changeRole(UserRole.MEMBER);
+                userRepository.save(user);
+            } else if (!isPayed && user.getUserRole() == UserRole.MEMBER) {
+                user.changeRole(UserRole.GUEST);
+                userRepository.save(user);
+            }
+        }
     }
 
     /**

--- a/src/main/java/inha/gdgoc/domain/user/repository/UserRepository.java
+++ b/src/main/java/inha/gdgoc/domain/user/repository/UserRepository.java
@@ -26,6 +26,14 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     boolean existsByNameAndEmail(String name, String email);
     boolean existsByEmail(String email);
 
+    /**
+     * 부원 지원서에서 계정을 되찾을 때 쓴다. 지원서에는 계정을 가리키는 컬럼이 없어 이메일이 유일한 키다.
+     *
+     * <p>users.email 에는 UNIQUE 가 없다. 구글 OAuth 라 실제로 겹칠 일은 없지만, 겹쳐도 조용히
+     * 한 건만 집지 않도록 목록으로 받는다.
+     */
+    List<User> findByEmailIgnoreCase(String email);
+
     /* ===== 출석/팀 뷰용 기본 쿼리 ===== */
 
     // 특정 팀에서 주어진 역할들(CORE/LEAD 등) 만 조회

--- a/src/test/java/inha/gdgoc/domain/auth/service/AuthServiceMemberPromotionTest.java
+++ b/src/test/java/inha/gdgoc/domain/auth/service/AuthServiceMemberPromotionTest.java
@@ -1,0 +1,169 @@
+package inha.gdgoc.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import inha.gdgoc.domain.auth.dto.request.SignupRequest;
+import inha.gdgoc.domain.recruit.member.entity.RecruitMember;
+import inha.gdgoc.domain.recruit.member.enums.AdmissionSemester;
+import inha.gdgoc.domain.recruit.member.enums.EnrolledClassification;
+import inha.gdgoc.domain.recruit.member.enums.Gender;
+import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.util.SemesterCalculator;
+import java.time.Duration;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회비를 낸 부원 지원자가 가입·로그인하는 순간 MEMBER 가 되는지 검증한다.
+ *
+ * <p>부원 지원은 비로그인으로 받아 지원서에 계정을 가리키는 컬럼이 없다. 지원 시점에는 올릴 대상이
+ * 없으므로 가입·로그인이 유일한 승격 지점이고, 이메일이 둘을 잇는 키다. 이 테스트가 깨지면
+ * 지원자는 회비를 내고도 GUEST 로 남아 자유게시판에 글을 쓰지 못한다.
+ *
+ * <p>login() 은 구글 토큰 검증을 타므로 여기서는 signup() 으로 검증한다. 두 경로가 같은
+ * promotePaidApplicantToMember 를 부른다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class AuthServiceMemberPromotionTest {
+
+    /** 실행 시점이 언제든 반드시 과거인 학기. enum 의 첫 상수라 현재 학기가 될 일이 없다. */
+    private static final AdmissionSemester PAST_SEMESTER = AdmissionSemester.Y21_2;
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private RecruitMemberRepository recruitMemberRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SemesterCalculator semesterCalculator;
+
+    /** 가입은 리프레시 토큰을 Redis 에 넣는다. 테스트 환경에는 Redis 가 없어 대체한다. */
+    @MockitoBean
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        recruitMemberRepository.deleteAll();
+
+        ValueOperations<String, String> valueOperations = Mockito.mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        Mockito.doNothing().when(valueOperations).set(anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    void 회비를_낸_이번_학기_지원자는_가입하면_MEMBER_가_된다() {
+        recruitMemberRepository.save(application("hong@inha.edu", currentSemester(), true));
+
+        authService.signup(signupRequest("hong@inha.edu"));
+
+        assertThat(roleOf("hong@inha.edu")).isEqualTo(UserRole.MEMBER);
+    }
+
+    // 입금 확인은 운영진이 나중에 한다. 그 전에 가입하면 아직 GUEST 여야 한다.
+    @Test
+    void 회비를_내지_않은_지원자는_GUEST_로_남는다() {
+        recruitMemberRepository.save(application("hong@inha.edu", currentSemester(), false));
+
+        authService.signup(signupRequest("hong@inha.edu"));
+
+        assertThat(roleOf("hong@inha.edu")).isEqualTo(UserRole.GUEST);
+    }
+
+    // 지난 학기 지원서로 이번 학기 권한을 얻으면 안 된다. 회비는 학기마다 받는다.
+    @Test
+    void 지난_학기_지원서로는_승격되지_않는다() {
+        recruitMemberRepository.save(application("hong@inha.edu", PAST_SEMESTER, true));
+
+        authService.signup(signupRequest("hong@inha.edu"));
+
+        assertThat(roleOf("hong@inha.edu")).isEqualTo(UserRole.GUEST);
+    }
+
+    @Test
+    void 지원_이력이_없으면_GUEST_로_남는다() {
+        authService.signup(signupRequest("hong@inha.edu"));
+
+        assertThat(roleOf("hong@inha.edu")).isEqualTo(UserRole.GUEST);
+    }
+
+    // 남의 지원서로 올라가면 안 된다. 이메일이 다르면 없는 것으로 본다.
+    @Test
+    void 다른_사람의_지원서로는_승격되지_않는다() {
+        recruitMemberRepository.save(application("kim@inha.edu", currentSemester(), true));
+
+        authService.signup(signupRequest("hong@inha.edu"));
+
+        assertThat(roleOf("hong@inha.edu")).isEqualTo(UserRole.GUEST);
+    }
+
+    // 지원 폼과 구글 계정의 대소문자가 다를 수 있다. 그걸로 승격이 갈리면 안 된다.
+    @Test
+    void 이메일_대소문자가_달라도_승격된다() {
+        recruitMemberRepository.save(application("Hong@Inha.edu", currentSemester(), true));
+
+        authService.signup(signupRequest("hong@inha.edu"));
+
+        assertThat(roleOf("hong@inha.edu")).isEqualTo(UserRole.MEMBER);
+    }
+
+    private UserRole roleOf(String email) {
+        return userRepository.findByOauthSubject("oauth-" + email)
+            .map(User::getUserRole)
+            .orElseThrow(() -> new AssertionError("가입한 사용자를 찾을 수 없습니다: " + email));
+    }
+
+    private SignupRequest signupRequest(String email) {
+        SignupRequest request = new SignupRequest();
+        request.setOauthSubject("oauth-" + email);
+        request.setEmail(email);
+        request.setName("홍길동");
+        request.setStudentId("12200001");
+        request.setMajor("컴퓨터공학과");
+        request.setPhoneNumber("01000000001");
+        return request;
+    }
+
+    private RecruitMember application(String email, AdmissionSemester semester, boolean payed) {
+        return RecruitMember.builder()
+            .name("홍길동")
+            .studentId("12200001")
+            .enrolledClassification(EnrolledClassification.FULL_REGISTRATION)
+            .phoneNumber("01000000001")
+            .email(email)
+            .gender(Gender.PRIVATE)
+            .birth(LocalDate.of(2003, 3, 1))
+            .major("CSE")
+            .isPayed(payed)
+            .admissionSemester(semester)
+            .build();
+    }
+
+    /**
+     * 테스트가 날짜에 묶이지 않도록 서비스와 같은 계산기를 쓴다.
+     * 상수를 박으면 학기가 넘어가는 순간 전부 무너진다.
+     */
+    private AdmissionSemester currentSemester() {
+        return semesterCalculator.currentSemester();
+    }
+}

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
@@ -12,6 +12,7 @@ import inha.gdgoc.domain.recruit.member.exception.RecruitMemberErrorCode;
 import inha.gdgoc.domain.recruit.member.exception.RecruitMemberException;
 import inha.gdgoc.domain.recruit.member.repository.RecruitMemberRepository;
 import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.domain.user.repository.UserRepository;
 import inha.gdgoc.global.util.SemesterCalculator;
 import java.time.LocalDate;
@@ -176,6 +177,100 @@ class RecruitMemberApplicationLimitTest {
         assertThatThrownBy(() -> recruitMemberService.findMyApplication(user.getId()))
             .isInstanceOf(RecruitMemberException.class)
             .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_FOUND);
+    }
+
+    // 이메일이 지원서와 계정을 잇는 유일한 키다. 다른 도메인으로 들어오면 나중에 로그인해도
+    // 영영 이어지지 않아 MEMBER 승격이 안 된다. 화면이 도메인을 고정하지만 API 는 열려 있다.
+    @Test
+    void 인하대_이메일이_아니면_지원할_수_없다() {
+        assertThatThrownBy(() ->
+            recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@gmail.com"), null))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN);
+
+        assertThat(recruitMemberRepository.count()).isZero();
+    }
+
+    @Test
+    void 인하대_이메일은_대소문자를_가리지_않는다() {
+        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@INHA.edu"), null);
+
+        assertThat(recruitMemberRepository.count()).isEqualTo(1);
+    }
+
+    // inha.edu 로 끝나기만 하면 통과하는 검사는 fake-inha.edu 같은 도메인을 놓친다.
+    @Test
+    void 인하대_도메인을_흉내낸_주소는_막힌다() {
+        assertThatThrownBy(() ->
+            recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@fake-inha.edu"), null))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN);
+    }
+
+    // ===== 입금 체크와 계정 역할 =====
+    // 지원서에는 계정을 가리키는 컬럼이 없다. 이메일로 이어 붙이는 이 연결이 끊기면
+    // 회비를 내고도 GUEST 로 남아 자유게시판에 글을 쓰지 못한다.
+
+    @Test
+    void 입금_완료로_바꾸면_GUEST_계정이_MEMBER_가_된다() {
+        RecruitMember application = recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
+        User account = userRepository.save(user("hong@inha.edu"));
+
+        recruitMemberService.updatePayment(application.getId(), true);
+
+        assertThat(roleOf(account)).isEqualTo(UserRole.MEMBER);
+    }
+
+    // 잘못 누른 체크를 되돌리면 권한도 함께 돌아와야 한다.
+    @Test
+    void 미입금으로_되돌리면_MEMBER_계정이_GUEST_가_된다() {
+        RecruitMember application = recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
+        User account = userRepository.save(user("hong@inha.edu"));
+        recruitMemberService.updatePayment(application.getId(), true);
+
+        recruitMemberService.updatePayment(application.getId(), false);
+
+        assertThat(roleOf(account)).isEqualTo(UserRole.GUEST);
+    }
+
+    // CORE 이상은 회비와 무관하게 임명된 자리다. 오클릭 한 번으로 운영진이 GUEST 가 되면 안 된다.
+    @Test
+    void 미입금으로_되돌려도_CORE_는_강등되지_않는다() {
+        RecruitMember application = recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
+        User account = userRepository.save(user("hong@inha.edu"));
+        account.changeRole(UserRole.CORE);
+        userRepository.save(account);
+
+        recruitMemberService.updatePayment(application.getId(), true);
+        recruitMemberService.updatePayment(application.getId(), false);
+
+        assertThat(roleOf(account)).isEqualTo(UserRole.CORE);
+    }
+
+    // 지난 학기 지원서의 입금 체크로 이번 학기 권한이 움직이면 안 된다.
+    @Test
+    void 지난_학기_지원서의_입금_체크는_역할을_바꾸지_않는다() {
+        RecruitMember application = recruitMemberRepository.save(
+            member("12200001", "01000000001", "hong@inha.edu", PAST_SEMESTER));
+        User account = userRepository.save(user("hong@inha.edu"));
+
+        recruitMemberService.updatePayment(application.getId(), true);
+
+        assertThat(roleOf(account)).isEqualTo(UserRole.GUEST);
+    }
+
+    // 아직 가입하지 않은 지원자다. 올릴 대상이 없을 뿐 입금 처리 자체는 성공해야 한다.
+    @Test
+    void 계정이_없는_지원자의_입금_체크도_정상_처리된다() {
+        RecruitMember application = recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
+
+        recruitMemberService.updatePayment(application.getId(), true);
+
+        assertThat(recruitMemberRepository.findById(application.getId()).orElseThrow().getIsPayed()).isTrue();
+    }
+
+    private UserRole roleOf(User account) {
+        return userRepository.findById(account.getId()).orElseThrow().getUserRole();
     }
 
     private Map<String, Object> payload(String studentId, String phoneNumber, String email) {


### PR DESCRIPTION
## 배경

부원 지원은 비로그인으로 받는다. 지원서(`recruit_member`)에 계정을 가리키는 컬럼이 없어, **지원해도 `user` 테이블에 레코드가 생기지 않는다.** 그래서 어드민 대시보드의 users 탭에 지원자가 보이지 않았고, 운영진이 한 명씩 수동으로 역할을 올려야 했다.

또 두 지원 서비스에 로그가 하나도 없어, 지원이 어디서 끊기는지 볼 수 없었다.

## 변경

### 1. MEMBER 자동 승격

이메일을 연결 고리로 **두 곳**에서 역할을 맞춘다. 두 자리가 서로의 빈틈을 메운다.

| 지점 | 대상 |
|---|---|
| 로그인·가입 (`AuthService`) | 아직 계정이 없던 지원자가 처음 들어올 때 |
| 입금 체크 (`RecruitMemberService.updatePayment`) | 이미 가입한 사람 — 재로그인 없이 즉시 반영 |

조건은 **현재 학기 지원서 + `isPayed=true`** 다.

- 올릴 때는 **GUEST만**, 내릴 때는 **MEMBER만** 건드린다. CORE 이상은 회비와 무관하게 임명된 자리라, 입금 체크를 잘못 눌러도 운영진이 강등되지 않는다.
- 지난 학기 지원서의 입금 체크로 이번 학기 권한이 움직이지 않도록 학기를 함께 본다.
- 학기가 바뀌어도 MEMBER를 되돌리지 않는다 (강등은 별도 정책).

### 2. 지원 폼 이메일 도메인 검증

이메일이 지원서와 계정을 잇는 **유일한 키**인데 서버 검증이 전혀 없었다. 로그인은 원래 `@inha.edu` 전용이라, 다른 도메인으로 지원하면 나중에 로그인해도 영영 이어지지 않는다. 화면은 도메인을 고정하지만 `/apply`는 인증 없이 열려 있어 주소를 직접 치면 그대로 들어온다.

### 3. 지원 성공/실패 로그

접수와 완료를 따로 남긴다. **접수만 있고 완료가 없으면 서버에서 실패한 것이고, 접수조차 없으면 요청이 도달하지 않은 것이다** — 폼 이탈과 서버 실패가 구별된다.

```
[recruit-member] 지원 접수 - studentId=..., name=..., hasProofFile=true
[recruit-member] 지원 완료 - applicationId=41, semester=Y26_2, studentId=..., name=...
[recruit-member] 지원 거절(중복) - field=email, semester=Y26_2, studentId=..., name=...
[recruit-core]   지원 거절(기간) - phase=CLOSED, boundary=...
```

- 중복 거절에 **어느 필드가 겹쳤는지** 남긴다. 세 검사가 같은 에러코드를 던져 화면에는 구분이 없다.
- 코어 예외 핸들러의 `log.debug` 4개를 `log.info`로 올렸다. 운영 기본 레벨이 INFO라 **지금까지 하나도 찍히지 않았다.**
- 식별자는 학번·이름까지. 이메일은 도메인만 남기고 전화번호·생년월일은 남기지 않는다.

## 테스트

전체 165개 통과. 이번에 14개 추가.

- 승격 6개 — 정상 승격 / 미납 / 지난 학기 / 이력 없음 / 남의 지원서 / 대소문자
- 입금 연동 5개 — 체크 시 승격 / 해제 시 강등 / **CORE는 강등 안 됨** / 지난 학기 무시 / 계정 없어도 처리 성공
- 도메인 검증 3개 — 타 도메인 거부 / 대소문자 / `fake-inha.edu` 흉내 거부

## 배포 순서

**이 PR을 먼저 배포하고 Web PR을 나중에 올린다.** Web의 확인 문구가 여기의 역할 연동을 전제한다.

관련: GDGoCINHA/24-2_GDGoC_Web#360

## 배포 후 확인할 것

`isPayed`가 기준이라, 현재 2학기 지원자들의 **입금 체크가 대시보드에 채워져 있어야** 승격이 일어난다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164CPboxMhVFrADNjFhhUiy