### PR TITLE
feat(recruit): 모집 안내 일정을 관리자가 바꾸도록 연다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/admin/recruit/common/controller/RecruitPeriodAdminController.java
+++ b/src/main/java/inha/gdgoc/domain/admin/recruit/common/controller/RecruitPeriodAdminController.java
@@ -6,7 +6,8 @@ import static inha.gdgoc.domain.admin.recruit.common.controller.message.RecruitP
 
 import inha.gdgoc.domain.admin.recruit.common.dto.request.RecruitPeriodUpdateRequest;
 import inha.gdgoc.domain.admin.recruit.common.dto.response.RecruitPeriodAdminResponse;
-import inha.gdgoc.domain.recruit.common.dto.RecruitWindow;
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
+import inha.gdgoc.domain.recruit.common.service.RecruitPeriodService.SavedPeriod;
 import inha.gdgoc.domain.recruit.common.enums.RecruitType;
 import inha.gdgoc.domain.recruit.common.service.RecruitPeriodService;
 import inha.gdgoc.domain.recruit.core.dto.response.RecruitCorePeriodResponse;
@@ -64,19 +65,25 @@ public class RecruitPeriodAdminController {
         @PathVariable RecruitType recruitType,
         @Valid @RequestBody RecruitPeriodUpdateRequest request) {
 
-        RecruitWindow saved =
+        SavedPeriod saved =
             recruitPeriodService.save(
-                recruitType, request.openAt(), request.closeAt(), me.getUserId());
+                recruitType,
+                request.openAt(),
+                request.closeAt(),
+                request.toNotice(),
+                me.getUserId());
 
         log.warn(
             "[recruit-period] 기간 변경 - type={}, openAt={}, closeAt={}, by={}",
             recruitType,
-            saved.openAt(),
-            saved.closeAt(),
+            saved.window().openAt(),
+            saved.window().closeAt(),
             me.getUserId());
 
         return ResponseEntity.ok(
-            ApiResponse.ok(RECRUIT_PERIOD_UPDATED, RecruitPeriodAdminResponse.of(saved, true)));
+            ApiResponse.ok(
+                RECRUIT_PERIOD_UPDATED,
+                RecruitPeriodAdminResponse.of(saved.window(), true, saved.notice())));
     }
 
     @DeleteMapping
@@ -97,13 +104,16 @@ public class RecruitPeriodAdminController {
      */
     private RecruitPeriodAdminResponse describe(RecruitType recruitType) {
         boolean overridden = recruitPeriodService.find(recruitType).isPresent();
+        RecruitScheduleNotice notice = recruitPeriodService.findNotice(recruitType);
 
         if (recruitType == RecruitType.CORE) {
             RecruitCorePeriodResponse period = recruitCoreApplicationService.getPeriod();
-            return new RecruitPeriodAdminResponse(period.openAt(), period.closeAt(), overridden);
+            return new RecruitPeriodAdminResponse(
+                period.openAt(), period.closeAt(), overridden, notice);
         }
 
         RecruitMemberPeriodResponse period = recruitMemberPeriodService.getPeriod();
-        return new RecruitPeriodAdminResponse(period.openAt(), period.closeAt(), overridden);
+        return new RecruitPeriodAdminResponse(
+            period.openAt(), period.closeAt(), overridden, notice);
     }
 }

--- a/src/main/java/inha/gdgoc/domain/admin/recruit/common/dto/request/RecruitPeriodUpdateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/admin/recruit/common/dto/request/RecruitPeriodUpdateRequest.java
@@ -1,5 +1,6 @@
 package inha.gdgoc.domain.admin.recruit.common.dto.request;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 
@@ -9,5 +10,33 @@ import java.time.Instant;
  * <p>순서 검증({@code openAt < closeAt})은 {@code RecruitWindow} 가 한다 — 설정에서 오는 값과
  * 화면에서 오는 값이 같은 규칙을 지나게 하려는 것이다.
  */
-public record RecruitPeriodUpdateRequest(@NotNull Instant openAt, @NotNull Instant closeAt) {
+public record RecruitPeriodUpdateRequest(
+    @NotNull Instant openAt,
+    @NotNull Instant closeAt,
+    Instant documentResultAt,
+    Instant interviewOpenAt,
+    Instant interviewCloseAt,
+    Instant finalResultAt,
+    String interviewNote,
+    String meetingNote,
+    Instant intensiveOpenAt,
+    Instant intensiveCloseAt) {
+
+    /**
+     * 안내 일정 부분만 떼어낸다.
+     *
+     * <p>기간과 달리 전부 비어도 된다. 비운 칸은 비운 채로 저장된다 — 화면에서 지웠다는 뜻이라
+     * 예전 값을 남겨두면 지운 날짜가 계속 보인다.
+     */
+    public RecruitScheduleNotice toNotice() {
+        return new RecruitScheduleNotice(
+            documentResultAt,
+            interviewOpenAt,
+            interviewCloseAt,
+            finalResultAt,
+            interviewNote,
+            meetingNote,
+            intensiveOpenAt,
+            intensiveCloseAt);
+    }
 }

--- a/src/main/java/inha/gdgoc/domain/admin/recruit/common/dto/response/RecruitPeriodAdminResponse.java
+++ b/src/main/java/inha/gdgoc/domain/admin/recruit/common/dto/response/RecruitPeriodAdminResponse.java
@@ -1,5 +1,6 @@
 package inha.gdgoc.domain.admin.recruit.common.dto.response;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import inha.gdgoc.domain.recruit.common.dto.RecruitWindow;
 import java.time.Instant;
 
@@ -9,9 +10,15 @@ import java.time.Instant;
  * @param overridden 화면에서 저장한 값을 쓰고 있으면 true. false 면 서버 설정값이다 — 이걸 알아야
  *     관리자가 '내가 저장한 값이 먹고 있는지'를 판단할 수 있다.
  */
-public record RecruitPeriodAdminResponse(Instant openAt, Instant closeAt, boolean overridden) {
+public record RecruitPeriodAdminResponse(
+    Instant openAt,
+    Instant closeAt,
+    boolean overridden,
+    RecruitScheduleNotice notice) {
 
-    public static RecruitPeriodAdminResponse of(RecruitWindow window, boolean overridden) {
-        return new RecruitPeriodAdminResponse(window.openAt(), window.closeAt(), overridden);
+    public static RecruitPeriodAdminResponse of(
+        RecruitWindow window, boolean overridden, RecruitScheduleNotice notice) {
+        return new RecruitPeriodAdminResponse(
+            window.openAt(), window.closeAt(), overridden, notice);
     }
 }

--- a/src/main/java/inha/gdgoc/domain/landing/dto/LandingContentPayload.java
+++ b/src/main/java/inha/gdgoc/domain/landing/dto/LandingContentPayload.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.landing.dto;
 
 import inha.gdgoc.domain.landing.enums.LandingBadgeTone;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -23,11 +24,15 @@ import java.util.List;
  */
 public record LandingContentPayload(
     @Valid @NotNull LandingHero hero,
+    @Valid @NotNull LandingAbout about,
     @Valid @NotNull @Size(max = 6) List<LandingPhoto> photoStrip,
     @Valid @NotNull @Size(max = 12) List<LandingActivity> activities,
     @Valid @NotNull LandingHackathonIntro hackathonIntro,
     @Valid @NotNull @Size(max = 12) List<LandingHackathon> hackathons,
-    @Valid @NotNull @Size(max = 12) List<LandingFaq> faqs) {
+    @Valid @NotNull @Size(max = 12) List<LandingFaq> faqs,
+    @Valid @NotNull LandingContact contact,
+    /** 히어로 배지에 붙는 학기 표기. 예: {@code 2026-2}. */
+    @NotBlank @Size(max = 20) String semesterLabel) {
 
   /**
    * 사진 주소로 허용하는 모양.
@@ -36,6 +41,9 @@ public record LandingContentPayload(
    * {@code javascript:}·{@code data:} 를 막기 위한 것이고, 공백과 따옴표·꺾쇠도 함께 막아 둔다.
    */
   private static final String PHOTO_SRC = "^(/images/|https://)[^\\s\"'<>]{1,480}$";
+
+  /** 바깥으로 나가는 링크. 사진과 달리 번들 경로가 없어 https 로 시작하는 것만 받는다. */
+  private static final String LINK_URL = "^https://[^\\s\"'<>]{1,280}$";
 
   public record LandingPhoto(
       @NotBlank @Size(max = 500) @Pattern(regexp = PHOTO_SRC, message = "사진 주소는 /images/ 또는 https:// 로 시작해야 합니다.")
@@ -54,6 +62,35 @@ public record LandingContentPayload(
       @Size(max = 30) String titleTail,
       @Size(max = 200) String description,
       @Size(max = 120) String ctaNote) {}
+
+  /**
+   * 커뮤니티 소개.
+   *
+   * <p>가치 네 칸은 개수가 고정이다. 번호와 색이 GDG 4색에 1:1 로 묶여 있어서 개수가 바뀌면 색이
+   * 어긋난다. 그래서 여기서는 문구만 받고 번호·색은 웹이 자리 순서로 붙인다 — 배지 색을 이름으로만
+   * 받는 것과 같은 이유다.
+   */
+  public record LandingAbout(
+      /** 두 줄로 끊어 쓴다. 화면에서 첫 줄만 흐린 색으로 그린다. */
+      @NotNull @Size(min = 2, max = 2) List<@NotBlank @Size(max = 120) String> heading,
+      @NotBlank @Size(max = 300) String body,
+      @Valid @NotNull @Size(min = 4, max = 4) List<LandingAboutValue> values) {}
+
+  public record LandingAboutValue(
+      @NotBlank @Size(max = 20) String title, @NotBlank @Size(max = 160) String body) {}
+
+  /**
+   * 문의 창구. 바닥글과 FAQ 답변이 같이 쓴다.
+   *
+   * <p>오픈채팅 주소는 https 로 시작하는 것만 받는다. 로그인 없이 보는 첫 화면에 그대로 링크로
+   * 걸리므로 {@code javascript:} 를 막아야 한다 — 사진 주소와 같은 이유다.
+   */
+  public record LandingContact(
+      @NotBlank @Email @Size(max = 120) String email,
+      @NotBlank
+          @Size(max = 300)
+          @Pattern(regexp = LINK_URL, message = "링크는 https:// 로 시작해야 합니다.")
+          String openChatUrl) {}
 
   public record LandingActivity(
       @NotBlank @Size(max = 60) String title, @NotBlank @Size(max = 200) String body) {}

--- a/src/main/java/inha/gdgoc/domain/recruit/common/dto/RecruitScheduleNotice.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/common/dto/RecruitScheduleNotice.java
@@ -1,0 +1,66 @@
+package inha.gdgoc.domain.recruit.common.dto;
+
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import java.time.Instant;
+
+/**
+ * 화면에 보여주는 모집 안내 일정.
+ *
+ * <p>{@link RecruitWindow} 와 나란히 두되 섞지 않는다. 저쪽은 지원 창구를 여닫는 값이고 이쪽은 안내
+ * 문구다 — 이 값이 비어 있어도 지원은 정상적으로 열리고 닫힌다.
+ *
+ * <p>모든 칸이 비어도 된다. 비면 웹이 번들에 든 기본값을 쓴다. 종류마다 쓰는 칸이 다르다 — CORE 는
+ * 서류·면접·최종을, MEMBER 는 집중 모집 기간만 쓴다.
+ */
+public record RecruitScheduleNotice(
+    Instant documentResultAt,
+    Instant interviewOpenAt,
+    Instant interviewCloseAt,
+    Instant finalResultAt,
+    String interviewNote,
+    String meetingNote,
+    Instant intensiveOpenAt,
+    Instant intensiveCloseAt) {
+
+    private static final int NOTE_MAX = 300;
+
+    public RecruitScheduleNotice {
+        interviewNote = normalize(interviewNote);
+        meetingNote = normalize(meetingNote);
+        requireOrder(interviewOpenAt, interviewCloseAt, "면접");
+        requireOrder(intensiveOpenAt, intensiveCloseAt, "집중 모집");
+    }
+
+    /** 아무것도 저장되지 않은 상태. */
+    public static RecruitScheduleNotice empty() {
+        return new RecruitScheduleNotice(null, null, null, null, null, null, null, null);
+    }
+
+    /** 빈 문자열은 null 로 눕힌다 — 화면에서 지웠다는 뜻이라 "빈 문구"로 남기면 안 된다. */
+    private static String normalize(String note) {
+        if (note == null) {
+            return null;
+        }
+        String trimmed = note.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (trimmed.length() > NOTE_MAX) {
+            throw new BusinessException(
+                GlobalErrorCode.BAD_REQUEST, "안내 문구는 " + NOTE_MAX + "자를 넘을 수 없습니다.");
+        }
+        return trimmed;
+    }
+
+    /**
+     * 한쪽만 채운 상태는 허용한다 — 시작만 정해두고 마감을 나중에 정하는 경우가 있다. 둘 다 있는데
+     * 거꾸로인 것만 막는다.
+     */
+    private static void requireOrder(Instant openAt, Instant closeAt, String label) {
+        if (openAt != null && closeAt != null && !openAt.isBefore(closeAt)) {
+            throw new BusinessException(
+                GlobalErrorCode.BAD_REQUEST, label + " 시작이 마감보다 앞서야 합니다.");
+        }
+    }
+}

--- a/src/main/java/inha/gdgoc/domain/recruit/common/entity/RecruitPeriodOverride.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/common/entity/RecruitPeriodOverride.java
@@ -1,5 +1,6 @@
 package inha.gdgoc.domain.recruit.common.entity;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import inha.gdgoc.domain.recruit.common.enums.RecruitType;
 import inha.gdgoc.global.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -34,6 +35,33 @@ public class RecruitPeriodOverride extends BaseEntity {
     @Column(name = "updated_by", nullable = false)
     private Long updatedBy;
 
+    // 아래는 화면에 보여주는 안내 일정이다. 지원 창구를 여닫는 값이 아니라서 전부 비어도 된다.
+    // 종류마다 쓰는 칸이 다르다 — CORE 는 서류·면접·최종, MEMBER 는 집중 모집 기간.
+
+    @Column(name = "document_result_at")
+    private Instant documentResultAt;
+
+    @Column(name = "interview_open_at")
+    private Instant interviewOpenAt;
+
+    @Column(name = "interview_close_at")
+    private Instant interviewCloseAt;
+
+    @Column(name = "final_result_at")
+    private Instant finalResultAt;
+
+    @Column(name = "interview_note", length = 300)
+    private String interviewNote;
+
+    @Column(name = "meeting_note", length = 300)
+    private String meetingNote;
+
+    @Column(name = "intensive_open_at")
+    private Instant intensiveOpenAt;
+
+    @Column(name = "intensive_close_at")
+    private Instant intensiveCloseAt;
+
     public static RecruitPeriodOverride create(
         RecruitType recruitType, Instant openAt, Instant closeAt, Long updatedBy) {
         RecruitPeriodOverride override = new RecruitPeriodOverride();
@@ -46,5 +74,29 @@ public class RecruitPeriodOverride extends BaseEntity {
         this.openAt = openAt;
         this.closeAt = closeAt;
         this.updatedBy = updatedBy;
+    }
+
+    /** 안내 일정을 통째로 덮어쓴다. 비운 칸은 비운 채로 저장한다 — 화면에서 지웠다는 뜻이다. */
+    public void applyNotice(RecruitScheduleNotice notice) {
+        this.documentResultAt = notice.documentResultAt();
+        this.interviewOpenAt = notice.interviewOpenAt();
+        this.interviewCloseAt = notice.interviewCloseAt();
+        this.finalResultAt = notice.finalResultAt();
+        this.interviewNote = notice.interviewNote();
+        this.meetingNote = notice.meetingNote();
+        this.intensiveOpenAt = notice.intensiveOpenAt();
+        this.intensiveCloseAt = notice.intensiveCloseAt();
+    }
+
+    public RecruitScheduleNotice toNotice() {
+        return new RecruitScheduleNotice(
+            documentResultAt,
+            interviewOpenAt,
+            interviewCloseAt,
+            finalResultAt,
+            interviewNote,
+            meetingNote,
+            intensiveOpenAt,
+            intensiveCloseAt);
     }
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/common/service/RecruitPeriodOverrideReader.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/common/service/RecruitPeriodOverrideReader.java
@@ -1,5 +1,6 @@
 package inha.gdgoc.domain.recruit.common.service;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import inha.gdgoc.domain.recruit.common.dto.RecruitWindow;
 import inha.gdgoc.domain.recruit.common.enums.RecruitType;
 import java.util.Optional;
@@ -15,6 +16,16 @@ public interface RecruitPeriodOverrideReader {
 
     /** 덮어쓸 기간이 없으면 비어 있다. 그러면 부르는 쪽이 설정값을 쓴다. */
     Optional<RecruitWindow> find(RecruitType recruitType);
+
+    /**
+     * 화면에 보여줄 안내 일정. 저장된 게 없으면 빈 값이고, 그때는 웹이 번들 기본값을 쓴다.
+     *
+     * <p>기본 구현을 둬서 {@link #NONE} 이 람다로 남는다 — 테스트가 DB 없이 설정값 경로를 검증하는
+     * 방식을 그대로 쓸 수 있다. 안내 일정은 지원 판정에 안 쓰이므로 비어 있어도 아무 문제가 없다.
+     */
+    default RecruitScheduleNotice findNotice(RecruitType recruitType) {
+        return RecruitScheduleNotice.empty();
+    }
 
     RecruitPeriodOverrideReader NONE = recruitType -> Optional.empty();
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/common/service/RecruitPeriodService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/common/service/RecruitPeriodService.java
@@ -1,5 +1,6 @@
 package inha.gdgoc.domain.recruit.common.service;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import inha.gdgoc.domain.recruit.common.dto.RecruitWindow;
 import inha.gdgoc.domain.recruit.common.entity.RecruitPeriodOverride;
 import inha.gdgoc.domain.recruit.common.enums.RecruitType;
@@ -30,10 +31,43 @@ public class RecruitPeriodService implements RecruitPeriodOverrideReader {
             .map(row -> new RecruitWindow(row.getOpenAt(), row.getCloseAt()));
     }
 
+    /**
+     * 화면에 보여줄 안내 일정. 저장된 행이 없으면 빈 값이다 — 그때는 웹이 번들 기본값을 쓴다.
+     *
+     * <p>{@link #find} 와 나눠 둔다. 저쪽은 지원 판정 경로라 매번 불리는데, 안내 일정까지 함께 실어
+     * 보내면 판정에 안 쓰는 값을 계속 읽게 된다.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public RecruitScheduleNotice findNotice(RecruitType recruitType) {
+        return repository
+            .findById(recruitType)
+            .map(RecruitPeriodOverride::toNotice)
+            .orElseGet(RecruitScheduleNotice::empty);
+    }
+
     /** 덮어쓸 기간을 저장한다. 순서 검증은 {@link RecruitWindow} 가 한다. */
     @Transactional
     public RecruitWindow save(
         RecruitType recruitType, Instant openAt, Instant closeAt, Long updatedBy) {
+        return save(recruitType, openAt, closeAt, null, updatedBy).window();
+    }
+
+    /**
+     * 기간과 안내 일정을 함께 저장한다.
+     *
+     * <p>한 번에 저장하는 이유는 이 둘이 관리자 화면에서 한 폼이기 때문이다. 따로 저장하면 기간만
+     * 바뀌고 안내는 옛날 날짜로 남는 중간 상태가 생긴다.
+     *
+     * @param notice null 이면 안내 일정은 건드리지 않는다 (기간만 바꾸는 호출).
+     */
+    @Transactional
+    public SavedPeriod save(
+        RecruitType recruitType,
+        Instant openAt,
+        Instant closeAt,
+        RecruitScheduleNotice notice,
+        Long updatedBy) {
         RecruitWindow window = new RecruitWindow(openAt, closeAt);
 
         RecruitPeriodOverride row =
@@ -44,10 +78,16 @@ public class RecruitPeriodService implements RecruitPeriodOverrideReader {
                         RecruitPeriodOverride.create(
                             recruitType, window.openAt(), window.closeAt(), updatedBy));
         row.apply(window.openAt(), window.closeAt(), updatedBy);
+        if (notice != null) {
+            row.applyNotice(notice);
+        }
         repository.save(row);
 
-        return window;
+        return new SavedPeriod(window, row.toNotice());
     }
+
+    /** 저장 직후의 값. 화면이 되돌려 그리는 데 쓴다. */
+    public record SavedPeriod(RecruitWindow window, RecruitScheduleNotice notice) {}
 
     /**
      * 덮어쓴 기간을 지운다. 지우면 설정값으로 돌아간다.

--- a/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCorePeriodResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/dto/response/RecruitCorePeriodResponse.java
@@ -1,12 +1,18 @@
 package inha.gdgoc.domain.recruit.core.dto.response;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import inha.gdgoc.domain.recruit.core.enums.RecruitCorePeriodStatus;
 import java.time.Instant;
 
+/**
+ * @param notice 서류 발표·면접·최종 발표처럼 화면에만 쓰는 안내 일정. 저장된 게 없으면 칸이 전부
+ *     비어 있고, 그때는 웹이 번들 기본값을 그린다. 지원 가능 여부와는 무관하다.
+ */
 public record RecruitCorePeriodResponse(
     String session,
     Instant openAt,
     Instant closeAt,
-    RecruitCorePeriodStatus status
+    RecruitCorePeriodStatus status,
+    RecruitScheduleNotice notice
 ) {
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/core/service/RecruitCoreApplicationService.java
@@ -272,7 +272,8 @@ public class RecruitCoreApplicationService {
             recruitCoreSessionResolver.currentSession(),
             window.openAt(),
             window.closeAt(),
-            getPeriodStatus());
+            getPeriodStatus(),
+            overrideReader.findNotice(RecruitType.CORE));
     }
 
     public RecruitCorePeriodStatus getPeriodStatus() {

--- a/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberPeriodResponse.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/dto/response/RecruitMemberPeriodResponse.java
@@ -1,5 +1,6 @@
 package inha.gdgoc.domain.recruit.member.dto.response;
 
+import inha.gdgoc.domain.recruit.common.dto.RecruitScheduleNotice;
 import inha.gdgoc.domain.recruit.member.enums.RecruitMemberPeriodStatus;
 import java.time.Instant;
 
@@ -11,6 +12,7 @@ import java.time.Instant;
 public record RecruitMemberPeriodResponse(
     Instant openAt,
     Instant closeAt,
-    RecruitMemberPeriodStatus status
+    RecruitMemberPeriodStatus status,
+    RecruitScheduleNotice notice
 ) {
 }

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberPeriodService.java
@@ -85,7 +85,10 @@ public class RecruitMemberPeriodService {
     public RecruitMemberPeriodResponse getPeriod() {
         RecruitWindow window = window();
         return new RecruitMemberPeriodResponse(
-            window.openAt(), window.closeAt(), getPeriodStatus());
+            window.openAt(),
+            window.closeAt(),
+            getPeriodStatus(),
+            overrideReader.findNotice(RecruitType.MEMBER));
     }
 
     public RecruitMemberPeriodStatus getPeriodStatus() {

--- a/src/main/resources/db/migration/V20260825_3__add_recruit_schedule_notice.sql
+++ b/src/main/resources/db/migration/V20260825_3__add_recruit_schedule_notice.sql
@@ -1,0 +1,30 @@
+-- 모집 안내 일정. 지원 창구를 여닫는 open_at/close_at 과 달리 **화면에 보여주는 값**이다.
+--
+-- 서류 발표·면접·최종 발표 날짜가 웹 상수(recruitSchedule.ts)에만 있어서 바꾸려면 배포가
+-- 필요했다. 랜딩과 지원 안내 두 화면이 같이 쓰는 값이라 랜딩 콘텐츠 문서가 아니라
+-- 모집 쪽에 둔다.
+--
+-- 전부 NULL 을 허용한다. NULL 이면 웹이 번들에 든 기본값을 그대로 쓴다 — 그래서 이
+-- 마이그레이션만 올라가고 아무도 저장하지 않아도 지금 화면이 그대로 유지된다.
+--
+-- 종류마다 쓰는 칸이 다르다. CORE 는 서류·면접·최종을, MEMBER 는 집중 모집 기간만 쓴다.
+-- 한쪽만 쓰는 칸을 이름 없이 공유하면 나중에 어느 쪽 값인지 알 수 없어 따로 둔다.
+ALTER TABLE recruit_period_override
+    ADD COLUMN IF NOT EXISTS document_result_at TIMESTAMPTZ,   -- CORE: 서류 발표
+    ADD COLUMN IF NOT EXISTS interview_open_at  TIMESTAMPTZ,   -- CORE: 면접 시작
+    ADD COLUMN IF NOT EXISTS interview_close_at TIMESTAMPTZ,   -- CORE: 면접 마감
+    ADD COLUMN IF NOT EXISTS final_result_at    TIMESTAMPTZ,   -- CORE: 최종 발표
+    ADD COLUMN IF NOT EXISTS interview_note     VARCHAR(300),  -- CORE: 면접 안내 문구
+    ADD COLUMN IF NOT EXISTS meeting_note       VARCHAR(300),  -- CORE: 상견례 안내 문구
+    ADD COLUMN IF NOT EXISTS intensive_open_at  TIMESTAMPTZ,   -- MEMBER: 집중 모집 시작
+    ADD COLUMN IF NOT EXISTS intensive_close_at TIMESTAMPTZ;   -- MEMBER: 집중 모집 마감
+
+-- 기간을 거꾸로 저장하는 사고를 막는다. 한쪽만 채운 상태는 허용한다 —
+-- 시작만 정해두고 마감을 나중에 정하는 경우가 있다.
+ALTER TABLE recruit_period_override
+    ADD CONSTRAINT chk_recruit_interview_order
+        CHECK (interview_open_at IS NULL OR interview_close_at IS NULL
+               OR interview_open_at < interview_close_at),
+    ADD CONSTRAINT chk_recruit_intensive_order
+        CHECK (intensive_open_at IS NULL OR intensive_close_at IS NULL
+               OR intensive_open_at < intensive_close_at);

--- a/src/test/java/inha/gdgoc/domain/recruit/common/dto/RecruitScheduleNoticeTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/common/dto/RecruitScheduleNoticeTest.java
@@ -1,0 +1,69 @@
+package inha.gdgoc.domain.recruit.common.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 안내 일정이 화면에 그대로 그려지므로, 저장되는 모양을 여기서 정리한다.
+ *
+ * <p>{@link RecruitWindow} 와 달리 전부 비어도 되는 값이다. 그래서 "비어 있어도 통과한다" 를 함께
+ * 못 박아 둔다 — 여기서 예외가 나면 아직 일정을 안 정한 상태에서 기간 저장 자체가 막힌다.
+ */
+class RecruitScheduleNoticeTest {
+
+    private static final Instant NINTH = OffsetDateTime.parse("2026-09-09T00:00:00+09:00").toInstant();
+    private static final Instant THIRTEENTH =
+        OffsetDateTime.parse("2026-09-13T23:59:59+09:00").toInstant();
+
+    private RecruitScheduleNotice interview(Instant openAt, Instant closeAt) {
+        return new RecruitScheduleNotice(null, openAt, closeAt, null, null, null, null, null);
+    }
+
+    @Test
+    @DisplayName("전부 비어 있어도 만들어진다 - 일정을 아직 안 정한 상태다")
+    void allowsEmpty() {
+        assertThatCode(RecruitScheduleNotice::empty).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("한쪽만 채운 기간은 통과한다 - 시작만 정하고 마감을 나중에 정하는 경우가 있다")
+    void allowsHalfFilledPeriod() {
+        assertThatCode(() -> interview(NINTH, null)).doesNotThrowAnyException();
+        assertThatCode(() -> interview(null, THIRTEENTH)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("둘 다 있는데 거꾸로면 막는다")
+    void rejectsReversedPeriod() {
+        assertThatThrownBy(() -> interview(THIRTEENTH, NINTH))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining("면접");
+    }
+
+    @Test
+    @DisplayName("공백만 남은 문구는 null 로 눕힌다 - 화면에서 지웠다는 뜻이다")
+    void blankNoteBecomesNull() {
+        RecruitScheduleNotice notice =
+            new RecruitScheduleNotice(null, null, null, null, "   ", "  안내  ", null, null);
+
+        assertThat(notice.interviewNote()).isNull();
+        assertThat(notice.meetingNote()).isEqualTo("안내");
+    }
+
+    @Test
+    @DisplayName("문구가 컬럼 길이를 넘으면 막는다 - 저장 시점에 깨지면 원인을 못 찾는다")
+    void rejectsTooLongNote() {
+        String tooLong = "가".repeat(301);
+
+        assertThatThrownBy(
+                () -> new RecruitScheduleNotice(null, null, null, null, tooLong, null, null, null))
+            .isInstanceOf(BusinessException.class);
+    }
+}


### PR DESCRIPTION
서류 발표·면접·최종 발표 날짜가 웹 상수에만 있어서 바꾸려면 배포가 필요했다.
`recruit_period_override` 에 화면용 안내 일정 칸을 더해 관리자 화면에서 고치게 한다.

## 스키마

`V20260825_3__add_recruit_schedule_notice.sql` — 기존 테이블에 **NULL 허용 컬럼 8개 추가**.
기존 데이터를 건드리지 않으며, 아무도 저장하지 않으면 NULL 이라 웹이 지금처럼 번들 기본값을 그린다.

## 확인

- `./gradlew compileJava compileTestJava test` 통과
- dev 반영 확인: `GET https://dev-api.gdgocinha.com/api/v1/recruit/core/period` 에 `notice` 키 존재 (운영엔 없음)
- 로컬 스텁으로 관리자 화면 저장 → 온보딩·지원 안내 반영까지 클릭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp5PH1nxuQMHAmYzC2Y3Mz