### PR TITLE
feat(admin): 유저 목록을 권한·팀으로 거르고 이메일·학번으로도 찾는다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/admin/user/controller/UserAdminController.java
+++ b/src/main/java/inha/gdgoc/domain/admin/user/controller/UserAdminController.java
@@ -4,6 +4,8 @@ import inha.gdgoc.domain.admin.user.dto.request.UpdateRoleRequest;
 import inha.gdgoc.domain.admin.user.dto.request.UpdateUserRoleTeamRequest;
 import inha.gdgoc.domain.admin.user.dto.response.UserSummaryResponse;
 import inha.gdgoc.domain.admin.user.service.UserAdminService;
+import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
 import inha.gdgoc.global.dto.response.ApiResponse;
 import inha.gdgoc.global.dto.response.PageMeta;
@@ -55,6 +57,8 @@ public class UserAdminController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<UserSummaryResponse>, PageMeta>> list(
             @RequestParam(required = false) String q,
+            @RequestParam(required = false) UserRole role,
+            @RequestParam(required = false) TeamType team,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "name") String sort,
@@ -62,7 +66,7 @@ public class UserAdminController {
     ) {
         Sort.Direction direction = "ASC".equalsIgnoreCase(dir) ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sort));
-        Page<UserSummaryResponse> result = userAdminService.listUsers(q, pageable);
+        Page<UserSummaryResponse> result = userAdminService.listUsers(q, role, team, pageable);
         return ResponseEntity.ok(ApiResponse.ok("USER_SUMMARY_LIST_RETRIEVED", result, PageMeta.of(result)));
     }
 

--- a/src/main/java/inha/gdgoc/domain/admin/user/service/UserAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/admin/user/service/UserAdminService.java
@@ -26,10 +26,16 @@ public class UserAdminService {
 
     private final UserRepository userRepository;
 
+    /**
+     * 관리자 유저 목록. {@code role}·{@code team} 은 null 이면 걸지 않는다.
+     *
+     * <p>{@code q} 는 이름·이메일·학번을 훑는다. 학과(major)는 뺐다 — DB 에는 코드값이
+     * 들어 있고 화면은 한글 라벨을 보여 주므로, 보이는 대로 쳐도 걸리지 않는다.
+     */
     @Transactional(readOnly = true)
-    public Page<UserSummaryResponse> listUsers(String q, Pageable pageable) {
+    public Page<UserSummaryResponse> listUsers(String q, UserRole role, TeamType team, Pageable pageable) {
         Pageable fixed = rewriteSort(pageable);
-        return userRepository.findSummaries(q, fixed);
+        return userRepository.findSummaries(q, role, team, fixed);
     }
 
     private Pageable rewriteSort(Pageable pageable) {

--- a/src/main/java/inha/gdgoc/domain/user/repository/UserRepository.java
+++ b/src/main/java/inha/gdgoc/domain/user/repository/UserRepository.java
@@ -53,9 +53,19 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             u.id, u.name, u.major, u.studentId, u.email, u.userRole, u.team
         )
         from User u
-        where (:q is null or :q = '' or u.name like concat('%', :q, '%'))
+        where (:q is null or :q = ''
+               or lower(u.name) like lower(concat('%', :q, '%'))
+               or lower(u.email) like lower(concat('%', :q, '%'))
+               or u.studentId like concat('%', :q, '%'))
+          and (:role is null or u.userRole = :role)
+          and (:team is null or u.team = :team)
         """)
-    Page<UserSummaryResponse> findSummaries(@Param("q") String q, Pageable pageable);
+    Page<UserSummaryResponse> findSummaries(
+            @Param("q") String q,
+            @Param("role") UserRole role,
+            @Param("team") TeamType team,
+            Pageable pageable
+    );
 
     @NotNull Optional<User> findById(@NotNull Long id);
 }

--- a/src/test/java/inha/gdgoc/domain/admin/user/service/UserAdminListFilterTest.java
+++ b/src/test/java/inha/gdgoc/domain/admin/user/service/UserAdminListFilterTest.java
@@ -1,0 +1,119 @@
+package inha.gdgoc.domain.admin.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inha.gdgoc.domain.admin.user.dto.response.UserSummaryResponse;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.TeamType;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자 유저 목록의 권한·팀 필터와 검색 범위를 실제 조회로 검증한다.
+ *
+ * <p>전에는 이름 검색뿐이라 관리 화면이 20행씩 넘기며 사람을 찾아야 했다.
+ * 검색이 이메일·학번까지 훑는지도 여기서 잡는다 — 이름만 훑던 시절로 돌아가면
+ * 화면의 placeholder 가 거짓말이 된다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class UserAdminListFilterTest {
+
+    private static final Pageable PAGE = PageRequest.of(0, 20);
+
+    @Autowired
+    private UserAdminService userAdminService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        userRepository.save(user("김가나", "12200001", "01000000001", "gana@inha.edu", UserRole.CORE, TeamType.TECH));
+        userRepository.save(user("이다라", "12200002", "01000000002", "dara@inha.edu", UserRole.CORE, TeamType.HR));
+        userRepository.save(user("박마바", "12200003", "01000000003", "maba@inha.edu", UserRole.MEMBER, null));
+    }
+
+    @Test
+    void 권한으로_거르면_그_권한만_나온다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers(null, UserRole.CORE, null, PAGE);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).allMatch(u -> u.userRole() == UserRole.CORE);
+    }
+
+    @Test
+    void 팀으로_거르면_그_팀만_나온다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers(null, null, TeamType.TECH, PAGE);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("김가나");
+    }
+
+    @Test
+    void 권한과_팀을_함께_걸면_둘_다_만족하는_유저만_나온다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers(null, UserRole.CORE, TeamType.HR, PAGE);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("이다라");
+    }
+
+    @Test
+    void 필터가_없으면_전체가_나온다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers(null, null, null, PAGE);
+
+        assertThat(result.getContent()).hasSize(3);
+    }
+
+    @Test
+    void 검색어가_이메일에도_걸린다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers("dara@", null, null, PAGE);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("이다라");
+    }
+
+    @Test
+    void 검색어가_학번에도_걸린다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers("12200003", null, null, PAGE);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("박마바");
+    }
+
+    @Test
+    void 이름_검색은_그대로_동작한다() {
+        Page<UserSummaryResponse> result = userAdminService.listUsers("가나", null, null, PAGE);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("김가나");
+    }
+
+    private User user(String name, String studentId, String phoneNumber, String email,
+                      UserRole role, TeamType team) {
+        return User.builder()
+                .name(name)
+                .oauthSubject("oauth-" + studentId)
+                .major("컴퓨터공학과")
+                .studentId(studentId)
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .userRole(role)
+                .team(team)
+                .image(null)
+                .social(null)
+                .careers(null)
+                .build();
+    }
+}


### PR DESCRIPTION
## 무엇을

`GET /api/v1/admin/users` 에 `role`·`team` 필터를 추가하고, `q` 검색 범위를 이름 → 이름·이메일·학번으로 넓힌다.

## 왜

관리자 대시보드 Users 화면 리디자인이 권한·팀 필터를 요구하는데, 목록이 서버 페이지네이션(20행)이라 **프론트에서 거르면 현재 페이지 안에서만 걸린다.** "CORE 전체 보기"가 되지 않는다.

## 세부

- `role`·`team` 은 `required=false`. 안 보내면 조건을 걸지 않는다.
- 이름 검색은 `lower()` 를 씌워 영문 이름의 대소문자를 무시한다. 한글은 영향 없다.
- **학과(major)는 검색에 넣지 않았다.** DB 에는 코드값이 들어 있고 화면은 `formatMajorLabel` 로 한글 라벨을 보여 주므로, 보이는 대로 쳐도 걸리지 않는다.

## 검증

`UserAdminListFilterTest` 7건 신규 (H2 실제 조회) — 권한/팀/복합 필터, 필터 없음, 이메일·학번·이름 검색.
`./gradlew cleanTest test` 전체 통과.

## 프론트 순서

이 PR 이 dev 에 반영된 뒤 Web 을 올린다. 반대로 하면 Web 이 없는 파라미터를 보낸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cng5Ne6ei2T7AWBVbD9KJY