### PR TITLE
feat: 행사 신청 폼 빌더와 QR 체크인

### DIFF
--- a/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
+++ b/src/main/java/inha/gdgoc/domain/board/event/service/EventBoardService.java
@@ -11,6 +11,7 @@ import inha.gdgoc.domain.board.event.dto.response.EventBoardSummaryResponse;
 import inha.gdgoc.domain.board.event.entity.EventBoard;
 import inha.gdgoc.domain.board.event.enums.EventBoardStatus;
 import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
 import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.TeamType;
@@ -32,6 +33,7 @@ public class EventBoardService {
 
   private final EventBoardRepository eventBoardRepository;
   private final UserRepository userRepository;
+  private final EventApplicationFormRepository eventApplicationFormRepository;
   private final S3Service s3Service;
   private final AttachmentPolicy attachmentPolicy;
 
@@ -104,6 +106,15 @@ public class EventBoardService {
       board.getAttachments().clear();
       attachmentPolicy.apply(board, req.attachments());
     }
+
+    // 신청 폼은 행사명·기간의 복사본을 들고 있다. 게시글이 사라져도 신청 데이터가 살아 있게 하려는
+    // 것이지, 원본과 갈라지라는 뜻은 아니다. 평소에는 게시글이 원본이므로 여기서 맞춰준다.
+    eventApplicationFormRepository
+        .findByEventBoardId(id)
+        .ifPresent(
+            form ->
+                form.syncEventInfo(
+                    board.getTitle(), board.getEventStartDate(), board.getEventEndDate()));
   }
 
   @Transactional

--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/AdminEventApplicantController.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/AdminEventApplicantController.java
@@ -1,0 +1,102 @@
+package inha.gdgoc.domain.eventapplication.controller;
+
+import static inha.gdgoc.domain.eventapplication.controller.message.EventApplicationMessage.*;
+
+import inha.gdgoc.domain.eventapplication.dto.request.AttendanceUpdateRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.ProxyApplicationRequest;
+import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
+import inha.gdgoc.domain.eventapplication.dto.response.CheckinTokenResponse;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.service.EventApplicantAdminService;
+import inha.gdgoc.domain.eventapplication.service.EventCheckinService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.dto.response.PageMeta;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 운영진의 신청자 확인·참석 처리. */
+@RestController
+@RequestMapping("/api/v1/admin/events/{eventBoardId}/applications")
+@RequiredArgsConstructor
+@Validated
+@Authorize(@Condition(atLeast = UserRole.CORE))
+public class AdminEventApplicantController {
+
+  private final EventApplicantAdminService eventApplicantAdminService;
+  private final EventCheckinService eventCheckinService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<Page<ApplicantResponse>, PageMeta>> listApplicants(
+      @PathVariable Long eventBoardId,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "50") @Min(1) @Max(200) int size,
+      @RequestParam(required = false) ApplicationStatus status) {
+    Page<ApplicantResponse> result =
+        eventApplicantAdminService.listApplicants(
+            eventBoardId, status, PageRequest.of(page, size, Sort.by("appliedAt").ascending()));
+    return ResponseEntity.ok(
+        ApiResponse.ok(APPLICANTS_RETRIEVED, result, PageMeta.of(result)));
+  }
+
+  /** 파일 응답이라 ApiResponse 로 감싸지 않는다. */
+  @GetMapping("/export")
+  public ResponseEntity<byte[]> exportCsv(
+      @PathVariable Long eventBoardId, @RequestParam(required = false) ApplicationStatus status) {
+    byte[] body = eventApplicantAdminService.exportCsv(eventBoardId, status);
+    String fileName =
+        URLEncoder.encode(eventApplicantAdminService.csvFileName(eventBoardId), StandardCharsets.UTF_8)
+            .replace("+", "%20");
+
+    return ResponseEntity.ok()
+        .contentType(new MediaType("text", "csv", StandardCharsets.UTF_8))
+        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + fileName)
+        .body(body);
+  }
+
+  /** QR 화면이 만료 전에 다시 불러 코드를 새로 그린다. */
+  @GetMapping("/checkin-token")
+  public ResponseEntity<ApiResponse<CheckinTokenResponse, Void>> issueCheckinToken(
+      @PathVariable Long eventBoardId) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(CHECKIN_TOKEN_ISSUED, eventCheckinService.issueToken(eventBoardId)));
+  }
+
+  @PatchMapping("/{applicationId}/attendance")
+  public ResponseEntity<ApiResponse<Void, Void>> updateAttendance(
+      @PathVariable Long eventBoardId,
+      @PathVariable Long applicationId,
+      @Valid @RequestBody AttendanceUpdateRequest req) {
+    eventApplicantAdminService.updateAttendance(eventBoardId, applicationId, req);
+    return ResponseEntity.ok(ApiResponse.ok(ATTENDANCE_UPDATED));
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<Long, Void>> registerProxy(
+      @PathVariable Long eventBoardId, @Valid @RequestBody ProxyApplicationRequest req) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(
+            PROXY_REGISTERED, eventApplicantAdminService.registerProxy(eventBoardId, req)));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/AdminEventFormController.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/AdminEventFormController.java
@@ -1,0 +1,93 @@
+package inha.gdgoc.domain.eventapplication.controller;
+
+import static inha.gdgoc.domain.eventapplication.controller.message.EventApplicationMessage.*;
+
+import inha.gdgoc.domain.eventapplication.dto.request.EventFormSaveRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.QuestionOrderRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.QuestionSaveRequest;
+import inha.gdgoc.domain.eventapplication.dto.response.EventFormResponse;
+import inha.gdgoc.domain.eventapplication.service.EventFormAdminService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 운영진의 신청 폼 관리. 행사 게시글 하나에 폼 하나가 붙는다. */
+@RestController
+@RequestMapping("/api/v1/admin/events/{eventBoardId}/form")
+@RequiredArgsConstructor
+@Validated
+@Authorize(@Condition(atLeast = UserRole.CORE))
+public class AdminEventFormController {
+
+  private final EventFormAdminService eventFormAdminService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<EventFormResponse, Void>> getForm(
+      @PathVariable Long eventBoardId) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(FORM_RETRIEVED, eventFormAdminService.getForm(eventBoardId)));
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<Long, Void>> createForm(
+      @PathVariable Long eventBoardId, @Valid @RequestBody EventFormSaveRequest req) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(FORM_CREATED, eventFormAdminService.createForm(eventBoardId, req)));
+  }
+
+  @PutMapping
+  public ResponseEntity<ApiResponse<Void, Void>> updateForm(
+      @PathVariable Long eventBoardId, @Valid @RequestBody EventFormSaveRequest req) {
+    eventFormAdminService.updateForm(eventBoardId, req);
+    return ResponseEntity.ok(ApiResponse.ok(FORM_UPDATED));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<ApiResponse<Void, Void>> deleteForm(@PathVariable Long eventBoardId) {
+    eventFormAdminService.deleteForm(eventBoardId);
+    return ResponseEntity.ok(ApiResponse.ok(FORM_DELETED));
+  }
+
+  @PostMapping("/questions")
+  public ResponseEntity<ApiResponse<Long, Void>> addQuestion(
+      @PathVariable Long eventBoardId, @Valid @RequestBody QuestionSaveRequest req) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(QUESTION_CREATED, eventFormAdminService.addQuestion(eventBoardId, req)));
+  }
+
+  @PutMapping("/questions/order")
+  public ResponseEntity<ApiResponse<Void, Void>> reorderQuestions(
+      @PathVariable Long eventBoardId, @Valid @RequestBody QuestionOrderRequest req) {
+    eventFormAdminService.reorderQuestions(eventBoardId, req);
+    return ResponseEntity.ok(ApiResponse.ok(QUESTION_ORDER_UPDATED));
+  }
+
+  @PutMapping("/questions/{questionId}")
+  public ResponseEntity<ApiResponse<Void, Void>> updateQuestion(
+      @PathVariable Long eventBoardId,
+      @PathVariable Long questionId,
+      @Valid @RequestBody QuestionSaveRequest req) {
+    eventFormAdminService.updateQuestion(eventBoardId, questionId, req);
+    return ResponseEntity.ok(ApiResponse.ok(QUESTION_UPDATED));
+  }
+
+  @DeleteMapping("/questions/{questionId}")
+  public ResponseEntity<ApiResponse<Void, Void>> deleteQuestion(
+      @PathVariable Long eventBoardId, @PathVariable Long questionId) {
+    eventFormAdminService.deleteQuestion(eventBoardId, questionId);
+    return ResponseEntity.ok(ApiResponse.ok(QUESTION_DELETED));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/EventApplicationController.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/EventApplicationController.java
@@ -1,0 +1,81 @@
+package inha.gdgoc.domain.eventapplication.controller;
+
+import static inha.gdgoc.domain.eventapplication.controller.message.EventApplicationMessage.*;
+
+import inha.gdgoc.domain.eventapplication.dto.request.CheckinRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.EventApplicationSubmitRequest;
+import inha.gdgoc.domain.eventapplication.dto.response.CheckinResponse;
+import inha.gdgoc.domain.eventapplication.dto.response.EventFormPublicResponse;
+import inha.gdgoc.domain.eventapplication.service.EventApplicationService;
+import inha.gdgoc.domain.eventapplication.service.EventCheckinService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 부원의 행사 신청.
+ *
+ * <p>신청 자격은 행사마다 다르므로({@code min_role}) 여기서는 로그인만 요구하고 실제 자격은 서비스가 판정한다. 외부 공개 행사는 {@code GUEST} 까지
+ * 신청할 수 있다.
+ */
+@RestController
+@RequestMapping("/api/v1/board/events/{eventBoardId}")
+@RequiredArgsConstructor
+@Validated
+@Authorize(@Condition(atLeast = UserRole.GUEST))
+public class EventApplicationController {
+
+  private final EventApplicationService eventApplicationService;
+  private final EventCheckinService eventCheckinService;
+
+  @GetMapping("/form")
+  public ResponseEntity<ApiResponse<EventFormPublicResponse, Void>> getForm(
+      @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long eventBoardId) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(
+            FORM_RETRIEVED,
+            eventApplicationService.getForm(eventBoardId, me.getUserId(), me.getRole())));
+  }
+
+  @PostMapping("/applications")
+  public ResponseEntity<ApiResponse<Void, Void>> apply(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long eventBoardId,
+      @Valid @RequestBody EventApplicationSubmitRequest req) {
+    eventApplicationService.apply(eventBoardId, req, me.getUserId(), me.getRole());
+    return ResponseEntity.ok(ApiResponse.ok(APPLICATION_SUBMITTED));
+  }
+
+  /** QR 을 찍으면 열리는 화면이 부른다. */
+  @PostMapping("/checkin")
+  public ResponseEntity<ApiResponse<CheckinResponse, Void>> checkIn(
+      @AuthenticationPrincipal CustomUserDetails me,
+      @PathVariable Long eventBoardId,
+      @Valid @RequestBody CheckinRequest req) {
+    CheckinResponse result =
+        eventCheckinService.checkIn(eventBoardId, req.token(), me.getUserId());
+    return ResponseEntity.ok(
+        ApiResponse.ok(result.alreadyCheckedIn() ? CHECKIN_ALREADY : CHECKIN_DONE, result));
+  }
+
+  @DeleteMapping("/applications/me")
+  public ResponseEntity<ApiResponse<Void, Void>> cancel(
+      @AuthenticationPrincipal CustomUserDetails me, @PathVariable Long eventBoardId) {
+    eventApplicationService.cancel(eventBoardId, me.getUserId());
+    return ResponseEntity.ok(ApiResponse.ok(APPLICATION_CANCELED));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/MyActivityController.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/MyActivityController.java
@@ -1,0 +1,35 @@
+package inha.gdgoc.domain.eventapplication.controller;
+
+import static inha.gdgoc.domain.eventapplication.controller.message.EventApplicationMessage.ACTIVITIES_RETRIEVED;
+
+import inha.gdgoc.domain.eventapplication.dto.response.MyActivityResponse;
+import inha.gdgoc.domain.eventapplication.service.MyActivityService;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.config.jwt.TokenProvider.CustomUserDetails;
+import inha.gdgoc.global.dto.response.ApiResponse;
+import inha.gdgoc.global.security.annotation.Authorize;
+import inha.gdgoc.global.security.annotation.Condition;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/me")
+@RequiredArgsConstructor
+@Authorize(@Condition(atLeast = UserRole.GUEST))
+public class MyActivityController {
+
+  private final MyActivityService myActivityService;
+
+  @GetMapping("/activities")
+  public ResponseEntity<ApiResponse<List<MyActivityResponse>, Void>> listMyActivities(
+      @AuthenticationPrincipal CustomUserDetails me) {
+    return ResponseEntity.ok(
+        ApiResponse.ok(
+            ACTIVITIES_RETRIEVED, myActivityService.listMyEventActivities(me.getUserId())));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/message/EventApplicationMessage.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/message/EventApplicationMessage.java
@@ -1,0 +1,26 @@
+package inha.gdgoc.domain.eventapplication.controller.message;
+
+public class EventApplicationMessage {
+
+  public static final String FORM_CREATED = "신청 폼을 만들었습니다.";
+  public static final String FORM_UPDATED = "신청 설정을 저장했습니다.";
+  public static final String FORM_DELETED = "신청 받기를 해제했습니다.";
+  public static final String FORM_RETRIEVED = "신청 폼을 조회했습니다.";
+  public static final String QUESTION_CREATED = "질문을 추가했습니다.";
+  public static final String QUESTION_UPDATED = "질문을 수정했습니다.";
+  public static final String QUESTION_DELETED = "질문을 삭제했습니다.";
+  public static final String QUESTION_ORDER_UPDATED = "질문 순서를 저장했습니다.";
+
+  public static final String APPLICATION_SUBMITTED = "신청이 완료되었습니다.";
+  public static final String APPLICATION_CANCELED = "신청을 취소했습니다.";
+
+  public static final String APPLICANTS_RETRIEVED = "신청자 목록을 조회했습니다.";
+  public static final String ATTENDANCE_UPDATED = "참석 상태를 저장했습니다.";
+  public static final String PROXY_REGISTERED = "현장 참석자를 등록했습니다.";
+
+  public static final String ACTIVITIES_RETRIEVED = "활동 이력을 조회했습니다.";
+
+  public static final String CHECKIN_DONE = "체크인이 완료되었습니다.";
+  public static final String CHECKIN_ALREADY = "이미 체크인된 신청입니다.";
+  public static final String CHECKIN_TOKEN_ISSUED = "체크인 토큰을 발급했습니다.";
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/AttendanceUpdateRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/AttendanceUpdateRequest.java
@@ -1,0 +1,7 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import jakarta.validation.constraints.NotNull;
+
+/** 운영진의 수기 참석 처리. QR 체크인 시각은 건드리지 않는다. */
+public record AttendanceUpdateRequest(@NotNull EventAttendanceStatus status) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/CheckinRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/CheckinRequest.java
@@ -1,0 +1,6 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** QR 에 담겨 있던 토큰. 60 초마다 바뀐다. */
+public record CheckinRequest(@NotBlank String token) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/EventApplicationSubmitRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/EventApplicationSubmitRequest.java
@@ -1,0 +1,15 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * 신청서 제출.
+ *
+ * <p>질문이 없는 행사면 answers 가 비어 있다. value 는 질문 유형에 따라 문자열·숫자·불린·배열로 온다.
+ */
+public record EventApplicationSubmitRequest(@Valid List<AnswerEntry> answers) {
+
+  public record AnswerEntry(@NotNull Long questionId, Object value) {}
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/EventFormSaveRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/EventFormSaveRequest.java
@@ -1,0 +1,26 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import inha.gdgoc.domain.user.enums.UserRole;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import java.time.Instant;
+
+/**
+ * 신청 폼의 설정. 생성과 수정에 함께 쓴다.
+ *
+ * <p>capacity 가 null 이면 정원 무제한이다. 수정에서 정원을 다시 무제한으로 되돌리려면 {@code clearCapacity} 를 true 로 보낸다 — null
+ * 만으로는 "안 바꿈"과 구분되지 않기 때문이다.
+ */
+public record EventFormSaveRequest(
+    Instant opensAt,
+    Instant closesAt,
+    @Min(1) Integer capacity,
+    boolean clearCapacity,
+    UserRole minRole,
+    Boolean isOpen) {
+
+  @AssertTrue(message = "신청 시작이 마감보다 늦을 수 없습니다.")
+  private boolean isPeriodValid() {
+    return opensAt == null || closesAt == null || opensAt.isBefore(closesAt);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/ProxyApplicationRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/ProxyApplicationRequest.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 신청 없이 현장에 온 사람을 운영진이 대신 등록한다.
+ *
+ * <p>마감과 정원을 넘겨도 등록된다. 현장 판단이 폼 설정보다 우선이기 때문이다. 답변은 받지 않으므로 필수 질문이 있어도 비어 있는 채로 남는다.
+ */
+public record ProxyApplicationRequest(@NotNull Long userId, boolean markAttended) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/QuestionOrderRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/QuestionOrderRequest.java
@@ -1,0 +1,7 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+/** 질문 순서 일괄 변경. 폼의 살아 있는 질문 전체를 원하는 순서로 보낸다. */
+public record QuestionOrderRequest(@NotEmpty List<Long> questionIds) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/QuestionSaveRequest.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/request/QuestionSaveRequest.java
@@ -1,0 +1,23 @@
+package inha.gdgoc.domain.eventapplication.dto.request;
+
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * 질문 추가·수정.
+ *
+ * <p>visibleWhenQuestionId 를 비우면 조건이 없는 질문이다. 수정에서 조건을 없애려면 {@code clearCondition} 을 true 로 보낸다.
+ */
+public record QuestionSaveRequest(
+    @NotNull QuestionType type,
+    @NotBlank @Size(max = 255) String label,
+    @Size(max = 500) String helpText,
+    boolean isRequired,
+    List<QuestionOption> options,
+    Long visibleWhenQuestionId,
+    List<String> visibleWhenValues,
+    boolean clearCondition) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/ApplicantResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/ApplicantResponse.java
@@ -1,0 +1,46 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * 운영진이 보는 신청자 한 명.
+ *
+ * <p>{@code checkedInAt} 이 있으면 QR 로 체크인한 것이고, 비어 있는데 참석으로 되어 있으면 운영진이 수기로 찍은 것이다.
+ */
+public record ApplicantResponse(
+    Long applicationId,
+    Long userId,
+    String name,
+    String studentId,
+    String major,
+    String email,
+    String phoneNumber,
+    ApplicationStatus status,
+    EventAttendanceStatus attendanceStatus,
+    Instant appliedAt,
+    Instant canceledAt,
+    Instant checkedInAt,
+    Map<Long, Object> answers) {
+
+  public static ApplicantResponse of(EventApplication application, Map<Long, Object> answers) {
+    var user = application.getUser();
+    return new ApplicantResponse(
+        application.getId(),
+        user.getId(),
+        user.getName(),
+        user.getStudentId(),
+        user.getMajor(),
+        user.getEmail(),
+        user.getPhoneNumber(),
+        application.getStatus(),
+        application.getAttendanceStatus(),
+        application.getAppliedAt(),
+        application.getCanceledAt(),
+        application.getCheckedInAt(),
+        answers);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/CheckinResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/CheckinResponse.java
@@ -1,0 +1,10 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+import java.time.Instant;
+
+/**
+ * 체크인 결과.
+ *
+ * <p>이미 처리된 경우를 오류로 다루지 않는다. 두 번 찍는 것은 흔한 일이고, 빨간 화면을 보여줄 이유가 없다.
+ */
+public record CheckinResponse(boolean alreadyCheckedIn, Instant checkedInAt, String eventTitle) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/CheckinTokenResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/CheckinTokenResponse.java
@@ -1,0 +1,8 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+/**
+ * 관리자 화면이 QR 로 그릴 값.
+ *
+ * <p>{@code expiresInSeconds} 가 0 이 되기 전에 다시 받아 QR 을 새로 그린다.
+ */
+public record CheckinTokenResponse(Long eventBoardId, String token, long expiresInSeconds) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/EventFormPublicResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/EventFormPublicResponse.java
@@ -1,0 +1,70 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 부원이 보는 신청 폼.
+ *
+ * <p>화면이 버튼 상태를 스스로 계산하지 않도록 {@code canApply} 와 그 사유를 함께 내려준다. 같은 판정을 두 곳에서 하면 어긋난다.
+ */
+public record EventFormPublicResponse(
+    Long eventBoardId,
+    String eventTitle,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    Instant opensAt,
+    Instant closesAt,
+    Integer capacity,
+    long appliedCount,
+    Integer remainingSeats,
+    boolean canApply,
+    String blockedReason,
+    List<QuestionResponse> questions,
+    MyApplication myApplication) {
+
+  /** 내 신청 상태. 신청한 적이 없으면 null 이다. */
+  public record MyApplication(
+      ApplicationStatus status,
+      EventAttendanceStatus attendanceStatus,
+      Instant appliedAt,
+      Map<Long, Object> answers) {}
+
+  public static EventFormPublicResponse of(
+      EventApplicationForm form,
+      long appliedCount,
+      boolean canApply,
+      String blockedReason,
+      EventApplication mine,
+      Map<Long, Object> myAnswers) {
+    Integer remaining =
+        form.getCapacity() == null ? null : Math.max(0, form.getCapacity() - (int) appliedCount);
+
+    MyApplication myApplication =
+        mine == null
+            ? null
+            : new MyApplication(
+                mine.getStatus(), mine.getAttendanceStatus(), mine.getAppliedAt(), myAnswers);
+
+    return new EventFormPublicResponse(
+        form.getEventBoardId(),
+        form.getEventTitle(),
+        form.getEventStartDate(),
+        form.getEventEndDate(),
+        form.getOpensAt(),
+        form.getClosesAt(),
+        form.getCapacity(),
+        appliedCount,
+        remaining,
+        canApply,
+        blockedReason,
+        form.activeQuestions().stream().map(QuestionResponse::from).toList(),
+        myApplication);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/EventFormResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/EventFormResponse.java
@@ -1,0 +1,43 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.user.enums.UserRole;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 운영진이 보는 신청 폼.
+ *
+ * <p>appliedCount 는 폼을 어디까지 고칠 수 있는지 가르는 값이라 함께 내려준다. 0 이면 무엇이든 바꿀 수 있고, 1 이상이면 유형·선택지·필수 강화가 막힌다.
+ */
+public record EventFormResponse(
+    Long id,
+    Long eventBoardId,
+    String eventTitle,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    Instant opensAt,
+    Instant closesAt,
+    Integer capacity,
+    UserRole minRole,
+    boolean isOpen,
+    long appliedCount,
+    List<QuestionResponse> questions) {
+
+  public static EventFormResponse of(EventApplicationForm form, long appliedCount) {
+    return new EventFormResponse(
+        form.getId(),
+        form.getEventBoardId(),
+        form.getEventTitle(),
+        form.getEventStartDate(),
+        form.getEventEndDate(),
+        form.getOpensAt(),
+        form.getClosesAt(),
+        form.getCapacity(),
+        form.getMinRole(),
+        form.isOpen(),
+        appliedCount,
+        form.activeQuestions().stream().map(QuestionResponse::from).toList());
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/MyActivityResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/MyActivityResponse.java
@@ -1,0 +1,34 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 마이페이지의 활동 한 줄.
+ *
+ * <p>행사명과 기간을 폼의 복사본에서 읽는다. 게시글이 휴지통에 들어가도 이력이 빈칸이 되지 않는 이유다. {@code eventBoardId} 는 링크를 걸 때만 쓰고, 글이
+ * 사라졌으면 화면이 링크를 빼면 된다.
+ */
+public record MyActivityResponse(
+    Long applicationId,
+    Long eventBoardId,
+    String eventTitle,
+    LocalDate eventStartDate,
+    LocalDate eventEndDate,
+    Instant appliedAt,
+    EventAttendanceStatus attendanceStatus) {
+
+  public static MyActivityResponse from(EventApplication application) {
+    var form = application.getForm();
+    return new MyActivityResponse(
+        application.getId(),
+        form.getEventBoardId(),
+        form.getEventTitle(),
+        form.getEventStartDate(),
+        form.getEventEndDate(),
+        application.getAppliedAt(),
+        application.getAttendanceStatus());
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/QuestionResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/QuestionResponse.java
@@ -1,0 +1,31 @@
+package inha.gdgoc.domain.eventapplication.dto.response;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import java.util.List;
+
+public record QuestionResponse(
+    Long id,
+    QuestionType type,
+    String label,
+    String helpText,
+    boolean isRequired,
+    int sortOrder,
+    List<QuestionOption> options,
+    Long visibleWhenQuestionId,
+    List<String> visibleWhenValues) {
+
+  public static QuestionResponse from(EventFormQuestion question) {
+    return new QuestionResponse(
+        question.getId(),
+        question.getType(),
+        question.getLabel(),
+        question.getHelpText(),
+        question.isRequired(),
+        question.getSortOrder(),
+        question.getOptions(),
+        question.getVisibleWhenQuestionId(),
+        question.getVisibleWhenValues());
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplication.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplication.java
@@ -1,0 +1,124 @@
+package inha.gdgoc.domain.eventapplication.entity;
+
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 한 사람의 행사 신청.
+ *
+ * <p>취소해도 행을 지우지 않고 {@link ApplicationStatus} 만 바꾼다. {@code UNIQUE(form_id, user_id)} 로 중복 신청을 막는데,
+ * 취소를 삭제로 처리하면 재신청 때 이 제약과 충돌하기 때문이다. 재신청은 {@link #reapply} 로 같은 행을 되살린다.
+ *
+ * <p>참석 여부를 여기에 컬럼으로 둔 것은 신청자가 곧 참석 대상이어서다. 별도 참석 표를 만들 이유가 없다.
+ */
+@Entity
+@Table(
+    name = "event_application",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_event_application_form_user",
+            columnNames = {"form_id", "user_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventApplication extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "form_id", nullable = false)
+  private EventApplicationForm form;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 16)
+  private ApplicationStatus status;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "attendance_status", nullable = false, length = 16)
+  private EventAttendanceStatus attendanceStatus;
+
+  /** QR 로 체크인한 시각. 비어 있으면 운영진이 수기로 처리한 것이다. */
+  @Column(name = "checked_in_at")
+  private Instant checkedInAt;
+
+  @Column(name = "applied_at", nullable = false)
+  private Instant appliedAt;
+
+  @Column(name = "canceled_at")
+  private Instant canceledAt;
+
+  @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<EventApplicationAnswer> answers = new ArrayList<>();
+
+  public static EventApplication create(EventApplicationForm form, User user, Instant now) {
+    EventApplication application = new EventApplication();
+    application.form = form;
+    application.user = user;
+    application.status = ApplicationStatus.APPLIED;
+    application.attendanceStatus = EventAttendanceStatus.PENDING;
+    application.appliedAt = now;
+    application.answers = new ArrayList<>();
+    return application;
+  }
+
+  public void cancel(Instant now) {
+    this.status = ApplicationStatus.CANCELED;
+    this.canceledAt = now;
+  }
+
+  /** 취소했던 신청을 되살린다. 답변은 새로 받은 것으로 갈아끼우므로 호출 전에 비운다. */
+  public void reapply(Instant now) {
+    this.status = ApplicationStatus.APPLIED;
+    this.appliedAt = now;
+    this.canceledAt = null;
+  }
+
+  public void checkIn(Instant now) {
+    this.attendanceStatus = EventAttendanceStatus.ATTENDED;
+    this.checkedInAt = now;
+  }
+
+  /** 운영진이 수기로 참석을 바꾼다. QR 체크인 시각은 건드리지 않는다. */
+  public void markAttendance(EventAttendanceStatus status) {
+    this.attendanceStatus = status;
+  }
+
+  public void clearAnswers() {
+    this.answers.clear();
+  }
+
+  public void addAnswer(EventApplicationAnswer answer) {
+    this.answers.add(answer);
+  }
+
+  public boolean isApplied() {
+    return this.status == ApplicationStatus.APPLIED;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplicationAnswer.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplicationAnswer.java
@@ -1,0 +1,60 @@
+package inha.gdgoc.domain.eventapplication.entity;
+
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * 질문 하나에 대한 답변.
+ *
+ * <p>유형마다 형태가 달라 JSON 문자열로 저장한다 — 단답은 {@code "홍길동"}, 복수선택은 {@code ["A","C"]}, 동의는 {@code true}. 지원서
+ * {@code Answer} 가 이미 같은 방식으로 돌아가고 있다.
+ */
+@Entity
+@Table(
+    name = "event_application_answer",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_event_answer_application_question",
+            columnNames = {"application_id", "question_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventApplicationAnswer extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "application_id", nullable = false)
+  private EventApplication application;
+
+  @Column(name = "question_id", nullable = false)
+  private Long questionId;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "value", nullable = false, columnDefinition = "jsonb")
+  private String value;
+
+  public static EventApplicationAnswer create(
+      EventApplication application, Long questionId, String value) {
+    EventApplicationAnswer answer = new EventApplicationAnswer();
+    answer.application = application;
+    answer.questionId = questionId;
+    answer.value = value;
+    return answer;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplicationForm.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplicationForm.java
@@ -1,0 +1,128 @@
+package inha.gdgoc.domain.eventapplication.entity;
+
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 행사 신청 폼.
+ *
+ * <p>이 행이 있어야 행사 상세 화면에 신청 버튼이 뜬다. 신청을 받지 않는 행사는 이 행이 없고, 그런 행사의 게시글은 지금까지와 완전히 동일하게 동작한다.
+ *
+ * <p>{@code eventBoardId} 는 FK 가 아니다. 행사명·기간을 이 표에 복사해 두고, 게시글이 휴지통에 들어가도 신청 데이터와 마이페이지 이력이 살아 있게 한다.
+ * 복사본은 게시글을 수정할 때 {@link #syncEventInfo} 로 함께 갱신한다.
+ */
+@Entity
+@Table(name = "event_application_form")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventApplicationForm extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "event_board_id", nullable = false, unique = true)
+  private Long eventBoardId;
+
+  @Column(name = "event_title", nullable = false, length = 255)
+  private String eventTitle;
+
+  @Column(name = "event_start_date", nullable = false)
+  private LocalDate eventStartDate;
+
+  @Column(name = "event_end_date", nullable = false)
+  private LocalDate eventEndDate;
+
+  @Column(name = "opens_at")
+  private Instant opensAt;
+
+  @Column(name = "closes_at")
+  private Instant closesAt;
+
+  @Column(name = "capacity")
+  private Integer capacity;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "min_role", nullable = false, length = 16)
+  private UserRole minRole;
+
+  @Column(name = "is_open", nullable = false)
+  private boolean isOpen;
+
+  @OneToMany(mappedBy = "form", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy("sortOrder ASC, id ASC")
+  private List<EventFormQuestion> questions = new ArrayList<>();
+
+  public static EventApplicationForm create(
+      Long eventBoardId,
+      String eventTitle,
+      LocalDate eventStartDate,
+      LocalDate eventEndDate,
+      Instant opensAt,
+      Instant closesAt,
+      Integer capacity,
+      UserRole minRole,
+      boolean isOpen) {
+    EventApplicationForm form = new EventApplicationForm();
+    form.eventBoardId = eventBoardId;
+    form.eventTitle = eventTitle;
+    form.eventStartDate = eventStartDate;
+    form.eventEndDate = eventEndDate;
+    form.opensAt = opensAt;
+    form.closesAt = closesAt;
+    form.capacity = capacity;
+    form.minRole = minRole != null ? minRole : UserRole.MEMBER;
+    form.isOpen = isOpen;
+    form.questions = new ArrayList<>();
+    return form;
+  }
+
+  /** 신청 설정을 바꾼다. null 인 항목은 건드리지 않는다. */
+  public void updateSettings(
+      Instant opensAt, Instant closesAt, Integer capacity, UserRole minRole, Boolean isOpen) {
+    if (opensAt != null) this.opensAt = opensAt;
+    if (closesAt != null) this.closesAt = closesAt;
+    if (capacity != null) this.capacity = capacity;
+    if (minRole != null) this.minRole = minRole;
+    if (isOpen != null) this.isOpen = isOpen;
+  }
+
+  /** 정원을 무제한으로 되돌린다. {@link #updateSettings} 로는 null 을 넣을 수 없기 때문이다. */
+  public void clearCapacity() {
+    this.capacity = null;
+  }
+
+  /** 게시글이 수정될 때 복사본을 최신으로 맞춘다. */
+  public void syncEventInfo(String eventTitle, LocalDate eventStartDate, LocalDate eventEndDate) {
+    if (eventTitle != null) this.eventTitle = eventTitle;
+    if (eventStartDate != null) this.eventStartDate = eventStartDate;
+    if (eventEndDate != null) this.eventEndDate = eventEndDate;
+  }
+
+  public void addQuestion(EventFormQuestion question) {
+    this.questions.add(question);
+  }
+
+  /** 삭제되지 않은 질문만 순서대로 돌려준다. */
+  public List<EventFormQuestion> activeQuestions() {
+    return this.questions.stream().filter(q -> !q.isDeleted()).toList();
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventFormQuestion.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventFormQuestion.java
@@ -1,0 +1,134 @@
+package inha.gdgoc.domain.eventapplication.entity;
+
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import inha.gdgoc.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * 신청 폼의 질문 하나.
+ *
+ * <p>{@code visibleWhenQuestionId} 가 있으면 조건부 표시다 — 기준 질문의 답이 {@code visibleWhenValues} 중 하나일 때만 보인다.
+ * 기준 질문은 반드시 자기보다 {@code sortOrder} 가 작아야 하며, 그 규칙 하나로 순환 참조가 구조적으로 불가능해진다.
+ *
+ * <p>기준 질문을 엔티티가 아니라 id 로 들고 있는 것은 의도다. 조건을 평가할 때는 같은 폼의 질문 목록에서 찾으면 되고, 자기 참조 연관을 만들면 로딩만 복잡해진다.
+ */
+@Entity
+@Table(name = "event_form_question")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventFormQuestion extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "form_id", nullable = false)
+  private EventApplicationForm form;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "type", nullable = false, length = 24)
+  private QuestionType type;
+
+  @Column(name = "label", nullable = false, length = 255)
+  private String label;
+
+  @Column(name = "help_text", length = 500)
+  private String helpText;
+
+  @Column(name = "is_required", nullable = false)
+  private boolean isRequired;
+
+  @Column(name = "sort_order", nullable = false)
+  private int sortOrder;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "options", columnDefinition = "jsonb")
+  private List<QuestionOption> options;
+
+  @Column(name = "visible_when_question_id")
+  private Long visibleWhenQuestionId;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "visible_when_values", columnDefinition = "jsonb")
+  private List<String> visibleWhenValues;
+
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted;
+
+  public static EventFormQuestion create(
+      EventApplicationForm form,
+      QuestionType type,
+      String label,
+      String helpText,
+      boolean isRequired,
+      int sortOrder,
+      List<QuestionOption> options,
+      Long visibleWhenQuestionId,
+      List<String> visibleWhenValues) {
+    EventFormQuestion question = new EventFormQuestion();
+    question.form = form;
+    question.type = type;
+    question.label = label;
+    question.helpText = helpText;
+    question.isRequired = isRequired;
+    question.sortOrder = sortOrder;
+    question.options = options;
+    question.visibleWhenQuestionId = visibleWhenQuestionId;
+    question.visibleWhenValues = visibleWhenValues;
+    question.isDeleted = false;
+    return question;
+  }
+
+  /** 문구·도움말·필수 여부를 바꾼다. 신청이 들어온 뒤에도 허용되는 범위다. */
+  public void updateContent(String label, String helpText, Boolean isRequired) {
+    if (label != null) this.label = label;
+    if (helpText != null) this.helpText = helpText;
+    if (isRequired != null) this.isRequired = isRequired;
+  }
+
+  /** 유형과 선택지를 바꾼다. 신청이 한 건이라도 있으면 서비스가 미리 막는다. */
+  public void updateShape(QuestionType type, List<QuestionOption> options) {
+    if (type != null) this.type = type;
+    if (options != null) this.options = options;
+  }
+
+  public void updateSortOrder(int sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  /** 표시 조건을 바꾼다. 기준 질문이 null 이면 조건을 없앤다. */
+  public void updateCondition(Long visibleWhenQuestionId, List<String> visibleWhenValues) {
+    this.visibleWhenQuestionId = visibleWhenQuestionId;
+    this.visibleWhenValues = visibleWhenQuestionId == null ? null : visibleWhenValues;
+  }
+
+  /** 지운 표시만 한다. 기존 답변이 고아가 되지 않도록. */
+  public void softDelete() {
+    this.isDeleted = true;
+  }
+
+  public boolean hasCondition() {
+    return this.visibleWhenQuestionId != null;
+  }
+
+  public boolean referencesOptionValue(String value) {
+    return this.visibleWhenValues != null && this.visibleWhenValues.contains(value);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/entity/QuestionOption.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/entity/QuestionOption.java
@@ -1,0 +1,9 @@
+package inha.gdgoc.domain.eventapplication.entity;
+
+/**
+ * 선택형 질문의 선택지.
+ *
+ * <p>답변에는 {@code value} 를 저장하고 화면에는 {@code label} 을 보여준다. 그래야 운영진이 나중에 문구를 고쳐도 기존 답변이 깨지지 않는다. 라벨을
+ * 그대로 저장하면 오타 하나 고칠 때마다 과거 답변이 고아가 된다.
+ */
+public record QuestionOption(String value, String label) {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/enums/ApplicationStatus.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/enums/ApplicationStatus.java
@@ -1,0 +1,12 @@
+package inha.gdgoc.domain.eventapplication.enums;
+
+/**
+ * 신청 상태.
+ *
+ * <p>취소해도 행을 지우지 않는다. {@code UNIQUE(form_id, user_id)} 로 중복 신청을 막는데, 취소를 삭제로 처리하면 재신청 때 이 제약과 충돌하기
+ * 때문이다. 재신청은 같은 행을 되살린다.
+ */
+public enum ApplicationStatus {
+  APPLIED,
+  CANCELED
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/enums/EventAttendanceStatus.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/enums/EventAttendanceStatus.java
@@ -1,0 +1,40 @@
+package inha.gdgoc.domain.eventapplication.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+/**
+ * 행사 참석 상태.
+ *
+ * <p>코어 정기모임의 {@code AttendanceStatus}(출석·지각·사전승인·결석)와 일부러 분리했다. 정기모임은 코어 전원이 대상이고 날짜당 한 번이지만, 행사는
+ * 신청자만 대상이고 하루에 여러 개가 열리며 사실상 왔다·안 왔다뿐이다.
+ */
+@Getter
+public enum EventAttendanceStatus {
+  PENDING("미확인"),
+  ATTENDED("참석"),
+  NO_SHOW("불참");
+
+  private final String label;
+
+  EventAttendanceStatus(String label) {
+    this.label = label;
+  }
+
+  @JsonCreator
+  public static EventAttendanceStatus from(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String normalized = raw.trim().replace('-', '_').replace(' ', '_').toUpperCase();
+    if (normalized.isBlank()) {
+      return null;
+    }
+    return switch (normalized) {
+      case "PENDING" -> PENDING;
+      case "ATTENDED" -> ATTENDED;
+      case "NO_SHOW", "NOSHOW", "ABSENT" -> NO_SHOW;
+      default -> throw new IllegalArgumentException("Unknown attendance status: " + raw);
+    };
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/enums/QuestionType.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/enums/QuestionType.java
@@ -1,0 +1,56 @@
+package inha.gdgoc.domain.eventapplication.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+/**
+ * 신청 폼의 질문 유형.
+ *
+ * <p>관리자는 질문을 몇 개든 추가할 수 있지만 유형은 이 목록에서 고른다. 유형마다 화면에 그리는 방법도, 검증 규칙도, 저장 형태도 다르기 때문이다. 새 유형을 늘리려면 여기와
+ * 프론트 렌더러를 함께 고쳐야 한다.
+ */
+@Getter
+public enum QuestionType {
+  SHORT_TEXT(false, false),
+  LONG_TEXT(false, false),
+  NUMBER(false, false),
+  DATE(false, false),
+  SINGLE_CHOICE(true, true),
+  MULTI_CHOICE(true, true),
+  DROPDOWN(true, true),
+  FILE(false, false),
+  AGREEMENT(false, true);
+
+  /** 선택지 목록이 반드시 있어야 하는 유형인지. */
+  private final boolean requiresOptions;
+
+  /** 다른 질문의 표시 조건에서 기준으로 삼을 수 있는 유형인지. */
+  private final boolean usableAsCondition;
+
+  QuestionType(boolean requiresOptions, boolean usableAsCondition) {
+    this.requiresOptions = requiresOptions;
+    this.usableAsCondition = usableAsCondition;
+  }
+
+  /**
+   * 요청 본문의 문자열을 유형으로 바꾼다.
+   *
+   * <p>null 을 먼저 거른다. {@code Set.of(...).contains(null)} 은 NPE 를 던져 400 이어야 할 응답이 500 이 된다.
+   */
+  @JsonCreator
+  public static QuestionType from(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String normalized = raw.trim().replace('-', '_').replace(' ', '_').toUpperCase();
+    if (normalized.isBlank()) {
+      return null;
+    }
+    for (QuestionType type : values()) {
+      if (type.name().equals(normalized)) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Unknown question type: " + raw);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
@@ -1,0 +1,59 @@
+package inha.gdgoc.domain.eventapplication.exception;
+
+import inha.gdgoc.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventApplicationErrorCode implements ErrorCode {
+  EVENT_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "행사를 찾을 수 없습니다."),
+  FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "이 행사는 신청을 받고 있지 않습니다."),
+  FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 신청 폼이 있는 행사입니다."),
+  FORM_HAS_APPLICATIONS(HttpStatus.BAD_REQUEST, "신청자가 있어 신청 받기를 해제할 수 없습니다. 마감으로 닫아주세요."),
+  QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문을 찾을 수 없습니다."),
+
+  OPTIONS_REQUIRED(HttpStatus.BAD_REQUEST, "선택형 질문에는 선택지가 필요합니다."),
+  OPTIONS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "이 유형의 질문에는 선택지를 둘 수 없습니다."),
+  OPTION_VALUE_DUPLICATED(HttpStatus.BAD_REQUEST, "선택지 값이 중복됩니다."),
+  OPTION_VALUE_BLANK(HttpStatus.BAD_REQUEST, "선택지 값과 라벨은 비워둘 수 없습니다."),
+
+  QUESTION_SHAPE_LOCKED(HttpStatus.BAD_REQUEST, "신청자가 있어 질문 유형과 선택지를 바꿀 수 없습니다."),
+  QUESTION_REQUIRED_LOCKED(HttpStatus.BAD_REQUEST, "신청자가 있어 선택 질문을 필수로 바꿀 수 없습니다."),
+  QUESTION_MUST_BE_OPTIONAL(HttpStatus.BAD_REQUEST, "신청자가 있으면 선택 질문만 추가할 수 있습니다."),
+  OPTION_VALUE_LOCKED(HttpStatus.BAD_REQUEST, "신청자가 있어 선택지를 지울 수 없습니다. 라벨은 고칠 수 있습니다."),
+
+  CONDITION_QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "조건의 기준 질문을 찾을 수 없습니다."),
+  CONDITION_QUESTION_NOT_BEFORE(HttpStatus.BAD_REQUEST, "조건의 기준은 앞 순서 질문이어야 합니다."),
+  CONDITION_QUESTION_TYPE_INVALID(HttpStatus.BAD_REQUEST, "선택형 질문만 조건의 기준이 될 수 있습니다."),
+  CONDITION_VALUE_INVALID(HttpStatus.BAD_REQUEST, "조건 값이 기준 질문의 선택지에 없습니다."),
+  CONDITION_VALUES_EMPTY(HttpStatus.BAD_REQUEST, "조건 값을 하나 이상 지정해야 합니다."),
+  CONDITION_REFERENCED(HttpStatus.BAD_REQUEST, "이 질문을 기준으로 삼는 조건이 있습니다. 조건을 먼저 푸세요."),
+  CONDITION_ORDER_BROKEN(HttpStatus.BAD_REQUEST, "이 순서로 바꾸면 조건이 뒤 질문을 가리키게 됩니다."),
+
+  CAPACITY_BELOW_APPLICANTS(HttpStatus.BAD_REQUEST, "현재 신청자 수보다 적은 정원으로는 줄일 수 없습니다."),
+  PERIOD_INVALID(HttpStatus.BAD_REQUEST, "신청 시작이 마감보다 늦을 수 없습니다."),
+  SORT_ORDER_MISMATCH(HttpStatus.BAD_REQUEST, "순서를 바꿀 질문 목록이 현재 질문과 일치하지 않습니다."),
+
+  NOT_OPEN_YET(HttpStatus.BAD_REQUEST, "아직 신청 기간이 아닙니다."),
+  ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "신청이 마감되었습니다."),
+  FORM_CLOSED(HttpStatus.BAD_REQUEST, "지금은 신청을 받지 않습니다."),
+  NOT_ELIGIBLE(HttpStatus.FORBIDDEN, "이 행사에 신청할 수 있는 권한이 아닙니다."),
+  CAPACITY_FULL(HttpStatus.BAD_REQUEST, "정원이 찼습니다."),
+  ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 신청한 행사입니다."),
+  APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "신청 내역이 없습니다."),
+
+  ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "필수 질문에 답하지 않았습니다."),
+  ANSWER_TYPE_INVALID(HttpStatus.BAD_REQUEST, "답변 형태가 질문 유형과 맞지 않습니다."),
+  ANSWER_VALUE_INVALID(HttpStatus.BAD_REQUEST, "선택지에 없는 값입니다."),
+  ANSWER_QUESTION_UNKNOWN(HttpStatus.BAD_REQUEST, "이 폼에 없는 질문에 답했습니다."),
+  ANSWER_SERIALIZE_FAILED(HttpStatus.BAD_REQUEST, "답변을 저장할 수 없는 형태입니다."),
+
+  CHECKIN_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "QR 이 만료되었습니다. 화면의 QR 을 다시 찍어주세요."),
+  CHECKIN_NOT_IN_PERIOD(HttpStatus.BAD_REQUEST, "행사 기간에만 체크인할 수 있습니다."),
+  CHECKIN_NOT_APPLIED(HttpStatus.BAD_REQUEST, "신청 내역이 없습니다. 먼저 신청해주세요.");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
@@ -45,6 +45,7 @@ public enum EventApplicationErrorCode implements ErrorCode {
   APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "신청 내역이 없습니다."),
 
   ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "필수 질문에 답하지 않았습니다."),
+  AGREEMENT_REQUIRED(HttpStatus.BAD_REQUEST, "필수 동의 항목에 동의해야 신청할 수 있습니다."),
   ANSWER_TYPE_INVALID(HttpStatus.BAD_REQUEST, "답변 형태가 질문 유형과 맞지 않습니다."),
   ANSWER_VALUE_INVALID(HttpStatus.BAD_REQUEST, "선택지에 없는 값입니다."),
   ANSWER_QUESTION_UNKNOWN(HttpStatus.BAD_REQUEST, "이 폼에 없는 질문에 답했습니다."),

--- a/src/main/java/inha/gdgoc/domain/eventapplication/repository/EventApplicationFormRepository.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/repository/EventApplicationFormRepository.java
@@ -1,0 +1,26 @@
+package inha.gdgoc.domain.eventapplication.repository;
+
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EventApplicationFormRepository extends JpaRepository<EventApplicationForm, Long> {
+
+  Optional<EventApplicationForm> findByEventBoardId(Long eventBoardId);
+
+  boolean existsByEventBoardId(Long eventBoardId);
+
+  /**
+   * 정원을 세기 전에 폼 행을 잠근다.
+   *
+   * <p>잠그지 않으면 신청이 몰릴 때 여러 요청이 {@code count < capacity} 를 동시에 통과해 정원을 넘긴다. 우리 규모에서는 이 한 줄이면 충분하고,
+   * 카운터 컬럼이나 낙관적 락을 따로 둘 이유가 없다.
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select f from EventApplicationForm f where f.eventBoardId = :eventBoardId")
+  Optional<EventApplicationForm> findByEventBoardIdForUpdate(@Param("eventBoardId") Long eventBoardId);
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/repository/EventApplicationRepository.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/repository/EventApplicationRepository.java
@@ -1,0 +1,56 @@
+package inha.gdgoc.domain.eventapplication.repository;
+
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EventApplicationRepository extends JpaRepository<EventApplication, Long> {
+
+  /** 폼 수정 허용 범위와 정원을 가르는 기준. 취소한 신청은 세지 않는다. */
+  long countByFormIdAndStatus(Long formId, ApplicationStatus status);
+
+  Optional<EventApplication> findByFormIdAndUserId(Long formId, Long userId);
+
+  /**
+   * 신청자 목록. status 가 null 이면 취소한 사람까지 보여준다.
+   *
+   * <p>사용자를 fetch join 하지 않으면 목록 한 쪽마다 사람 수만큼 쿼리가 더 나간다.
+   */
+  @Query(
+      value =
+          "select a from EventApplication a join fetch a.user "
+              + "where a.form.id = :formId and (:status is null or a.status = :status)",
+      countQuery =
+          "select count(a) from EventApplication a "
+              + "where a.form.id = :formId and (:status is null or a.status = :status)")
+  Page<EventApplication> findApplicants(
+      @Param("formId") Long formId,
+      @Param("status") ApplicationStatus status,
+      Pageable pageable);
+
+  /**
+   * 마이페이지 활동 이력.
+   *
+   * <p>폼을 fetch join 해서 행사명·기간을 그 복사본에서 읽는다. 게시판 표를 조인하지 않으므로 글이 휴지통에 들어가도 이력이 비지 않는다.
+   */
+  @Query(
+      "select a from EventApplication a join fetch a.form f "
+          + "where a.user.id = :userId and a.status = :status "
+          + "order by f.eventStartDate desc, a.appliedAt desc")
+  List<EventApplication> findMyActivities(
+      @Param("userId") Long userId, @Param("status") ApplicationStatus status);
+
+  /** CSV 로 내보낼 때는 페이지 없이 전부 가져온다. */
+  @Query(
+      "select a from EventApplication a join fetch a.user "
+          + "where a.form.id = :formId and (:status is null or a.status = :status) "
+          + "order by a.appliedAt asc")
+  List<EventApplication> findAllApplicants(
+      @Param("formId") Long formId, @Param("status") ApplicationStatus status);
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/repository/EventFormQuestionRepository.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/repository/EventFormQuestionRepository.java
@@ -1,0 +1,6 @@
+package inha.gdgoc.domain.eventapplication.repository;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventFormQuestionRepository extends JpaRepository<EventFormQuestion, Long> {}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/AnswerCodec.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/AnswerCodec.java
@@ -1,0 +1,51 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.ANSWER_SERIALIZE_FAILED;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationAnswer;
+import inha.gdgoc.global.exception.BusinessException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 답변 값과 jsonb 문자열 사이를 오간다.
+ *
+ * <p>컬럼이 jsonb 라 Hibernate 는 String 을 JSON 텍스트 그대로 바인딩한다. 즉 여기서 만든 문자열이 DB 에 그대로 들어가며, 문자열 답변이 이중으로
+ * 인용되는 일은 없다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AnswerCodec {
+
+  private final ObjectMapper objectMapper;
+
+  public String write(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      throw new BusinessException(ANSWER_SERIALIZE_FAILED);
+    }
+  }
+
+  public Object read(String raw) {
+    try {
+      return objectMapper.readValue(raw, Object.class);
+    } catch (JsonProcessingException e) {
+      // 저장할 때 직렬화한 값이라 깨질 일은 없지만, 한 건 때문에 목록 전체를 막지는 않는다.
+      return null;
+    }
+  }
+
+  public Map<Long, Object> readAll(EventApplication application) {
+    Map<Long, Object> answers = new LinkedHashMap<>();
+    for (EventApplicationAnswer answer : application.getAnswers()) {
+      answers.put(answer.getQuestionId(), read(answer.getValue()));
+    }
+    return answers;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/AnswerValidator.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/AnswerValidator.java
@@ -1,0 +1,148 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.*;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/**
+ * 신청서에 딸려온 답변을 검사하고, 실제로 저장할 답변만 골라낸다.
+ *
+ * <p>화면이 "이건 숨겼으니 검사하지 마세요"라고 하는 것을 믿지 않는다. 서버가 받은 답변으로 조건을 직접 평가해 보이는 질문을 정하고, 그 결과로 필수를 검사한다. 숨겨진
+ * 질문에 딸려온 답은 400 을 내지 않고 조용히 버린다 — 사용자가 선택을 바꾸는 과정에서 자연스럽게 생기는 값이라 오류로 다룰 일이 아니다.
+ */
+@Component
+public class AnswerValidator {
+
+  /**
+   * @param questions 살아 있는 질문을 sortOrder 오름차순으로
+   * @param submitted 질문 id → 제출된 값
+   * @return 저장할 답변만 남긴 맵. 숨겨진 질문은 빠져 있다
+   */
+  public Map<Long, Object> validateAndFilter(
+      List<EventFormQuestion> questions, Map<Long, Object> submitted) {
+    Set<Long> known = new HashSet<>();
+    for (EventFormQuestion question : questions) {
+      known.add(question.getId());
+    }
+    for (Long questionId : submitted.keySet()) {
+      if (!known.contains(questionId)) {
+        throw new BusinessException(ANSWER_QUESTION_UNKNOWN);
+      }
+    }
+
+    Set<Long> visible = QuestionConditionEvaluator.visibleQuestionIds(questions, submitted);
+
+    Map<Long, Object> kept = new LinkedHashMap<>();
+    for (EventFormQuestion question : questions) {
+      if (!visible.contains(question.getId())) {
+        continue; // 숨겨진 질문의 답은 버린다.
+      }
+      Object value = submitted.get(question.getId());
+      if (isEmpty(value)) {
+        if (question.isRequired()) {
+          throw new BusinessException(ANSWER_REQUIRED);
+        }
+        continue;
+      }
+      validateShape(question, value);
+      kept.put(question.getId(), value);
+    }
+    return kept;
+  }
+
+  private boolean isEmpty(Object value) {
+    if (value == null) {
+      return true;
+    }
+    if (value instanceof String s) {
+      return s.isBlank();
+    }
+    if (value instanceof Collection<?> c) {
+      return c.isEmpty();
+    }
+    return false;
+  }
+
+  private void validateShape(EventFormQuestion question, Object value) {
+    switch (question.getType()) {
+      case SHORT_TEXT, LONG_TEXT -> requireString(value);
+      case NUMBER -> {
+        if (!(value instanceof Number)) {
+          throw new BusinessException(ANSWER_TYPE_INVALID);
+        }
+      }
+      case DATE -> requireIsoDate(value);
+      case AGREEMENT -> {
+        if (!(value instanceof Boolean)) {
+          throw new BusinessException(ANSWER_TYPE_INVALID);
+        }
+      }
+      case SINGLE_CHOICE, DROPDOWN -> {
+        String selected = requireString(value);
+        if (!allowedValues(question).contains(selected)) {
+          throw new BusinessException(ANSWER_VALUE_INVALID);
+        }
+      }
+      case MULTI_CHOICE -> {
+        if (!(value instanceof Collection<?> selected)) {
+          throw new BusinessException(ANSWER_TYPE_INVALID);
+        }
+        Set<String> allowed = allowedValues(question);
+        for (Object item : selected) {
+          if (!(item instanceof String s)) {
+            throw new BusinessException(ANSWER_TYPE_INVALID);
+          }
+          if (!allowed.contains(s)) {
+            throw new BusinessException(ANSWER_VALUE_INVALID);
+          }
+        }
+      }
+      // 파일은 업로드가 끝난 S3 키를 받는다. 키의 실재 확인은 저장 단계에서 한다.
+      case FILE -> {
+        if (!(value instanceof Map<?, ?>) && !(value instanceof String)) {
+          throw new BusinessException(ANSWER_TYPE_INVALID);
+        }
+      }
+    }
+  }
+
+  private String requireString(Object value) {
+    if (!(value instanceof String s)) {
+      throw new BusinessException(ANSWER_TYPE_INVALID);
+    }
+    return s;
+  }
+
+  private void requireIsoDate(Object value) {
+    String raw = requireString(value);
+    try {
+      LocalDate.parse(raw);
+    } catch (DateTimeParseException e) {
+      throw new BusinessException(ANSWER_TYPE_INVALID);
+    }
+  }
+
+  private Set<String> allowedValues(EventFormQuestion question) {
+    Set<String> values = new HashSet<>();
+    List<QuestionOption> options = question.getOptions();
+    if (options != null) {
+      for (QuestionOption option : options) {
+        if (option != null && option.value() != null) {
+          values.add(option.value());
+        }
+      }
+    }
+    return values;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/AnswerValidator.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/AnswerValidator.java
@@ -84,8 +84,12 @@ public class AnswerValidator {
       }
       case DATE -> requireIsoDate(value);
       case AGREEMENT -> {
-        if (!(value instanceof Boolean)) {
+        if (!(value instanceof Boolean agreed)) {
           throw new BusinessException(ANSWER_TYPE_INVALID);
+        }
+        // 체크를 푼 것도 '답한 것'으로 보면 개인정보 동의에 동의하지 않고 신청이 된다.
+        if (question.isRequired() && !agreed) {
+          throw new BusinessException(AGREEMENT_REQUIRED);
         }
       }
       case SINGLE_CHOICE, DROPDOWN -> {

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriter.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriter.java
@@ -1,0 +1,106 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * 신청자 목록을 CSV 로 만든다. 운영진은 결국 스프레드시트에서 확인하기 때문에 이게 없으면 구글폼을 계속 쓰게 된다.
+ *
+ * <p>맨 앞에 UTF-8 BOM 을 넣는다. 없으면 Excel 이 한글을 깨진 글자로 연다 — 파일 자체는 멀쩡한데 받는 사람에게는 버그로 보인다.
+ */
+@Component
+public class ApplicantCsvWriter {
+
+  private static final byte[] UTF8_BOM = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+  private static final DateTimeFormatter TIMESTAMP =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(KST);
+
+  private static final List<String> FIXED_HEADERS =
+      List.of("이름", "학번", "학과", "이메일", "연락처", "신청일시", "상태", "참석", "체크인");
+
+  /**
+   * @param questions 삭제된 질문까지 포함해 넘긴다. 지운 뒤에도 과거 답변은 남아 있기 때문이다
+   */
+  public byte[] write(List<EventFormQuestion> questions, List<ApplicantResponse> applicants) {
+    StringBuilder sb = new StringBuilder();
+
+    List<String> headers = new java.util.ArrayList<>(FIXED_HEADERS);
+    for (EventFormQuestion question : questions) {
+      headers.add(question.isDeleted() ? "(삭제됨) " + question.getLabel() : question.getLabel());
+    }
+    sb.append(headers.stream().map(this::escape).collect(Collectors.joining(","))).append("\r\n");
+
+    for (ApplicantResponse applicant : applicants) {
+      List<String> cells = new java.util.ArrayList<>();
+      cells.add(applicant.name());
+      cells.add(applicant.studentId());
+      cells.add(applicant.major());
+      cells.add(applicant.email());
+      cells.add(applicant.phoneNumber());
+      cells.add(format(applicant.appliedAt()));
+      cells.add(applicant.status() == null ? "" : applicant.status().name());
+      cells.add(applicant.attendanceStatus() == null ? "" : applicant.attendanceStatus().getLabel());
+      cells.add(format(applicant.checkedInAt()));
+
+      Map<Long, Object> answers = applicant.answers();
+      for (EventFormQuestion question : questions) {
+        cells.add(stringify(answers == null ? null : answers.get(question.getId())));
+      }
+      sb.append(cells.stream().map(this::escape).collect(Collectors.joining(","))).append("\r\n");
+    }
+
+    return withBom(sb.toString());
+  }
+
+  private byte[] withBom(String body) {
+    byte[] content = body.getBytes(StandardCharsets.UTF_8);
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream(UTF8_BOM.length + content.length)) {
+      out.write(UTF8_BOM);
+      out.write(content);
+      return out.toByteArray();
+    } catch (IOException e) {
+      // ByteArrayOutputStream 은 IO 를 하지 않는다. 여기 오면 JDK 가 이상한 것이다.
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private String format(Instant instant) {
+    return instant == null ? "" : TIMESTAMP.format(instant);
+  }
+
+  /** 다중선택은 한 칸에 모아 적는다. 셀 안의 쉼표는 escape 가 처리한다. */
+  private String stringify(Object value) {
+    if (value == null) {
+      return "";
+    }
+    if (value instanceof Collection<?> collection) {
+      return collection.stream().map(String::valueOf).collect(Collectors.joining(", "));
+    }
+    if (value instanceof Boolean b) {
+      return b ? "O" : "X";
+    }
+    return String.valueOf(value);
+  }
+
+  private String escape(String raw) {
+    if (raw == null) {
+      return "";
+    }
+    if (raw.contains(",") || raw.contains("\"") || raw.contains("\n") || raw.contains("\r")) {
+      return '"' + raw.replace("\"", "\"\"") + '"';
+    }
+    return raw;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriter.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriter.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.eventapplication.service;
 
 import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
 import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -56,7 +57,8 @@ public class ApplicantCsvWriter {
 
       Map<Long, Object> answers = applicant.answers();
       for (EventFormQuestion question : questions) {
-        cells.add(stringify(answers == null ? null : answers.get(question.getId())));
+        cells.add(
+            stringify(answers == null ? null : answers.get(question.getId()), labelsOf(question)));
       }
       sb.append(cells.stream().map(this::escape).collect(Collectors.joining(","))).append("\r\n");
     }
@@ -80,18 +82,40 @@ public class ApplicantCsvWriter {
     return instant == null ? "" : TIMESTAMP.format(instant);
   }
 
+  /** 답변에는 선택지의 value 가 들어 있다. 사람이 읽는 파일이므로 label 로 바꿔 적는다. */
+  private Map<String, String> labelsOf(EventFormQuestion question) {
+    if (question.getOptions() == null) {
+      return Map.of();
+    }
+    Map<String, String> labels = new java.util.HashMap<>();
+    for (QuestionOption option : question.getOptions()) {
+      if (option != null && option.value() != null && option.label() != null) {
+        labels.put(option.value(), option.label());
+      }
+    }
+    return labels;
+  }
+
   /** 다중선택은 한 칸에 모아 적는다. 셀 안의 쉼표는 escape 가 처리한다. */
-  private String stringify(Object value) {
+  private String stringify(Object value, Map<String, String> labels) {
     if (value == null) {
       return "";
     }
     if (value instanceof Collection<?> collection) {
-      return collection.stream().map(String::valueOf).collect(Collectors.joining(", "));
+      return collection.stream()
+          .map(item -> label(item, labels))
+          .collect(Collectors.joining(", "));
     }
     if (value instanceof Boolean b) {
       return b ? "O" : "X";
     }
-    return String.valueOf(value);
+    return label(value, labels);
+  }
+
+  /** 선택지가 지워졌거나 자유 입력이면 저장된 값을 그대로 쓴다. */
+  private String label(Object value, Map<String, String> labels) {
+    String raw = String.valueOf(value);
+    return labels.getOrDefault(raw, raw);
   }
 
   private String escape(String raw) {

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminService.java
@@ -1,0 +1,150 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.*;
+
+import inha.gdgoc.domain.eventapplication.dto.request.AttendanceUpdateRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.ProxyApplicationRequest;
+import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 운영진의 신청자 확인과 참석 처리. */
+@Service
+@Transactional(readOnly = true)
+public class EventApplicantAdminService {
+
+  private final EventApplicationFormRepository formRepository;
+  private final EventApplicationRepository applicationRepository;
+  private final UserRepository userRepository;
+  private final AnswerCodec answerCodec;
+  private final ApplicantCsvWriter csvWriter;
+  private final Clock clock;
+
+  @Autowired
+  public EventApplicantAdminService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      UserRepository userRepository,
+      AnswerCodec answerCodec,
+      ApplicantCsvWriter csvWriter) {
+    this(
+        formRepository,
+        applicationRepository,
+        userRepository,
+        answerCodec,
+        csvWriter,
+        Clock.system(ZoneId.of("Asia/Seoul")));
+  }
+
+  public EventApplicantAdminService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      UserRepository userRepository,
+      AnswerCodec answerCodec,
+      ApplicantCsvWriter csvWriter,
+      Clock clock) {
+    this.formRepository = formRepository;
+    this.applicationRepository = applicationRepository;
+    this.userRepository = userRepository;
+    this.answerCodec = answerCodec;
+    this.csvWriter = csvWriter;
+    this.clock = clock;
+  }
+
+  public Page<ApplicantResponse> listApplicants(
+      Long eventBoardId, ApplicationStatus status, Pageable pageable) {
+    EventApplicationForm form = findForm(eventBoardId);
+    return applicationRepository
+        .findApplicants(form.getId(), status, pageable)
+        .map(application -> ApplicantResponse.of(application, answerCodec.readAll(application)));
+  }
+
+  /** 삭제된 질문도 컬럼으로 넣는다. 지운 뒤에도 과거 답변은 남아 있기 때문이다. */
+  public byte[] exportCsv(Long eventBoardId, ApplicationStatus status) {
+    EventApplicationForm form = findForm(eventBoardId);
+    List<ApplicantResponse> applicants =
+        applicationRepository.findAllApplicants(form.getId(), status).stream()
+            .map(application -> ApplicantResponse.of(application, answerCodec.readAll(application)))
+            .toList();
+    return csvWriter.write(form.getQuestions(), applicants);
+  }
+
+  public String csvFileName(Long eventBoardId) {
+    return findForm(eventBoardId).getEventTitle() + "_신청자.csv";
+  }
+
+  @Transactional
+  public void updateAttendance(
+      Long eventBoardId, Long applicationId, AttendanceUpdateRequest req) {
+    EventApplication application = findApplication(eventBoardId, applicationId);
+    application.markAttendance(req.status());
+  }
+
+  /**
+   * 신청 없이 현장에 온 사람을 등록한다.
+   *
+   * <p>마감이나 정원을 넘겨도 막지 않는다. 이미 온 사람을 돌려보낼 수는 없고, 현장 판단이 폼 설정보다 우선이기 때문이다.
+   */
+  @Transactional
+  public Long registerProxy(Long eventBoardId, ProxyApplicationRequest req) {
+    EventApplicationForm form = findForm(eventBoardId);
+    User user =
+        userRepository
+            .findById(req.userId())
+            .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+    Instant now = Instant.now(clock);
+    EventApplication application =
+        applicationRepository.findByFormIdAndUserId(form.getId(), req.userId()).orElse(null);
+
+    if (application == null) {
+      application = EventApplication.create(form, user, now);
+      applicationRepository.save(application);
+    } else if (!application.isApplied()) {
+      application.reapply(now);
+    } else {
+      throw new BusinessException(ALREADY_APPLIED);
+    }
+
+    if (req.markAttended()) {
+      application.markAttendance(EventAttendanceStatus.ATTENDED);
+    }
+    return application.getId();
+  }
+
+  private EventApplicationForm findForm(Long eventBoardId) {
+    return formRepository
+        .findByEventBoardId(eventBoardId)
+        .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
+  }
+
+  private EventApplication findApplication(Long eventBoardId, Long applicationId) {
+    EventApplicationForm form = findForm(eventBoardId);
+    EventApplication application =
+        applicationRepository
+            .findById(applicationId)
+            .orElseThrow(() -> new BusinessException(APPLICATION_NOT_FOUND));
+    // 다른 행사의 신청 id 를 넘겨 남의 참석을 바꾸지 못하게 한다.
+    if (!application.getForm().getId().equals(form.getId())) {
+      throw new BusinessException(APPLICATION_NOT_FOUND);
+    }
+    return application;
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicationService.java
@@ -1,0 +1,201 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.*;
+
+import inha.gdgoc.domain.eventapplication.dto.request.EventApplicationSubmitRequest;
+import inha.gdgoc.domain.eventapplication.dto.response.EventFormPublicResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationAnswer;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import inha.gdgoc.global.exception.GlobalErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 부원의 신청과 취소.
+ *
+ * <p>신청 가능 여부 판정을 한 곳({@link #blockedBy})에 모아두고 조회와 신청이 같은 것을 쓴다. 화면에 보이는 버튼 상태와 실제 처리 결과가 어긋나지 않게 하려는
+ * 것이다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class EventApplicationService {
+
+  private final EventApplicationFormRepository formRepository;
+  private final EventApplicationRepository applicationRepository;
+  private final UserRepository userRepository;
+  private final AnswerValidator answerValidator;
+  private final AnswerCodec answerCodec;
+  private final Clock clock;
+
+  @Autowired
+  public EventApplicationService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      UserRepository userRepository,
+      AnswerValidator answerValidator,
+      AnswerCodec answerCodec) {
+    this(
+        formRepository,
+        applicationRepository,
+        userRepository,
+        answerValidator,
+        answerCodec,
+        Clock.system(ZoneId.of("Asia/Seoul")));
+  }
+
+  /** 테스트가 마감·개시 시각을 고정할 때 쓴다. */
+  public EventApplicationService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      UserRepository userRepository,
+      AnswerValidator answerValidator,
+      AnswerCodec answerCodec,
+      Clock clock) {
+    this.formRepository = formRepository;
+    this.applicationRepository = applicationRepository;
+    this.userRepository = userRepository;
+    this.answerValidator = answerValidator;
+    this.answerCodec = answerCodec;
+    this.clock = clock;
+  }
+
+  public EventFormPublicResponse getForm(Long eventBoardId, Long userId, UserRole role) {
+    EventApplicationForm form = findForm(eventBoardId);
+    long applied = countApplied(form);
+
+    EventApplication mine =
+        userId == null
+            ? null
+            : applicationRepository.findByFormIdAndUserId(form.getId(), userId).orElse(null);
+
+    EventApplicationErrorCode blocked = blockedBy(form, role, applied, Instant.now(clock));
+    // 이미 신청한 사람에게는 정원이 찼다는 안내가 의미 없다.
+    if (mine != null && mine.isApplied() && blocked == CAPACITY_FULL) {
+      blocked = null;
+    }
+
+    return EventFormPublicResponse.of(
+        form,
+        applied,
+        blocked == null,
+        blocked == null ? null : blocked.getMessage(),
+        mine,
+        mine == null ? null : answerCodec.readAll(mine));
+  }
+
+  @Transactional
+  public void apply(Long eventBoardId, EventApplicationSubmitRequest req, Long userId, UserRole role) {
+    // 정원을 세기 전에 폼을 잠근다. 잠그지 않으면 동시 신청이 정원을 넘긴다.
+    EventApplicationForm form =
+        formRepository
+            .findByEventBoardIdForUpdate(eventBoardId)
+            .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
+
+    EventApplication existing =
+        applicationRepository.findByFormIdAndUserId(form.getId(), userId).orElse(null);
+    if (existing != null && existing.isApplied()) {
+      throw new BusinessException(ALREADY_APPLIED);
+    }
+
+    long applied = countApplied(form);
+    EventApplicationErrorCode blocked = blockedBy(form, role, applied, Instant.now(clock));
+    if (blocked != null) {
+      throw new BusinessException(blocked);
+    }
+
+    Map<Long, Object> submitted = toAnswerMap(req);
+    Map<Long, Object> kept = answerValidator.validateAndFilter(form.activeQuestions(), submitted);
+
+    Instant now = Instant.now(clock);
+    EventApplication application;
+    if (existing != null) {
+      // 취소했던 신청은 같은 행을 되살린다. UNIQUE(form_id, user_id) 때문에 새로 만들 수 없다.
+      existing.clearAnswers();
+      existing.reapply(now);
+      application = existing;
+    } else {
+      User user =
+          userRepository
+              .findById(userId)
+              .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+      application = EventApplication.create(form, user, now);
+      applicationRepository.save(application);
+    }
+
+    for (Map.Entry<Long, Object> entry : kept.entrySet()) {
+      application.addAnswer(
+          EventApplicationAnswer.create(application, entry.getKey(), answerCodec.write(entry.getValue())));
+    }
+  }
+
+  @Transactional
+  public void cancel(Long eventBoardId, Long userId) {
+    EventApplicationForm form = findForm(eventBoardId);
+    EventApplication application =
+        applicationRepository
+            .findByFormIdAndUserId(form.getId(), userId)
+            .filter(EventApplication::isApplied)
+            .orElseThrow(() -> new BusinessException(APPLICATION_NOT_FOUND));
+
+    application.cancel(Instant.now(clock));
+  }
+
+  /** 신청을 막는 첫 번째 사유. 없으면 null 이다. */
+  private EventApplicationErrorCode blockedBy(
+      EventApplicationForm form, UserRole role, long applied, Instant now) {
+    if (!form.isOpen()) {
+      return FORM_CLOSED;
+    }
+    if (form.getOpensAt() != null && now.isBefore(form.getOpensAt())) {
+      return NOT_OPEN_YET;
+    }
+    if (form.getClosesAt() != null && !now.isBefore(form.getClosesAt())) {
+      return ALREADY_CLOSED;
+    }
+    if (!UserRole.hasAtLeast(role, form.getMinRole())) {
+      return NOT_ELIGIBLE;
+    }
+    if (form.getCapacity() != null && applied >= form.getCapacity()) {
+      return CAPACITY_FULL;
+    }
+    return null;
+  }
+
+  private Map<Long, Object> toAnswerMap(EventApplicationSubmitRequest req) {
+    Map<Long, Object> submitted = new LinkedHashMap<>();
+    if (req != null && req.answers() != null) {
+      for (EventApplicationSubmitRequest.AnswerEntry entry : req.answers()) {
+        submitted.put(entry.questionId(), entry.value());
+      }
+    }
+    return submitted;
+  }
+
+
+
+
+  private EventApplicationForm findForm(Long eventBoardId) {
+    return formRepository
+        .findByEventBoardId(eventBoardId)
+        .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
+  }
+
+  private long countApplied(EventApplicationForm form) {
+    return applicationRepository.countByFormIdAndStatus(form.getId(), ApplicationStatus.APPLIED);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinService.java
@@ -1,0 +1,102 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.*;
+
+import inha.gdgoc.domain.eventapplication.dto.response.CheckinResponse;
+import inha.gdgoc.domain.eventapplication.dto.response.CheckinTokenResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * QR 체크인.
+ *
+ * <p>운영진이 행사장에 QR 을 띄우고 부원이 각자 스캔한다. 부원의 기본 카메라 앱이 브라우저를 열어주므로 서버도 웹도 카메라를 다루지 않는다.
+ *
+ * <p>수기 참석 처리는 그대로 남겨둔다. 폰이 없거나 행사장 네트워크가 안 되는 사람이 있고, QR 이 안 될 때 행사가 멈추면 안 되기 때문이다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class EventCheckinService {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final EventApplicationFormRepository formRepository;
+  private final EventApplicationRepository applicationRepository;
+  private final EventCheckinTokenService tokenService;
+  private final Clock clock;
+
+  @Autowired
+  public EventCheckinService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      EventCheckinTokenService tokenService) {
+    this(formRepository, applicationRepository, tokenService, Clock.system(KST));
+  }
+
+  EventCheckinService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      EventCheckinTokenService tokenService,
+      Clock clock) {
+    this.formRepository = formRepository;
+    this.applicationRepository = applicationRepository;
+    this.tokenService = tokenService;
+    this.clock = clock;
+  }
+
+  /** 관리자 화면이 주기적으로 불러 QR 을 새로 그린다. */
+  public CheckinTokenResponse issueToken(Long eventBoardId) {
+    EventApplicationForm form = findForm(eventBoardId);
+    return new CheckinTokenResponse(
+        eventBoardId, tokenService.issue(form.getId()), tokenService.remainingSeconds());
+  }
+
+  @Transactional
+  public CheckinResponse checkIn(Long eventBoardId, String token, Long userId) {
+    EventApplicationForm form = findForm(eventBoardId);
+
+    Instant now = Instant.now(clock);
+    if (!withinEventPeriod(form, now)) {
+      throw new BusinessException(CHECKIN_NOT_IN_PERIOD);
+    }
+    if (!tokenService.verify(form.getId(), token)) {
+      throw new BusinessException(CHECKIN_TOKEN_INVALID);
+    }
+
+    EventApplication application =
+        applicationRepository
+            .findByFormIdAndUserId(form.getId(), userId)
+            .filter(EventApplication::isApplied)
+            .orElseThrow(() -> new BusinessException(CHECKIN_NOT_APPLIED));
+
+    if (application.getCheckedInAt() != null) {
+      // 두 번 찍는 것은 흔한 일이다. 오류로 다루지 않는다.
+      return new CheckinResponse(true, application.getCheckedInAt(), form.getEventTitle());
+    }
+
+    application.checkIn(now);
+    return new CheckinResponse(false, now, form.getEventTitle());
+  }
+
+  /** 행사 시작일 00:00 부터 종료일 24:00 까지. 별도 설정을 두지 않고 행사 날짜를 그대로 쓴다. */
+  private boolean withinEventPeriod(EventApplicationForm form, Instant now) {
+    LocalDate today = now.atZone(KST).toLocalDate();
+    return !today.isBefore(form.getEventStartDate()) && !today.isAfter(form.getEventEndDate());
+  }
+
+  private EventApplicationForm findForm(Long eventBoardId) {
+    return formRepository
+        .findByEventBoardId(eventBoardId)
+        .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenService.java
@@ -1,0 +1,94 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * QR 체크인 토큰.
+ *
+ * <p>행사장에 띄운 QR 을 찍어서 안 온 사람에게 보내는 것이 이 방식의 유일한 약점이다. 토큰을 {@code HMAC(비밀키, 폼ID + 분단위 시각)} 으로 계산해 60
+ * 초마다 갈아치우면 사진으로 받은 QR 은 무효가 된다. 저장 테이블이 필요 없다.
+ *
+ * <p>검증할 때 현재 분과 직전 분을 모두 받아준다. 59 초에 찍은 사람이 경계를 넘었다고 실패하면 안 되기 때문이다.
+ */
+@Slf4j
+@Component
+public class EventCheckinTokenService {
+
+  private static final long WINDOW_SECONDS = 60;
+  private static final int TOKEN_LENGTH = 10;
+
+  private final byte[] secret;
+  private final Clock clock;
+
+  @Autowired
+  public EventCheckinTokenService(@Value("${app.event-checkin.secret:}") String configuredSecret) {
+    this(configuredSecret, Clock.system(ZoneId.of("Asia/Seoul")));
+  }
+
+  EventCheckinTokenService(String configuredSecret, Clock clock) {
+    this.clock = clock;
+    if (configuredSecret == null || configuredSecret.isBlank()) {
+      // 설정이 없으면 기동할 때마다 새로 만든다. 60 초짜리 토큰이라 재시작으로 무효가 되어도
+      // 화면을 새로고침하면 그만이다. 다만 서버를 여러 대로 늘리면 인스턴스마다 키가 달라져
+      // 검증이 실패하므로, 그때는 app.event-checkin.secret 을 반드시 넣어야 한다.
+      byte[] generated = new byte[32];
+      new SecureRandom().nextBytes(generated);
+      this.secret = generated;
+      log.info("app.event-checkin.secret 이 없어 기동 시 임의 키를 생성했다. 단일 인스턴스에서만 유효하다.");
+    } else {
+      this.secret = configuredSecret.getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  /** 지금 화면에 띄울 토큰. */
+  public String issue(Long formId) {
+    return sign(formId, currentWindow());
+  }
+
+  /** 이 토큰이 바뀌기까지 남은 초. 관리자 화면이 카운트다운에 쓴다. */
+  public long remainingSeconds() {
+    long epochSecond = Instant.now(clock).getEpochSecond();
+    return WINDOW_SECONDS - (epochSecond % WINDOW_SECONDS);
+  }
+
+  public boolean verify(Long formId, String token) {
+    if (token == null || token.isBlank()) {
+      return false;
+    }
+    long window = currentWindow();
+    return matches(token, sign(formId, window)) || matches(token, sign(formId, window - 1));
+  }
+
+  private long currentWindow() {
+    return Instant.now(clock).getEpochSecond() / WINDOW_SECONDS;
+  }
+
+  private String sign(Long formId, long window) {
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+      byte[] raw = mac.doFinal((formId + ":" + window).getBytes(StandardCharsets.UTF_8));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(raw).substring(0, TOKEN_LENGTH);
+    } catch (Exception e) {
+      // HmacSHA256 은 모든 JDK 에 있다. 여기 오면 런타임이 이상한 것이다.
+      throw new IllegalStateException("체크인 토큰을 만들 수 없다", e);
+    }
+  }
+
+  private boolean matches(String given, String expected) {
+    return MessageDigest.isEqual(
+        given.getBytes(StandardCharsets.UTF_8), expected.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
@@ -1,0 +1,216 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.*;
+
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.eventapplication.dto.request.EventFormSaveRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.QuestionOrderRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.QuestionSaveRequest;
+import inha.gdgoc.domain.eventapplication.dto.response.EventFormResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.exception.BusinessException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 운영진이 신청 폼과 질문을 만드는 서비스.
+ *
+ * <p>신청이 한 건이라도 들어온 뒤에는 고칠 수 있는 범위가 좁아진다. 저장된 답변의 형태가 달라지거나 답변이 고아가 되는 변경을 막기 위해서다. 그 판정 기준이 되는 신청 수는
+ * 취소를 뺀 {@code APPLIED} 만 센다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventFormAdminService {
+
+  private final EventApplicationFormRepository formRepository;
+  private final EventApplicationRepository applicationRepository;
+  private final EventBoardRepository eventBoardRepository;
+  private final EventFormValidator validator;
+
+  public EventFormResponse getForm(Long eventBoardId) {
+    EventApplicationForm form = findForm(eventBoardId);
+    return EventFormResponse.of(form, countApplied(form));
+  }
+
+  /** 신청 받기를 켠다. 이 행이 생겨야 행사 상세에 신청 버튼이 뜬다. */
+  @Transactional
+  public Long createForm(Long eventBoardId, EventFormSaveRequest req) {
+    if (formRepository.existsByEventBoardId(eventBoardId)) {
+      throw new BusinessException(FORM_ALREADY_EXISTS);
+    }
+    EventBoard board = findLiveBoard(eventBoardId);
+
+    EventApplicationForm form =
+        EventApplicationForm.create(
+            eventBoardId,
+            board.getTitle(),
+            board.getEventStartDate(),
+            board.getEventEndDate(),
+            req.opensAt(),
+            req.closesAt(),
+            req.capacity(),
+            req.minRole() != null ? req.minRole() : UserRole.MEMBER,
+            req.isOpen() == null || req.isOpen());
+    return formRepository.save(form).getId();
+  }
+
+  @Transactional
+  public void updateForm(Long eventBoardId, EventFormSaveRequest req) {
+    EventApplicationForm form = findForm(eventBoardId);
+
+    if (req.capacity() != null && req.capacity() < countApplied(form)) {
+      throw new BusinessException(CAPACITY_BELOW_APPLICANTS);
+    }
+    form.updateSettings(req.opensAt(), req.closesAt(), req.capacity(), req.minRole(), req.isOpen());
+    if (req.clearCapacity()) {
+      form.clearCapacity();
+    }
+    if (form.getOpensAt() != null
+        && form.getClosesAt() != null
+        && !form.getOpensAt().isBefore(form.getClosesAt())) {
+      throw new BusinessException(PERIOD_INVALID);
+    }
+  }
+
+  /** 신청 받기를 해제한다. 신청자가 있으면 지우지 않고 마감으로 닫도록 안내한다. */
+  @Transactional
+  public void deleteForm(Long eventBoardId) {
+    EventApplicationForm form = findForm(eventBoardId);
+    if (countApplied(form) > 0) {
+      throw new BusinessException(FORM_HAS_APPLICATIONS);
+    }
+    formRepository.delete(form);
+  }
+
+  @Transactional
+  public Long addQuestion(Long eventBoardId, QuestionSaveRequest req) {
+    EventApplicationForm form = findForm(eventBoardId);
+    List<EventFormQuestion> siblings = form.activeQuestions();
+    boolean hasApplicants = countApplied(form) > 0;
+
+    // 신청이 들어온 뒤에 필수 질문을 더하면 기존 신청자가 미응답 상태로 필수를 위반하게 된다.
+    if (hasApplicants && req.isRequired()) {
+      throw new BusinessException(QUESTION_MUST_BE_OPTIONAL);
+    }
+    validator.validateShape(req.type(), req.options());
+
+    int sortOrder = siblings.stream().mapToInt(EventFormQuestion::getSortOrder).max().orElse(-1) + 1;
+    validator.validateCondition(
+        sortOrder, req.visibleWhenQuestionId(), req.visibleWhenValues(), siblings);
+
+    EventFormQuestion question =
+        EventFormQuestion.create(
+            form,
+            req.type(),
+            req.label(),
+            req.helpText(),
+            req.isRequired(),
+            sortOrder,
+            req.options(),
+            req.visibleWhenQuestionId(),
+            req.visibleWhenValues());
+    form.addQuestion(question);
+    formRepository.flush();
+    return question.getId();
+  }
+
+  @Transactional
+  public void updateQuestion(Long eventBoardId, Long questionId, QuestionSaveRequest req) {
+    EventApplicationForm form = findForm(eventBoardId);
+    List<EventFormQuestion> siblings = form.activeQuestions();
+    EventFormQuestion question = findQuestion(siblings, questionId);
+    boolean hasApplicants = countApplied(form) > 0;
+
+    if (hasApplicants) {
+      if (req.type() != question.getType()) {
+        throw new BusinessException(QUESTION_SHAPE_LOCKED);
+      }
+      if (req.isRequired() && !question.isRequired()) {
+        throw new BusinessException(QUESTION_REQUIRED_LOCKED);
+      }
+      // 라벨은 고칠 수 있지만 값은 지울 수 없다. 그 값을 고른 답변이 고아가 된다.
+      validator.validateOptionValuesKept(question.getOptions(), req.options());
+    } else if (req.type() != question.getType()) {
+      // 유형이 바뀌면 이 질문을 기준으로 삼던 조건이 성립하지 않을 수 있다.
+      validator.validateNotReferenced(questionId, siblings);
+    }
+
+    validator.validateShape(req.type(), req.options());
+    Long baseId = req.clearCondition() ? null : req.visibleWhenQuestionId();
+    List<String> values = req.clearCondition() ? null : req.visibleWhenValues();
+    validator.validateCondition(question.getSortOrder(), baseId, values, siblings);
+
+    question.updateContent(req.label(), req.helpText(), req.isRequired());
+    question.updateShape(req.type(), req.options());
+    question.updateCondition(baseId, values);
+  }
+
+  /** 지운 표시만 한다. 기존 답변은 남고 신청자 목록에 흐리게 나온다. */
+  @Transactional
+  public void deleteQuestion(Long eventBoardId, Long questionId) {
+    EventApplicationForm form = findForm(eventBoardId);
+    List<EventFormQuestion> siblings = form.activeQuestions();
+    EventFormQuestion question = findQuestion(siblings, questionId);
+
+    validator.validateNotReferenced(questionId, siblings);
+    question.softDelete();
+  }
+
+  @Transactional
+  public void reorderQuestions(Long eventBoardId, QuestionOrderRequest req) {
+    EventApplicationForm form = findForm(eventBoardId);
+    List<EventFormQuestion> siblings = form.activeQuestions();
+
+    Set<Long> current = new HashSet<>(siblings.stream().map(EventFormQuestion::getId).toList());
+    Set<Long> requested = new HashSet<>(req.questionIds());
+    if (current.size() != requested.size() || !current.containsAll(requested)) {
+      throw new BusinessException(SORT_ORDER_MISMATCH);
+    }
+
+    List<EventFormQuestion> inNewOrder = new ArrayList<>();
+    for (Long id : req.questionIds()) {
+      inNewOrder.add(findQuestion(siblings, id));
+    }
+    validator.validateOrderKeepsConditions(inNewOrder);
+
+    for (int i = 0; i < inNewOrder.size(); i++) {
+      inNewOrder.get(i).updateSortOrder(i);
+    }
+  }
+
+  private EventApplicationForm findForm(Long eventBoardId) {
+    return formRepository
+        .findByEventBoardId(eventBoardId)
+        .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
+  }
+
+  private EventBoard findLiveBoard(Long eventBoardId) {
+    return eventBoardRepository
+        .findById(eventBoardId)
+        .filter(board -> board.getDeletedAt() == null)
+        .orElseThrow(() -> new BusinessException(EVENT_BOARD_NOT_FOUND));
+  }
+
+  private EventFormQuestion findQuestion(List<EventFormQuestion> siblings, Long questionId) {
+    return siblings.stream()
+        .filter(q -> q.getId().equals(questionId))
+        .findFirst()
+        .orElseThrow(() -> new BusinessException(QUESTION_NOT_FOUND));
+  }
+
+  private long countApplied(EventApplicationForm form) {
+    return applicationRepository.countByFormIdAndStatus(form.getId(), ApplicationStatus.APPLIED);
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormValidator.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormValidator.java
@@ -1,0 +1,165 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode.*;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import inha.gdgoc.global.exception.BusinessException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/**
+ * 질문과 조건이 성립하는지 검사한다.
+ *
+ * <p>신청이 한 건이라도 들어온 뒤에는 허용 범위가 좁아진다. 저장된 답변의 형태가 달라지거나 답변이 고아가 되는 변경을 막기 위해서다.
+ */
+@Component
+public class EventFormValidator {
+
+  /** 동의 질문은 선택지가 없다. 조건 값으로는 이 둘만 쓸 수 있다. */
+  private static final Set<String> AGREEMENT_VALUES = Set.of("true", "false");
+
+  /** 유형과 선택지가 맞물리는지 본다. */
+  public void validateShape(QuestionType type, List<QuestionOption> options) {
+    boolean hasOptions = options != null && !options.isEmpty();
+
+    if (type.isRequiresOptions()) {
+      if (!hasOptions) {
+        throw new BusinessException(OPTIONS_REQUIRED);
+      }
+      Set<String> seen = new HashSet<>();
+      for (QuestionOption option : options) {
+        if (option == null
+            || option.value() == null
+            || option.value().isBlank()
+            || option.label() == null
+            || option.label().isBlank()) {
+          throw new BusinessException(OPTION_VALUE_BLANK);
+        }
+        if (!seen.add(option.value())) {
+          throw new BusinessException(OPTION_VALUE_DUPLICATED);
+        }
+      }
+      return;
+    }
+
+    if (hasOptions) {
+      throw new BusinessException(OPTIONS_NOT_ALLOWED);
+    }
+  }
+
+  /**
+   * 표시 조건이 성립하는지 본다.
+   *
+   * @param sortOrder 조건을 거는 질문의 순서
+   * @param baseId 기준 질문 id. null 이면 조건이 없는 것이므로 통과한다
+   * @param values 기준 질문의 답이 이 중 하나일 때 보인다
+   * @param siblings 같은 폼의 살아 있는 질문들
+   */
+  public void validateCondition(
+      int sortOrder, Long baseId, List<String> values, List<EventFormQuestion> siblings) {
+    if (baseId == null) {
+      return;
+    }
+    if (values == null || values.isEmpty()) {
+      throw new BusinessException(CONDITION_VALUES_EMPTY);
+    }
+    for (String value : values) {
+      if (value == null || value.isBlank()) {
+        throw new BusinessException(CONDITION_VALUES_EMPTY);
+      }
+    }
+
+    EventFormQuestion base =
+        siblings.stream()
+            .filter(q -> baseId.equals(q.getId()))
+            .findFirst()
+            .orElseThrow(() -> new BusinessException(CONDITION_QUESTION_NOT_FOUND));
+
+    if (!base.getType().isUsableAsCondition()) {
+      throw new BusinessException(CONDITION_QUESTION_TYPE_INVALID);
+    }
+    // 앞 순서만 참조한다. 이 한 줄이 순환 참조를 구조적으로 막는다.
+    if (base.getSortOrder() >= sortOrder) {
+      throw new BusinessException(CONDITION_QUESTION_NOT_BEFORE);
+    }
+
+    Set<String> allowed = allowedConditionValues(base);
+    for (String value : values) {
+      if (!allowed.contains(value)) {
+        throw new BusinessException(CONDITION_VALUE_INVALID);
+      }
+    }
+  }
+
+  private Set<String> allowedConditionValues(EventFormQuestion base) {
+    if (base.getType() == QuestionType.AGREEMENT) {
+      return AGREEMENT_VALUES;
+    }
+    Set<String> values = new HashSet<>();
+    if (base.getOptions() != null) {
+      for (QuestionOption option : base.getOptions()) {
+        if (option != null && option.value() != null) {
+          values.add(option.value());
+        }
+      }
+    }
+    return values;
+  }
+
+  /** 이 질문을 기준으로 삼는 조건이 남아 있으면 지우거나 유형을 바꿀 수 없다. */
+  public void validateNotReferenced(Long questionId, List<EventFormQuestion> siblings) {
+    boolean referenced =
+        siblings.stream()
+            .anyMatch(q -> !q.getId().equals(questionId) && questionId.equals(q.getVisibleWhenQuestionId()));
+    if (referenced) {
+      throw new BusinessException(CONDITION_REFERENCED);
+    }
+  }
+
+  /** 새 순서에서도 모든 조건이 앞 질문을 가리키는지 본다. */
+  public void validateOrderKeepsConditions(List<EventFormQuestion> inNewOrder) {
+    for (int i = 0; i < inNewOrder.size(); i++) {
+      EventFormQuestion question = inNewOrder.get(i);
+      if (!question.hasCondition()) {
+        continue;
+      }
+      int baseIndex = indexOf(inNewOrder, question.getVisibleWhenQuestionId());
+      if (baseIndex < 0 || baseIndex >= i) {
+        throw new BusinessException(CONDITION_ORDER_BROKEN);
+      }
+    }
+  }
+
+  private int indexOf(List<EventFormQuestion> questions, Long id) {
+    for (int i = 0; i < questions.size(); i++) {
+      if (questions.get(i).getId().equals(id)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** 신청이 있을 때는 선택지를 지울 수 없다. 라벨만 고칠 수 있다. */
+  public void validateOptionValuesKept(List<QuestionOption> before, List<QuestionOption> after) {
+    if (before == null || before.isEmpty()) {
+      return;
+    }
+    Set<String> afterValues = new HashSet<>();
+    if (after != null) {
+      for (QuestionOption option : after) {
+        if (option != null && option.value() != null) {
+          afterValues.add(option.value());
+        }
+      }
+    }
+    for (QuestionOption option : before) {
+      if (option != null && option.value() != null && !afterValues.contains(option.value())) {
+        throw new BusinessException(OPTION_VALUE_LOCKED);
+      }
+    }
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/MyActivityService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/MyActivityService.java
@@ -1,0 +1,28 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import inha.gdgoc.domain.eventapplication.dto.response.MyActivityResponse;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 마이페이지의 활동 이력.
+ *
+ * <p>지금은 행사 참여만 담지만 나중에 스터디·정기모임을 같은 목록에 합칠 수 있도록 경로와 이름을 넓게 잡았다. 취소한 신청은 이력이 아니므로 뺀다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyActivityService {
+
+  private final EventApplicationRepository applicationRepository;
+
+  public List<MyActivityResponse> listMyEventActivities(Long userId) {
+    return applicationRepository.findMyActivities(userId, ApplicationStatus.APPLIED).stream()
+        .map(MyActivityResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/QuestionConditionEvaluator.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/QuestionConditionEvaluator.java
@@ -1,0 +1,81 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 답변을 놓고 각 질문이 화면에 보이는지 판정한다.
+ *
+ * <p>같은 판정이 프론트 렌더러에도 있다. 한쪽만 고치면 화면에는 보이는데 서버가 필수라고 거절하거나 그 반대가 되므로, 규칙을 바꿀 때는 반드시 양쪽을 함께 고치고 여기의
+ * 테스트를 갱신한다.
+ *
+ * <p>기준 질문이 자기보다 앞 순서라는 규칙 덕분에 한 번 훑는 것으로 판정이 끝난다. 순환 참조는 애초에 만들어질 수 없다.
+ */
+public final class QuestionConditionEvaluator {
+
+  private QuestionConditionEvaluator() {}
+
+  /**
+   * 보이는 질문의 id 를 돌려준다.
+   *
+   * @param questions 삭제되지 않은 질문을 sortOrder 오름차순으로 넘긴다
+   * @param answers 질문 id → 답변 값. 문자열·불린·컬렉션을 받는다
+   */
+  public static Set<Long> visibleQuestionIds(
+      List<EventFormQuestion> questions, Map<Long, Object> answers) {
+    Set<Long> visible = new LinkedHashSet<>();
+    Map<Long, EventFormQuestion> byId = new HashMap<>();
+    for (EventFormQuestion question : questions) {
+      byId.put(question.getId(), question);
+    }
+
+    for (EventFormQuestion question : questions) {
+      if (isVisible(question, byId, visible, answers)) {
+        visible.add(question.getId());
+      }
+    }
+    return visible;
+  }
+
+  private static boolean isVisible(
+      EventFormQuestion question,
+      Map<Long, EventFormQuestion> byId,
+      Set<Long> visibleSoFar,
+      Map<Long, Object> answers) {
+    if (!question.hasCondition()) {
+      return true;
+    }
+    Long baseId = question.getVisibleWhenQuestionId();
+    EventFormQuestion base = byId.get(baseId);
+    if (base == null) {
+      // 기준 질문이 지워졌다면 조건을 판정할 수 없다. 숨기는 쪽이 안전하다.
+      return false;
+    }
+    // 기준 질문 자체가 숨겨져 있으면 답이 있을 수 없다.
+    if (!visibleSoFar.contains(baseId)) {
+      return false;
+    }
+    return matches(answers == null ? null : answers.get(baseId), question.getVisibleWhenValues());
+  }
+
+  /** 답변이 기대값 중 하나에 해당하는지. 다중선택은 고른 값 중 하나라도 걸리면 참이다. */
+  static boolean matches(Object answer, List<String> expected) {
+    if (answer == null || expected == null || expected.isEmpty()) {
+      return false;
+    }
+    if (answer instanceof Collection<?> collection) {
+      for (Object item : collection) {
+        if (item != null && expected.contains(String.valueOf(item))) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return expected.contains(String.valueOf(answer));
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -60,6 +60,10 @@ springdoc:
     enabled: false
 
 app:
+  # 비워두면 기동할 때마다 임의 키를 만든다. 60초짜리 QR 토큰이라 재시작으로 무효가 돼도
+  # 화면을 새로고침하면 그만이다. 다만 서버를 여러 대로 늘리면 반드시 채워야 한다.
+  event-checkin:
+    secret: ${EVENT_CHECKIN_SECRET:}
   s3:
     bucket: ${AWS_TEST_RESOURCE_BUCKET}
   admin:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -60,6 +60,10 @@ springdoc:
     enabled: false
 
 app:
+  # 비워두면 기동할 때마다 임의 키를 만든다. 60초짜리 QR 토큰이라 재시작으로 무효가 돼도
+  # 화면을 새로고침하면 그만이다. 다만 서버를 여러 대로 늘리면 반드시 채워야 한다.
+  event-checkin:
+    secret: ${EVENT_CHECKIN_SECRET:}
   s3:
     bucket: ${AWS_TEST_RESOURCE_BUCKET}
   admin:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -60,6 +60,10 @@ springdoc:
     enabled: false
 
 app:
+  # 비워두면 기동할 때마다 임의 키를 만든다. 60초짜리 QR 토큰이라 재시작으로 무효가 돼도
+  # 화면을 새로고침하면 그만이다. 다만 서버를 여러 대로 늘리면 반드시 채워야 한다.
+  event-checkin:
+    secret: ${EVENT_CHECKIN_SECRET:}
   s3:
     bucket: ${AWS_RESOURCE_BUCKET}
   admin:

--- a/src/main/resources/db/migration/V20260827_1__create_event_application.sql
+++ b/src/main/resources/db/migration/V20260827_1__create_event_application.sql
@@ -1,0 +1,82 @@
+-- 행사 신청 폼 빌더.
+--
+-- 행사마다 구글폼을 새로 만드는 대신 운영진이 홈페이지에서 신청 폼을 만든다.
+-- 행사가 열릴 때마다 컬럼을 추가하지 않도록 질문·신청·답변을 데이터로 저장한다.
+--
+-- 행사 자체는 event_board 를 그대로 쓴다. 다만 FK 로 묶지 않고 id 만 들고,
+-- 표시에 필요한 값(행사명·기간)은 이 표에 복사해 둔다. 게시글이 휴지통에 들어가도
+-- 신청 데이터와 마이페이지 이력이 그대로 살아야 하기 때문이다.
+-- 복사본은 게시글을 수정할 때 함께 갱신한다.
+
+CREATE TABLE IF NOT EXISTS event_application_form (
+    id               BIGSERIAL    PRIMARY KEY,
+    event_board_id   BIGINT       NOT NULL UNIQUE,
+    event_title      VARCHAR(255) NOT NULL,
+    event_start_date DATE         NOT NULL,
+    event_end_date   DATE         NOT NULL,
+    opens_at         TIMESTAMPTZ,
+    closes_at        TIMESTAMPTZ,
+    capacity         INT,
+    min_role         VARCHAR(16)  NOT NULL DEFAULT 'MEMBER',
+    is_open          BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_event_form_period   CHECK (opens_at IS NULL OR closes_at IS NULL OR opens_at < closes_at),
+    CONSTRAINT chk_event_form_capacity CHECK (capacity IS NULL OR capacity > 0)
+);
+
+-- visible_when_* 는 조건부 표시다. 기준 질문의 답이 visible_when_values 중 하나일 때만 보인다.
+-- 기준 질문은 반드시 자기보다 sort_order 가 작아야 한다 — 이 규칙 하나로 순환 참조가
+-- 구조적으로 불가능해진다. 순서 검사는 애플리케이션이 한다.
+CREATE TABLE IF NOT EXISTS event_form_question (
+    id                       BIGSERIAL    PRIMARY KEY,
+    form_id                  BIGINT       NOT NULL REFERENCES event_application_form(id) ON DELETE CASCADE,
+    type                     VARCHAR(24)  NOT NULL,
+    label                    VARCHAR(255) NOT NULL,
+    help_text                VARCHAR(500),
+    is_required              BOOLEAN      NOT NULL DEFAULT FALSE,
+    sort_order               INT          NOT NULL,
+    options                  JSONB,
+    visible_when_question_id BIGINT       REFERENCES event_form_question(id),
+    visible_when_values      JSONB,
+    is_deleted               BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at               TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_event_question_condition
+        CHECK ((visible_when_question_id IS NULL) = (visible_when_values IS NULL)),
+    CONSTRAINT chk_event_question_not_self
+        CHECK (visible_when_question_id IS NULL OR visible_when_question_id <> id)
+);
+
+-- 취소는 행을 지우지 않고 status 만 바꾼다. UNIQUE(form_id, user_id) 로 중복 신청을 막는데,
+-- 취소를 삭제로 처리하면 재신청 때 이 제약과 충돌하기 때문이다. 재신청은 같은 행을 되살린다.
+CREATE TABLE IF NOT EXISTS event_application (
+    id                BIGSERIAL    PRIMARY KEY,
+    form_id           BIGINT       NOT NULL REFERENCES event_application_form(id) ON DELETE CASCADE,
+    user_id           BIGINT       NOT NULL REFERENCES users(id),
+    status            VARCHAR(16)  NOT NULL DEFAULT 'APPLIED',
+    attendance_status VARCHAR(16)  NOT NULL DEFAULT 'PENDING',
+    checked_in_at     TIMESTAMPTZ,
+    applied_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    canceled_at       TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_event_application_form_user UNIQUE (form_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS event_application_answer (
+    id             BIGSERIAL   PRIMARY KEY,
+    application_id BIGINT      NOT NULL REFERENCES event_application(id) ON DELETE CASCADE,
+    question_id    BIGINT      NOT NULL REFERENCES event_form_question(id),
+    value          JSONB       NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_event_answer_application_question UNIQUE (application_id, question_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_question_form_order   ON event_form_question(form_id, sort_order);
+CREATE INDEX IF NOT EXISTS idx_event_question_visible_when ON event_form_question(visible_when_question_id)
+    WHERE visible_when_question_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_event_application_form      ON event_application(form_id, status);
+CREATE INDEX IF NOT EXISTS idx_event_application_user      ON event_application(user_id);
+CREATE INDEX IF NOT EXISTS idx_event_answer_application    ON event_application_answer(application_id);

--- a/src/test/java/inha/gdgoc/domain/board/event/service/EventBoardAttachmentServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/event/service/EventBoardAttachmentServiceTest.java
@@ -12,6 +12,7 @@ import inha.gdgoc.domain.board.common.service.AttachmentPolicy;
 import inha.gdgoc.domain.board.event.dto.request.EventBoardCreateRequest;
 import inha.gdgoc.domain.board.event.entity.EventBoard;
 import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
 import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.entity.User;
 import inha.gdgoc.domain.user.enums.TeamType;
@@ -38,13 +39,19 @@ class EventBoardAttachmentServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private S3Service s3Service;
 
+  @Mock private EventApplicationFormRepository eventApplicationFormRepository;
+
   private EventBoardService eventBoardService;
 
   @BeforeEach
   void setUp() {
     eventBoardService =
         new EventBoardService(
-            eventBoardRepository, userRepository, s3Service, new AttachmentPolicy(s3Service));
+            eventBoardRepository,
+                userRepository,
+                eventApplicationFormRepository,
+                s3Service,
+                new AttachmentPolicy(s3Service));
   }
 
   @Test

--- a/src/test/java/inha/gdgoc/domain/board/event/service/EventBoardServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/board/event/service/EventBoardServiceTest.java
@@ -9,6 +9,7 @@ import inha.gdgoc.domain.board.common.service.AttachmentPolicy;
 import inha.gdgoc.domain.board.event.dto.request.EventBoardUpdateRequest;
 import inha.gdgoc.domain.board.event.entity.EventBoard;
 import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
 import inha.gdgoc.domain.resource.service.S3Service;
 import inha.gdgoc.domain.user.enums.TeamType;
 import inha.gdgoc.domain.user.enums.UserRole;
@@ -42,13 +43,19 @@ class EventBoardServiceTest {
     @Mock
     private S3Service s3Service;
 
+  @Mock private EventApplicationFormRepository eventApplicationFormRepository;
+
     private EventBoardService eventBoardService;
 
     @BeforeEach
     void setUp() {
         eventBoardService =
                 new EventBoardService(
-                        eventBoardRepository, userRepository, s3Service, new AttachmentPolicy(s3Service));
+                        eventBoardRepository,
+                userRepository,
+                eventApplicationFormRepository,
+                s3Service,
+                new AttachmentPolicy(s3Service));
     }
 
     // --- 미공개 글 가시성 ---

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/AnswerValidatorTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/AnswerValidatorTest.java
@@ -1,0 +1,171 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.global.exception.BusinessException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AnswerValidatorTest {
+
+  private final AnswerValidator validator = new AnswerValidator();
+
+  @Test
+  @DisplayName("필수 질문에 답하지 않으면 거절한다")
+  void requiredAnswerMissing() {
+    EventFormQuestion q = required(text(1L, 0));
+
+    assertError(() -> validator.validateAndFilter(List.of(q), Map.of()), EventApplicationErrorCode.ANSWER_REQUIRED);
+  }
+
+  @Test
+  @DisplayName("빈 문자열은 답하지 않은 것으로 본다")
+  void blankIsTreatedAsMissing() {
+    EventFormQuestion q = required(text(1L, 0));
+
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(1L, "   ")),
+        EventApplicationErrorCode.ANSWER_REQUIRED);
+  }
+
+  @Test
+  @DisplayName("조건에 걸려 숨겨진 필수 질문은 검사하지 않는다")
+  void hiddenRequiredQuestionIsExempt() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+    EventFormQuestion dependent = required(text(2L, 1));
+    dependent.updateCondition(1L, List.of("YES"));
+
+    // NO 를 골랐으므로 2번은 숨는다. 필수여도 통과해야 한다.
+    Map<Long, Object> kept = validator.validateAndFilter(List.of(base, dependent), answers(1L, "NO"));
+
+    assertThat(kept).containsOnlyKeys(1L);
+  }
+
+  @Test
+  @DisplayName("숨겨진 질문에 답이 딸려와도 오류 없이 버린다")
+  void hiddenAnswersAreDiscardedSilently() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+    EventFormQuestion dependent = text(2L, 1);
+    dependent.updateCondition(1L, List.of("YES"));
+
+    Map<Long, Object> submitted = new LinkedHashMap<>();
+    submitted.put(1L, "NO");
+    submitted.put(2L, "숨겨진 뒤에도 남아 있던 값");
+
+    Map<Long, Object> kept = validator.validateAndFilter(List.of(base, dependent), submitted);
+
+    assertThat(kept).containsOnlyKeys(1L);
+  }
+
+  @Test
+  @DisplayName("조건이 만족되면 그 질문의 필수가 다시 살아난다")
+  void visibleRequiredQuestionIsEnforced() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+    EventFormQuestion dependent = required(text(2L, 1));
+    dependent.updateCondition(1L, List.of("YES"));
+
+    assertError(
+        () -> validator.validateAndFilter(List.of(base, dependent), answers(1L, "YES")),
+        EventApplicationErrorCode.ANSWER_REQUIRED);
+  }
+
+  @Test
+  @DisplayName("선택지에 없는 값은 거절한다")
+  void valueMustBeInOptions() {
+    EventFormQuestion q = choice(1L, 0, "YES", "NO");
+
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(1L, "MAYBE")),
+        EventApplicationErrorCode.ANSWER_VALUE_INVALID);
+  }
+
+  @Test
+  @DisplayName("숫자 질문에 문자열을 보내면 거절한다")
+  void numberRejectsString() {
+    EventFormQuestion q = build(1L, 0, QuestionType.NUMBER, null);
+
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(1L, "둘")),
+        EventApplicationErrorCode.ANSWER_TYPE_INVALID);
+  }
+
+  @Test
+  @DisplayName("날짜 질문은 ISO 형식만 받는다")
+  void dateMustBeIso() {
+    EventFormQuestion q = build(1L, 0, QuestionType.DATE, null);
+
+    assertThat(validator.validateAndFilter(List.of(q), answers(1L, "2026-09-01"))).containsKey(1L);
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(1L, "2026년 9월 1일")),
+        EventApplicationErrorCode.ANSWER_TYPE_INVALID);
+  }
+
+  @Test
+  @DisplayName("다중선택은 고른 값이 모두 선택지에 있어야 한다")
+  void multiChoiceValidatesEveryValue() {
+    EventFormQuestion q = build(1L, 0, QuestionType.MULTI_CHOICE, options("A", "B", "C"));
+
+    assertThat(validator.validateAndFilter(List.of(q), answers(1L, List.of("A", "C"))))
+        .containsKey(1L);
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(1L, List.of("A", "Z"))),
+        EventApplicationErrorCode.ANSWER_VALUE_INVALID);
+  }
+
+  @Test
+  @DisplayName("폼에 없는 질문에 답하면 거절한다")
+  void unknownQuestionRejected() {
+    EventFormQuestion q = text(1L, 0);
+
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(99L, "값")),
+        EventApplicationErrorCode.ANSWER_QUESTION_UNKNOWN);
+  }
+
+  private void assertError(Runnable action, EventApplicationErrorCode expected) {
+    assertThatThrownBy(action::run)
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(expected);
+  }
+
+  private static Map<Long, Object> answers(Long questionId, Object value) {
+    Map<Long, Object> map = new LinkedHashMap<>();
+    map.put(questionId, value);
+    return map;
+  }
+
+  private static List<QuestionOption> options(String... values) {
+    return List.of(values).stream().map(v -> new QuestionOption(v, v)).toList();
+  }
+
+  private static EventFormQuestion text(Long id, int sortOrder) {
+    return build(id, sortOrder, QuestionType.SHORT_TEXT, null);
+  }
+
+  private static EventFormQuestion choice(Long id, int sortOrder, String... values) {
+    return build(id, sortOrder, QuestionType.SINGLE_CHOICE, options(values));
+  }
+
+  private static EventFormQuestion required(EventFormQuestion question) {
+    question.updateContent(null, null, true);
+    return question;
+  }
+
+  private static EventFormQuestion build(
+      Long id, int sortOrder, QuestionType type, List<QuestionOption> options) {
+    EventFormQuestion question =
+        EventFormQuestion.create(null, type, "질문", null, false, sortOrder, options, null, null);
+    ReflectionTestUtils.setField(question, "id", id);
+    return question;
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/AnswerValidatorTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/AnswerValidatorTest.java
@@ -122,6 +122,26 @@ class AnswerValidatorTest {
   }
 
   @Test
+  @DisplayName("필수 동의 항목은 체크해야 통과한다")
+  void requiredAgreementMustBeTrue() {
+    EventFormQuestion q = required(build(1L, 0, QuestionType.AGREEMENT, null));
+
+    assertThat(validator.validateAndFilter(List.of(q), answers(1L, true))).containsKey(1L);
+    // 체크를 푼 것도 '답한 것'으로 보면 개인정보 동의 없이 신청이 된다.
+    assertError(
+        () -> validator.validateAndFilter(List.of(q), answers(1L, false)),
+        EventApplicationErrorCode.AGREEMENT_REQUIRED);
+  }
+
+  @Test
+  @DisplayName("선택 동의 항목은 체크하지 않아도 된다")
+  void optionalAgreementMayBeFalse() {
+    EventFormQuestion q = build(1L, 0, QuestionType.AGREEMENT, null);
+
+    assertThat(validator.validateAndFilter(List.of(q), answers(1L, false))).containsKey(1L);
+  }
+
+  @Test
   @DisplayName("폼에 없는 질문에 답하면 거절한다")
   void unknownQuestionRejected() {
     EventFormQuestion q = text(1L, 0);

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriterTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriterTest.java
@@ -93,6 +93,59 @@ class ApplicantCsvWriterTest {
     assertThat(csv.strip()).endsWith(",");
   }
 
+  @Test
+  @DisplayName("선택형 답변을 선택지 문구로 바꿔 적는다")
+  void optionValueBecomesLabel() {
+    // 폼 빌더가 만드는 value 는 OPT_1756... 같은 내부 값이다. 그대로 적으면 아무도 못 읽는다.
+    EventFormQuestion q =
+        choiceQuestion(
+            1L,
+            "식사 여부",
+            QuestionType.SINGLE_CHOICE,
+            List.of(new QuestionOption("OPT_1", "네, 먹습니다"), new QuestionOption("OPT_2", "아니요")));
+
+    String csv = text(writer.write(List.of(q), List.of(applicant(answers(1L, "OPT_1")))));
+
+    assertThat(csv).contains("\"네, 먹습니다\"").doesNotContain("OPT_1");
+  }
+
+  @Test
+  @DisplayName("다중선택도 선택지 문구로 바꿔 모아 적는다")
+  void multiChoiceValuesBecomeLabels() {
+    EventFormQuestion q =
+        choiceQuestion(
+            1L,
+            "관심 세션",
+            QuestionType.MULTI_CHOICE,
+            List.of(new QuestionOption("OPT_1", "서버리스"), new QuestionOption("OPT_2", "배포")));
+
+    String csv =
+        text(writer.write(List.of(q), List.of(applicant(answers(1L, List.of("OPT_1", "OPT_2"))))));
+
+    assertThat(csv).contains("\"서버리스, 배포\"");
+  }
+
+  @Test
+  @DisplayName("선택지에서 사라진 값은 저장된 그대로 적는다")
+  void unknownOptionValueStaysAsIs() {
+    // 운영진이 선택지를 지운 뒤에도 과거 답변은 남는다. 빈 칸으로 만들면 데이터를 잃는다.
+    EventFormQuestion q =
+        choiceQuestion(
+            1L, "식사 여부", QuestionType.SINGLE_CHOICE, List.of(new QuestionOption("OPT_1", "네")));
+
+    String csv = text(writer.write(List.of(q), List.of(applicant(answers(1L, "OPT_GONE")))));
+
+    assertThat(csv).contains("OPT_GONE");
+  }
+
+  private static EventFormQuestion choiceQuestion(
+      Long id, String label, QuestionType type, List<QuestionOption> options) {
+    EventFormQuestion question =
+        EventFormQuestion.create(null, type, label, null, false, 0, options, null, null);
+    ReflectionTestUtils.setField(question, "id", id);
+    return question;
+  }
+
   private static Map<Long, Object> answers(Long questionId, Object value) {
     Map<Long, Object> map = new LinkedHashMap<>();
     map.put(questionId, value);

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriterTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriterTest.java
@@ -1,0 +1,135 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ApplicantCsvWriterTest {
+
+  private final ApplicantCsvWriter writer = new ApplicantCsvWriter();
+
+  @Test
+  @DisplayName("UTF-8 BOM 으로 시작한다")
+  void startsWithBom() {
+    byte[] csv = writer.write(List.of(), List.of());
+
+    // BOM 이 없으면 Excel 이 한글을 깨서 연다. 파일은 멀쩡한데 받는 사람에게는 버그로 보인다.
+    assertThat(csv[0]).isEqualTo((byte) 0xEF);
+    assertThat(csv[1]).isEqualTo((byte) 0xBB);
+    assertThat(csv[2]).isEqualTo((byte) 0xBF);
+  }
+
+  @Test
+  @DisplayName("질문이 헤더 뒤쪽 열이 된다")
+  void questionsBecomeColumns() {
+    EventFormQuestion q1 = question(1L, "저녁 참여", QuestionType.SINGLE_CHOICE);
+    EventFormQuestion q2 = question(2L, "티셔츠 사이즈", QuestionType.DROPDOWN);
+
+    String csv = text(writer.write(List.of(q1, q2), List.of()));
+
+    assertThat(firstLine(csv)).isEqualTo("이름,학번,학과,이메일,연락처,신청일시,상태,참석,체크인,저녁 참여,티셔츠 사이즈");
+  }
+
+  @Test
+  @DisplayName("삭제된 질문도 표시를 달아 열로 남긴다")
+  void deletedQuestionsStayAsColumns() {
+    EventFormQuestion q = question(1L, "예전 질문", QuestionType.SHORT_TEXT);
+    q.softDelete();
+
+    String csv = text(writer.write(List.of(q), List.of()));
+
+    // 질문을 지워도 과거 답변은 남아 있으므로 열이 사라지면 데이터를 잃는다.
+    assertThat(firstLine(csv)).endsWith(",(삭제됨) 예전 질문");
+  }
+
+  @Test
+  @DisplayName("쉼표·따옴표·줄바꿈이 든 답변을 감싼다")
+  void escapesSpecialCharacters() {
+    EventFormQuestion q = question(1L, "하고 싶은 말", QuestionType.LONG_TEXT);
+    String csv =
+        text(writer.write(List.of(q), List.of(applicant(answers(1L, "안녕, \"반가워\"\n잘 부탁해")))));
+
+    assertThat(csv).contains("\"안녕, \"\"반가워\"\"\n잘 부탁해\"");
+  }
+
+  @Test
+  @DisplayName("다중선택은 한 칸에 모아 적는다")
+  void joinsMultiChoice() {
+    EventFormQuestion q = question(1L, "관심 세션", QuestionType.MULTI_CHOICE);
+    String csv = text(writer.write(List.of(q), List.of(applicant(answers(1L, List.of("A", "C"))))));
+
+    // 셀 안에 쉼표가 생기므로 따옴표로 감싸져야 한다.
+    assertThat(csv).contains("\"A, C\"");
+  }
+
+  @Test
+  @DisplayName("동의 답변은 O/X 로 적는다")
+  void booleanBecomesMark() {
+    EventFormQuestion q = question(1L, "개인정보 동의", QuestionType.AGREEMENT);
+
+    assertThat(text(writer.write(List.of(q), List.of(applicant(answers(1L, true)))))).contains(",O");
+    assertThat(text(writer.write(List.of(q), List.of(applicant(answers(1L, false)))))).contains(",X");
+  }
+
+  @Test
+  @DisplayName("답하지 않은 질문은 빈 칸으로 둔다")
+  void missingAnswerBecomesEmptyCell() {
+    EventFormQuestion q = question(1L, "선택 질문", QuestionType.SHORT_TEXT);
+    String csv = text(writer.write(List.of(q), List.of(applicant(new LinkedHashMap<>()))));
+
+    assertThat(csv.strip()).endsWith(",");
+  }
+
+  private static Map<Long, Object> answers(Long questionId, Object value) {
+    Map<Long, Object> map = new LinkedHashMap<>();
+    map.put(questionId, value);
+    return map;
+  }
+
+  private static ApplicantResponse applicant(Map<Long, Object> answers) {
+    return new ApplicantResponse(
+        1L,
+        7L,
+        "홍길동",
+        "12201234",
+        "컴퓨터공학과",
+        "hong@test.io",
+        "01000000000",
+        ApplicationStatus.APPLIED,
+        EventAttendanceStatus.PENDING,
+        Instant.parse("2026-09-01T03:00:00Z"),
+        null,
+        null,
+        answers);
+  }
+
+  private static EventFormQuestion question(Long id, String label, QuestionType type) {
+    List<QuestionOption> options =
+        type.isRequiresOptions() ? List.of(new QuestionOption("A", "A")) : null;
+    EventFormQuestion question =
+        EventFormQuestion.create(null, type, label, null, false, 0, options, null, null);
+    ReflectionTestUtils.setField(question, "id", id);
+    return question;
+  }
+
+  private static String text(byte[] csv) {
+    return new String(csv, 3, csv.length - 3, StandardCharsets.UTF_8);
+  }
+
+  private static String firstLine(String csv) {
+    return csv.split("\r\n", 2)[0];
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminServiceTest.java
@@ -1,0 +1,173 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inha.gdgoc.domain.eventapplication.dto.request.AttendanceUpdateRequest;
+import inha.gdgoc.domain.eventapplication.dto.request.ProxyApplicationRequest;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EventApplicantAdminServiceTest {
+
+  private static final Long BOARD_ID = 10L;
+  private static final Long FORM_ID = 100L;
+  private static final Long USER_ID = 7L;
+  private static final Instant NOW = Instant.parse("2026-09-01T03:00:00Z");
+
+  @Mock private EventApplicationFormRepository formRepository;
+  @Mock private EventApplicationRepository applicationRepository;
+  @Mock private UserRepository userRepository;
+
+  private EventApplicantAdminService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new EventApplicantAdminService(
+            formRepository,
+            applicationRepository,
+            userRepository,
+            new AnswerCodec(new ObjectMapper()),
+            new ApplicantCsvWriter(),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
+  @Test
+  @DisplayName("다른 행사의 신청 id 로는 참석을 바꿀 수 없다")
+  void cannotTouchApplicationOfAnotherEvent() {
+    givenForm(form(FORM_ID));
+    EventApplication otherEvent = EventApplication.create(form(999L), user(), NOW);
+    ReflectionTestUtils.setField(otherEvent, "id", 55L);
+    when(applicationRepository.findById(55L)).thenReturn(Optional.of(otherEvent));
+
+    // 경로의 행사와 신청이 맞물리는지 보지 않으면 남의 행사 참석을 건드릴 수 있다.
+    assertError(
+        () ->
+            service.updateAttendance(
+                BOARD_ID, 55L, new AttendanceUpdateRequest(EventAttendanceStatus.ATTENDED)),
+        EventApplicationErrorCode.APPLICATION_NOT_FOUND);
+    assertThat(otherEvent.getAttendanceStatus()).isEqualTo(EventAttendanceStatus.PENDING);
+  }
+
+  @Test
+  @DisplayName("수기 참석 처리는 QR 체크인 시각을 남기지 않는다")
+  void manualAttendanceLeavesCheckedInAtNull() {
+    EventApplicationForm form = form(FORM_ID);
+    givenForm(form);
+    EventApplication application = EventApplication.create(form, user(), NOW);
+    ReflectionTestUtils.setField(application, "id", 1L);
+    when(applicationRepository.findById(1L)).thenReturn(Optional.of(application));
+
+    service.updateAttendance(
+        BOARD_ID, 1L, new AttendanceUpdateRequest(EventAttendanceStatus.ATTENDED));
+
+    assertThat(application.getAttendanceStatus()).isEqualTo(EventAttendanceStatus.ATTENDED);
+    // 값이 비어 있어야 나중에 QR 로 온 사람과 수기 처리를 구분할 수 있다.
+    assertThat(application.getCheckedInAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("현장 참석자를 등록하면 신청과 참석이 함께 생긴다")
+  void proxyRegistrationCreatesAttendedApplication() {
+    givenForm(form(FORM_ID));
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user()));
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID)).thenReturn(Optional.empty());
+
+    service.registerProxy(BOARD_ID, new ProxyApplicationRequest(USER_ID, true));
+
+    verify(applicationRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("이미 신청한 사람은 대리 등록할 수 없다")
+  void proxyRejectsExistingApplicant() {
+    EventApplicationForm form = form(FORM_ID);
+    givenForm(form);
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user()));
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID))
+        .thenReturn(Optional.of(EventApplication.create(form, user(), NOW)));
+
+    assertError(
+        () -> service.registerProxy(BOARD_ID, new ProxyApplicationRequest(USER_ID, true)),
+        EventApplicationErrorCode.ALREADY_APPLIED);
+  }
+
+  @Test
+  @DisplayName("취소했던 사람을 대리 등록하면 같은 행을 되살린다")
+  void proxyRevivesCanceledApplication() {
+    EventApplicationForm form = form(FORM_ID);
+    givenForm(form);
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user()));
+    EventApplication canceled = EventApplication.create(form, user(), NOW.minusSeconds(600));
+    canceled.cancel(NOW.minusSeconds(300));
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID))
+        .thenReturn(Optional.of(canceled));
+
+    service.registerProxy(BOARD_ID, new ProxyApplicationRequest(USER_ID, true));
+
+    assertThat(canceled.getStatus()).isEqualTo(ApplicationStatus.APPLIED);
+    assertThat(canceled.getAttendanceStatus()).isEqualTo(EventAttendanceStatus.ATTENDED);
+    verify(applicationRepository, never()).save(any());
+  }
+
+  private void givenForm(EventApplicationForm form) {
+    when(formRepository.findByEventBoardId(BOARD_ID)).thenReturn(Optional.of(form));
+  }
+
+  private static EventApplicationForm form(Long id) {
+    EventApplicationForm form =
+        EventApplicationForm.create(
+            BOARD_ID,
+            "가을 해커톤",
+            LocalDate.of(2026, 9, 1),
+            LocalDate.of(2026, 9, 2),
+            null,
+            null,
+            null,
+            UserRole.MEMBER,
+            true);
+    ReflectionTestUtils.setField(form, "id", id);
+    return form;
+  }
+
+  private static User user() {
+    User user = User.builder().name("홍길동").build();
+    ReflectionTestUtils.setField(user, "id", USER_ID);
+    return user;
+  }
+
+  private void assertError(Runnable action, EventApplicationErrorCode expected) {
+    assertThatThrownBy(action::run)
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(expected);
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicationServiceTest.java
@@ -1,0 +1,236 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inha.gdgoc.domain.eventapplication.dto.request.EventApplicationSubmitRequest;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.enums.ApplicationStatus;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.domain.user.repository.UserRepository;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EventApplicationServiceTest {
+
+  private static final Long BOARD_ID = 10L;
+  private static final Long FORM_ID = 100L;
+  private static final Long USER_ID = 7L;
+  private static final Instant NOW = Instant.parse("2026-09-01T03:00:00Z");
+
+  @Mock private EventApplicationFormRepository formRepository;
+  @Mock private EventApplicationRepository applicationRepository;
+  @Mock private UserRepository userRepository;
+
+  private EventApplicationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new EventApplicationService(
+            formRepository,
+            applicationRepository,
+            userRepository,
+            new AnswerValidator(),
+            new AnswerCodec(new ObjectMapper()),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
+  @Test
+  @DisplayName("권한이 모자라면 신청을 막는다")
+  void rejectsWhenRoleBelowMinimum() {
+    givenForm(form(UserRole.MEMBER, null, null, null, true));
+    givenNoExistingApplication();
+
+    assertError(() -> apply(UserRole.GUEST), EventApplicationErrorCode.NOT_ELIGIBLE);
+    verify(applicationRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("외부 공개 행사는 GUEST 도 신청할 수 있다")
+  void guestCanApplyWhenMinRoleIsGuest() {
+    givenForm(form(UserRole.GUEST, null, null, null, true));
+    givenNoExistingApplication();
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user()));
+
+    assertThatCode(() -> apply(UserRole.GUEST)).doesNotThrowAnyException();
+    verify(applicationRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("신청 시작 전이면 막는다")
+  void rejectsBeforeOpen() {
+    givenForm(form(UserRole.MEMBER, NOW.plusSeconds(3600), null, null, true));
+    givenNoExistingApplication();
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.NOT_OPEN_YET);
+  }
+
+  @Test
+  @DisplayName("마감 시각이 되면 막는다")
+  void rejectsAtCloseInstant() {
+    // 마감 시각 정각은 이미 닫힌 것으로 본다.
+    givenForm(form(UserRole.MEMBER, null, NOW, null, true));
+    givenNoExistingApplication();
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.ALREADY_CLOSED);
+  }
+
+  @Test
+  @DisplayName("수동으로 닫아두면 기간 안이어도 막는다")
+  void rejectsWhenManuallyClosed() {
+    givenForm(form(UserRole.MEMBER, null, null, null, false));
+    givenNoExistingApplication();
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.FORM_CLOSED);
+  }
+
+  @Test
+  @DisplayName("정원이 찼으면 막는다")
+  void rejectsWhenCapacityFull() {
+    givenForm(form(UserRole.MEMBER, null, null, 2, true));
+    givenNoExistingApplication();
+    when(applicationRepository.countByFormIdAndStatus(FORM_ID, ApplicationStatus.APPLIED))
+        .thenReturn(2L);
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.CAPACITY_FULL);
+  }
+
+  @Test
+  @DisplayName("정원을 셀 때 폼 행을 잠근다")
+  void locksFormRowBeforeCountingCapacity() {
+    givenForm(form(UserRole.MEMBER, null, null, 10, true));
+    givenNoExistingApplication();
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user()));
+
+    apply(UserRole.MEMBER);
+
+    // 잠그지 않고 읽으면 동시 신청이 정원을 넘긴다.
+    verify(formRepository).findByEventBoardIdForUpdate(BOARD_ID);
+  }
+
+  @Test
+  @DisplayName("이미 신청했으면 다시 신청할 수 없다")
+  void rejectsDuplicateApplication() {
+    EventApplicationForm form = form(UserRole.MEMBER, null, null, null, true);
+    givenForm(form);
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID))
+        .thenReturn(Optional.of(EventApplication.create(form, user(), NOW)));
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.ALREADY_APPLIED);
+  }
+
+  @Test
+  @DisplayName("취소했던 신청은 새 행을 만들지 않고 같은 행을 되살린다")
+  void reapplyRevivesSameRow() {
+    EventApplicationForm form = form(UserRole.MEMBER, null, null, null, true);
+    givenForm(form);
+    EventApplication canceled = EventApplication.create(form, user(), NOW.minusSeconds(600));
+    canceled.cancel(NOW.minusSeconds(300));
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID))
+        .thenReturn(Optional.of(canceled));
+
+    apply(UserRole.MEMBER);
+
+    assertThat(canceled.getStatus()).isEqualTo(ApplicationStatus.APPLIED);
+    assertThat(canceled.getCanceledAt()).isNull();
+    // UNIQUE(form_id, user_id) 때문에 새로 저장하면 충돌한다.
+    verify(applicationRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("신청 내역이 없으면 취소할 수 없다")
+  void cancelWithoutApplication() {
+    givenFormForRead(form(UserRole.MEMBER, null, null, null, true));
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID)).thenReturn(Optional.empty());
+
+    assertError(
+        () -> service.cancel(BOARD_ID, USER_ID), EventApplicationErrorCode.APPLICATION_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("취소하면 행이 남고 상태만 바뀐다")
+  void cancelKeepsRow() {
+    EventApplicationForm form = form(UserRole.MEMBER, null, null, null, true);
+    givenFormForRead(form);
+    EventApplication application = EventApplication.create(form, user(), NOW.minusSeconds(60));
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID))
+        .thenReturn(Optional.of(application));
+
+    service.cancel(BOARD_ID, USER_ID);
+
+    assertThat(application.getStatus()).isEqualTo(ApplicationStatus.CANCELED);
+    assertThat(application.getCanceledAt()).isEqualTo(NOW);
+    verify(applicationRepository, never()).delete(any());
+  }
+
+  private void apply(UserRole role) {
+    service.apply(BOARD_ID, new EventApplicationSubmitRequest(List.of()), USER_ID, role);
+  }
+
+  private void givenForm(EventApplicationForm form) {
+    when(formRepository.findByEventBoardIdForUpdate(BOARD_ID)).thenReturn(Optional.of(form));
+  }
+
+  private void givenFormForRead(EventApplicationForm form) {
+    when(formRepository.findByEventBoardId(BOARD_ID)).thenReturn(Optional.of(form));
+  }
+
+  private void givenNoExistingApplication() {
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID)).thenReturn(Optional.empty());
+  }
+
+  private static EventApplicationForm form(
+      UserRole minRole, Instant opensAt, Instant closesAt, Integer capacity, boolean isOpen) {
+    EventApplicationForm form =
+        EventApplicationForm.create(
+            BOARD_ID,
+            "가을 해커톤",
+            LocalDate.of(2026, 9, 1),
+            LocalDate.of(2026, 9, 2),
+            opensAt,
+            closesAt,
+            capacity,
+            minRole,
+            isOpen);
+    ReflectionTestUtils.setField(form, "id", FORM_ID);
+    return form;
+  }
+
+  private static User user() {
+    User user = User.builder().name("홍길동").build();
+    ReflectionTestUtils.setField(user, "id", USER_ID);
+    return user;
+  }
+
+  private void assertError(Runnable action, EventApplicationErrorCode expected) {
+    assertThatThrownBy(action::run)
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(expected);
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinServiceTest.java
@@ -1,0 +1,181 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import inha.gdgoc.domain.eventapplication.dto.response.CheckinResponse;
+import inha.gdgoc.domain.eventapplication.entity.EventApplication;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.enums.EventAttendanceStatus;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.entity.User;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EventCheckinServiceTest {
+
+  private static final Long BOARD_ID = 10L;
+  private static final Long FORM_ID = 100L;
+  private static final Long USER_ID = 7L;
+
+  /** 행사 기간(9/1~9/2) 안. KST 로 9월 1일 낮이다. */
+  private static final Instant DURING_EVENT = Instant.parse("2026-09-01T03:00:00Z");
+
+  @Mock private EventApplicationFormRepository formRepository;
+  @Mock private EventApplicationRepository applicationRepository;
+
+  @Test
+  @DisplayName("신청자가 유효한 토큰으로 찍으면 참석으로 바뀐다")
+  void checkInMarksAttended() {
+    EventApplicationForm form = form();
+    EventApplication application = application(form);
+    givenForm(form);
+    givenApplication(application);
+
+    EventCheckinService service = service(DURING_EVENT);
+    CheckinResponse result = service.checkIn(BOARD_ID, token(), USER_ID);
+
+    assertThat(result.alreadyCheckedIn()).isFalse();
+    assertThat(application.getAttendanceStatus()).isEqualTo(EventAttendanceStatus.ATTENDED);
+    assertThat(application.getCheckedInAt()).isEqualTo(DURING_EVENT);
+  }
+
+  @Test
+  @DisplayName("두 번 찍어도 오류가 아니라 이미 처리됨으로 알려준다")
+  void secondScanIsNotAnError() {
+    EventApplicationForm form = form();
+    EventApplication application = application(form);
+    Instant firstScan = DURING_EVENT.minusSeconds(600);
+    application.checkIn(firstScan);
+    givenForm(form);
+    givenApplication(application);
+
+    CheckinResponse result = service(DURING_EVENT).checkIn(BOARD_ID, token(), USER_ID);
+
+    assertThat(result.alreadyCheckedIn()).isTrue();
+    // 처음 찍은 시각을 덮어쓰지 않는다.
+    assertThat(result.checkedInAt()).isEqualTo(firstScan);
+    assertThat(application.getCheckedInAt()).isEqualTo(firstScan);
+  }
+
+  @Test
+  @DisplayName("만료된 토큰을 거절한다")
+  void rejectsExpiredToken() {
+    EventApplicationForm form = form();
+    givenForm(form);
+
+    // 3분 전에 찍힌 QR 사진으로 시도하는 상황이다.
+    String staleToken =
+        new EventCheckinTokenService("s", Clock.fixed(DURING_EVENT.minusSeconds(180), ZoneOffset.UTC))
+            .issue(FORM_ID);
+
+    assertError(
+        () -> service(DURING_EVENT).checkIn(BOARD_ID, staleToken, USER_ID),
+        EventApplicationErrorCode.CHECKIN_TOKEN_INVALID);
+  }
+
+  @Test
+  @DisplayName("행사 기간이 아니면 거절한다")
+  void rejectsOutsideEventPeriod() {
+    givenForm(form());
+
+    Instant dayAfter = Instant.parse("2026-09-03T03:00:00Z");
+    assertError(
+        () -> service(dayAfter).checkIn(BOARD_ID, token(dayAfter), USER_ID),
+        EventApplicationErrorCode.CHECKIN_NOT_IN_PERIOD);
+  }
+
+  @Test
+  @DisplayName("신청하지 않은 사람은 신청부터 하라고 돌려보낸다")
+  void rejectsWhenNotApplied() {
+    givenForm(form());
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID)).thenReturn(Optional.empty());
+
+    assertError(
+        () -> service(DURING_EVENT).checkIn(BOARD_ID, token(), USER_ID),
+        EventApplicationErrorCode.CHECKIN_NOT_APPLIED);
+  }
+
+  @Test
+  @DisplayName("취소한 신청으로는 체크인할 수 없다")
+  void rejectsCanceledApplication() {
+    EventApplicationForm form = form();
+    EventApplication application = application(form);
+    application.cancel(DURING_EVENT.minusSeconds(60));
+    givenForm(form);
+    givenApplication(application);
+
+    assertError(
+        () -> service(DURING_EVENT).checkIn(BOARD_ID, token(), USER_ID),
+        EventApplicationErrorCode.CHECKIN_NOT_APPLIED);
+  }
+
+  private EventCheckinService service(Instant now) {
+    return new EventCheckinService(
+        formRepository,
+        applicationRepository,
+        new EventCheckinTokenService("s", Clock.fixed(now, ZoneOffset.UTC)),
+        Clock.fixed(now, ZoneOffset.UTC));
+  }
+
+  private static String token() {
+    return token(DURING_EVENT);
+  }
+
+  private static String token(Instant now) {
+    return new EventCheckinTokenService("s", Clock.fixed(now, ZoneOffset.UTC)).issue(FORM_ID);
+  }
+
+  private void givenForm(EventApplicationForm form) {
+    when(formRepository.findByEventBoardId(BOARD_ID)).thenReturn(Optional.of(form));
+  }
+
+  private void givenApplication(EventApplication application) {
+    when(applicationRepository.findByFormIdAndUserId(FORM_ID, USER_ID))
+        .thenReturn(Optional.of(application));
+  }
+
+  private static EventApplicationForm form() {
+    EventApplicationForm form =
+        EventApplicationForm.create(
+            BOARD_ID,
+            "가을 해커톤",
+            LocalDate.of(2026, 9, 1),
+            LocalDate.of(2026, 9, 2),
+            null,
+            null,
+            null,
+            UserRole.MEMBER,
+            true);
+    ReflectionTestUtils.setField(form, "id", FORM_ID);
+    return form;
+  }
+
+  private static EventApplication application(EventApplicationForm form) {
+    User user = User.builder().name("홍길동").build();
+    ReflectionTestUtils.setField(user, "id", USER_ID);
+    return EventApplication.create(form, user, DURING_EVENT.minusSeconds(86400));
+  }
+
+  private void assertError(Runnable action, EventApplicationErrorCode expected) {
+    assertThatThrownBy(action::run)
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(expected);
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenServiceTest.java
@@ -1,0 +1,101 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * QR 토큰의 회전 규칙.
+ *
+ * <p>이 규칙이 무너지면 QR 사진을 받은 사람이 오지 않고도 출석 처리된다.
+ */
+class EventCheckinTokenServiceTest {
+
+  private static final String SECRET = "test-secret-for-checkin";
+  private static final Instant BASE = Instant.parse("2026-09-01T03:00:00Z");
+
+  @Test
+  @DisplayName("같은 분 안에서는 같은 토큰이 나온다")
+  void stableWithinWindow() {
+    EventCheckinTokenService at00 = service(BASE);
+    EventCheckinTokenService at59 = service(BASE.plusSeconds(59));
+
+    assertThat(at00.issue(1L)).isEqualTo(at59.issue(1L));
+  }
+
+  @Test
+  @DisplayName("1분이 지나면 토큰이 바뀐다")
+  void rotatesEveryMinute() {
+    assertThat(service(BASE).issue(1L)).isNotEqualTo(service(BASE.plusSeconds(60)).issue(1L));
+  }
+
+  @Test
+  @DisplayName("행사마다 토큰이 다르다")
+  void differsPerForm() {
+    EventCheckinTokenService service = service(BASE);
+
+    assertThat(service.issue(1L)).isNotEqualTo(service.issue(2L));
+  }
+
+  @Test
+  @DisplayName("직전 분에 발급된 토큰도 받아준다")
+  void acceptsPreviousWindow() {
+    String issuedEarlier = service(BASE.plusSeconds(59)).issue(1L);
+
+    // 59초에 QR 을 찍고 1초 뒤에 요청이 도착하는 것은 정상적인 상황이다.
+    EventCheckinTokenService oneSecondLater = service(BASE.plusSeconds(61));
+
+    assertThat(oneSecondLater.verify(1L, issuedEarlier)).isTrue();
+  }
+
+  @Test
+  @DisplayName("두 번 이상 지난 토큰은 거절한다")
+  void rejectsOlderThanOneWindow() {
+    String old = service(BASE).issue(1L);
+
+    // 사진으로 전달된 QR 이 걸리는 지점이다.
+    assertThat(service(BASE.plusSeconds(180)).verify(1L, old)).isFalse();
+  }
+
+  @Test
+  @DisplayName("다른 행사의 토큰으로는 체크인할 수 없다")
+  void rejectsTokenOfAnotherForm() {
+    EventCheckinTokenService service = service(BASE);
+
+    assertThat(service.verify(2L, service.issue(1L))).isFalse();
+  }
+
+  @Test
+  @DisplayName("비어 있거나 엉뚱한 토큰을 거절한다")
+  void rejectsGarbage() {
+    EventCheckinTokenService service = service(BASE);
+
+    assertThat(service.verify(1L, null)).isFalse();
+    assertThat(service.verify(1L, "")).isFalse();
+    assertThat(service.verify(1L, "AAAAAAAAAA")).isFalse();
+  }
+
+  @Test
+  @DisplayName("비밀키가 다르면 서로의 토큰을 받지 않는다")
+  void differentSecretsDoNotInterop() {
+    EventCheckinTokenService other =
+        new EventCheckinTokenService("another-secret", Clock.fixed(BASE, ZoneOffset.UTC));
+
+    assertThat(other.verify(1L, service(BASE).issue(1L))).isFalse();
+  }
+
+  @Test
+  @DisplayName("남은 초는 다음 분까지의 거리다")
+  void remainingSecondsCountsDown() {
+    assertThat(service(BASE).remainingSeconds()).isEqualTo(60);
+    assertThat(service(BASE.plusSeconds(45)).remainingSeconds()).isEqualTo(15);
+  }
+
+  private static EventCheckinTokenService service(Instant now) {
+    return new EventCheckinTokenService(SECRET, Clock.fixed(now, ZoneOffset.UTC));
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventFormValidatorTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventFormValidatorTest.java
@@ -1,0 +1,163 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.global.exception.BusinessException;
+import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class EventFormValidatorTest {
+
+  private final EventFormValidator validator = new EventFormValidator();
+
+  @Test
+  @DisplayName("선택형 질문에 선택지가 없으면 거절한다")
+  void choiceRequiresOptions() {
+    assertError(
+        () -> validator.validateShape(QuestionType.SINGLE_CHOICE, null),
+        EventApplicationErrorCode.OPTIONS_REQUIRED);
+  }
+
+  @Test
+  @DisplayName("단답형에 선택지를 넣으면 거절한다")
+  void shortTextRejectsOptions() {
+    assertError(
+        () -> validator.validateShape(QuestionType.SHORT_TEXT, options("A")),
+        EventApplicationErrorCode.OPTIONS_NOT_ALLOWED);
+  }
+
+  @Test
+  @DisplayName("선택지 값이 겹치면 거절한다")
+  void duplicatedOptionValueRejected() {
+    List<QuestionOption> duplicated =
+        List.of(new QuestionOption("M", "미디엄"), new QuestionOption("M", "라지"));
+    assertError(
+        () -> validator.validateShape(QuestionType.DROPDOWN, duplicated),
+        EventApplicationErrorCode.OPTION_VALUE_DUPLICATED);
+  }
+
+  @Test
+  @DisplayName("뒤 순서 질문을 조건의 기준으로 삼으면 거절한다")
+  void conditionMustPointBackward() {
+    EventFormQuestion later = choice(2L, 5, "YES", "NO");
+
+    assertError(
+        () -> validator.validateCondition(1, 2L, List.of("YES"), List.of(later)),
+        EventApplicationErrorCode.CONDITION_QUESTION_NOT_BEFORE);
+  }
+
+  @Test
+  @DisplayName("선택형이 아닌 질문은 조건의 기준이 될 수 없다")
+  void conditionBaseMustBeSelectable() {
+    EventFormQuestion text = build(1L, 0, QuestionType.LONG_TEXT, null);
+
+    assertError(
+        () -> validator.validateCondition(1, 1L, List.of("아무값"), List.of(text)),
+        EventApplicationErrorCode.CONDITION_QUESTION_TYPE_INVALID);
+  }
+
+  @Test
+  @DisplayName("기준 질문의 선택지에 없는 값은 조건으로 쓸 수 없다")
+  void conditionValueMustExistInOptions() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+
+    assertError(
+        () -> validator.validateCondition(1, 1L, List.of("MAYBE"), List.of(base)),
+        EventApplicationErrorCode.CONDITION_VALUE_INVALID);
+  }
+
+  @Test
+  @DisplayName("동의 질문은 true/false 만 조건 값으로 받는다")
+  void agreementConditionAcceptsBooleanStrings() {
+    EventFormQuestion base = build(1L, 0, QuestionType.AGREEMENT, null);
+
+    assertThatCode(() -> validator.validateCondition(1, 1L, List.of("true"), List.of(base)))
+        .doesNotThrowAnyException();
+    assertError(
+        () -> validator.validateCondition(1, 1L, List.of("YES"), List.of(base)),
+        EventApplicationErrorCode.CONDITION_VALUE_INVALID);
+  }
+
+  @Test
+  @DisplayName("조건 값이 비어 있으면 거절한다")
+  void conditionValuesCannotBeEmpty() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+
+    assertError(
+        () -> validator.validateCondition(1, 1L, List.of(), List.of(base)),
+        EventApplicationErrorCode.CONDITION_VALUES_EMPTY);
+  }
+
+  @Test
+  @DisplayName("다른 질문이 기준으로 삼고 있으면 지울 수 없다")
+  void referencedQuestionCannotBeRemoved() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+    EventFormQuestion dependent = build(2L, 1, QuestionType.SHORT_TEXT, null);
+    dependent.updateCondition(1L, List.of("YES"));
+
+    assertError(
+        () -> validator.validateNotReferenced(1L, List.of(base, dependent)),
+        EventApplicationErrorCode.CONDITION_REFERENCED);
+  }
+
+  @Test
+  @DisplayName("순서를 바꿔 기준 질문이 뒤로 가면 거절한다")
+  void reorderCannotBreakConditions() {
+    EventFormQuestion base = choice(1L, 0, "YES", "NO");
+    EventFormQuestion dependent = build(2L, 1, QuestionType.SHORT_TEXT, null);
+    dependent.updateCondition(1L, List.of("YES"));
+
+    assertThatCode(() -> validator.validateOrderKeepsConditions(List.of(base, dependent)))
+        .doesNotThrowAnyException();
+    assertError(
+        () -> validator.validateOrderKeepsConditions(List.of(dependent, base)),
+        EventApplicationErrorCode.CONDITION_ORDER_BROKEN);
+  }
+
+  @Test
+  @DisplayName("신청자가 있으면 선택지 값을 지울 수 없지만 라벨은 고칠 수 있다")
+  void optionValuesAreKeptButLabelsMayChange() {
+    List<QuestionOption> before = List.of(new QuestionOption("M", "M"), new QuestionOption("L", "L"));
+
+    assertThatCode(
+            () ->
+                validator.validateOptionValuesKept(
+                    before, List.of(new QuestionOption("M", "M (95)"), new QuestionOption("L", "L"))))
+        .doesNotThrowAnyException();
+
+    assertError(
+        () -> validator.validateOptionValuesKept(before, options("M")),
+        EventApplicationErrorCode.OPTION_VALUE_LOCKED);
+  }
+
+  private void assertError(Runnable action, EventApplicationErrorCode expected) {
+    assertThatThrownBy(action::run)
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(expected);
+  }
+
+  private static List<QuestionOption> options(String... values) {
+    return List.of(values).stream().map(v -> new QuestionOption(v, v)).toList();
+  }
+
+  private static EventFormQuestion choice(Long id, int sortOrder, String... values) {
+    return build(id, sortOrder, QuestionType.SINGLE_CHOICE, options(values));
+  }
+
+  private static EventFormQuestion build(
+      Long id, int sortOrder, QuestionType type, List<QuestionOption> options) {
+    EventFormQuestion question =
+        EventFormQuestion.create(null, type, "질문", null, false, sortOrder, options, null, null);
+    ReflectionTestUtils.setField(question, "id", id);
+    return question;
+  }
+}

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/QuestionConditionEvaluatorTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/QuestionConditionEvaluatorTest.java
@@ -1,0 +1,154 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
+import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.domain.eventapplication.enums.QuestionType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 조건부 표시의 판정 규칙.
+ *
+ * <p>같은 판정이 프론트 렌더러에도 있다. 규칙을 바꿀 때는 양쪽을 함께 고치고 이 테스트를 갱신한다.
+ */
+class QuestionConditionEvaluatorTest {
+
+  @Test
+  @DisplayName("조건이 없는 질문은 답이 무엇이든 보인다")
+  void questionsWithoutConditionAreAlwaysVisible() {
+    EventFormQuestion q1 = choice(1L, 0, "저녁 참여", "YES", "NO");
+    EventFormQuestion q2 = shortText(2L, 1);
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2), Map.of()))
+        .containsExactly(1L, 2L);
+  }
+
+  @Test
+  @DisplayName("기준 질문의 답이 조건 값과 같으면 보인다")
+  void visibleWhenAnswerMatches() {
+    EventFormQuestion q1 = choice(1L, 0, "저녁 참여", "YES", "NO");
+    EventFormQuestion q2 = shortText(2L, 1);
+    condition(q2, 1L, List.of("YES"));
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2), Map.of(1L, "YES")))
+        .containsExactly(1L, 2L);
+  }
+
+  @Test
+  @DisplayName("기준 질문의 답이 다르면 숨는다")
+  void hiddenWhenAnswerDiffers() {
+    EventFormQuestion q1 = choice(1L, 0, "저녁 참여", "YES", "NO");
+    EventFormQuestion q2 = shortText(2L, 1);
+    condition(q2, 1L, List.of("YES"));
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2), Map.of(1L, "NO")))
+        .containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("기준 질문에 아직 답하지 않았으면 숨는다")
+  void hiddenWhenBaseUnanswered() {
+    EventFormQuestion q1 = choice(1L, 0, "저녁 참여", "YES", "NO");
+    EventFormQuestion q2 = shortText(2L, 1);
+    condition(q2, 1L, List.of("YES"));
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2), Map.of()))
+        .containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("다중선택은 고른 값 중 하나라도 조건에 걸리면 보인다")
+  void multiChoiceMatchesAnySelectedValue() {
+    EventFormQuestion q1 = multiChoice(1L, 0, "관심 세션", "A", "B", "C");
+    EventFormQuestion q2 = shortText(2L, 1);
+    condition(q2, 1L, List.of("B"));
+
+    assertThat(
+            QuestionConditionEvaluator.visibleQuestionIds(
+                List.of(q1, q2), Map.of(1L, List.of("A", "B"))))
+        .containsExactly(1L, 2L);
+
+    assertThat(
+            QuestionConditionEvaluator.visibleQuestionIds(
+                List.of(q1, q2), Map.of(1L, List.of("A", "C"))))
+        .containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("동의 질문은 true/false 를 조건 값으로 쓴다")
+  void agreementUsesBooleanValue() {
+    EventFormQuestion q1 = agreement(1L, 0);
+    EventFormQuestion q2 = shortText(2L, 1);
+    condition(q2, 1L, List.of("true"));
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2), Map.of(1L, true)))
+        .containsExactly(1L, 2L);
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2), Map.of(1L, false)))
+        .containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("기준 질문이 숨겨져 있으면 거기 딸린 질문도 숨는다")
+  void hiddenChainPropagates() {
+    EventFormQuestion q1 = choice(1L, 0, "저녁 참여", "YES", "NO");
+    EventFormQuestion q2 = choice(2L, 1, "메뉴", "한식", "양식");
+    condition(q2, 1L, List.of("YES"));
+    EventFormQuestion q3 = shortText(3L, 2);
+    condition(q3, 2L, List.of("한식"));
+
+    // q1 에 NO 라고 답하면 q2 가 숨고, q2 를 기준 삼는 q3 도 함께 숨어야 한다.
+    // 답변 맵에 q2 값이 남아 있어도 마찬가지다.
+    Map<Long, Object> answers = Map.of(1L, "NO", 2L, "한식");
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q1, q2, q3), answers))
+        .containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("기준 질문이 목록에 없으면 숨는다")
+  void hiddenWhenBaseMissing() {
+    EventFormQuestion q2 = shortText(2L, 1);
+    condition(q2, 99L, List.of("YES"));
+
+    assertThat(QuestionConditionEvaluator.visibleQuestionIds(List.of(q2), Map.of(99L, "YES")))
+        .isEmpty();
+  }
+
+  private static EventFormQuestion shortText(Long id, int sortOrder) {
+    return build(id, sortOrder, QuestionType.SHORT_TEXT, "질문", null);
+  }
+
+  private static EventFormQuestion choice(Long id, int sortOrder, String label, String... values) {
+    return build(id, sortOrder, QuestionType.SINGLE_CHOICE, label, options(values));
+  }
+
+  private static EventFormQuestion multiChoice(
+      Long id, int sortOrder, String label, String... values) {
+    return build(id, sortOrder, QuestionType.MULTI_CHOICE, label, options(values));
+  }
+
+  private static EventFormQuestion agreement(Long id, int sortOrder) {
+    return build(id, sortOrder, QuestionType.AGREEMENT, "개인정보 수집 동의", null);
+  }
+
+  private static List<QuestionOption> options(String... values) {
+    return List.of(values).stream().map(v -> new QuestionOption(v, v)).toList();
+  }
+
+  private static EventFormQuestion build(
+      Long id, int sortOrder, QuestionType type, String label, List<QuestionOption> options) {
+    EventFormQuestion question =
+        EventFormQuestion.create(null, type, label, null, false, sortOrder, options, null, null);
+    ReflectionTestUtils.setField(question, "id", id);
+    return question;
+  }
+
+  private static void condition(EventFormQuestion question, Long baseId, List<String> values) {
+    question.updateCondition(baseId, values);
+  }
+}


### PR DESCRIPTION
행사마다 구글폼을 새로 만들던 것을 사이트 안으로 들여온다.

## 무엇

- **신청 폼** — 행사 게시글(`event_board`)에 폼을 하나 붙인다. 마감 일시·정원·신청 자격을 두고, 질문은 운영진이 직접 만든다(9개 유형, 표시 조건, 순서).
- **신청·취소·재신청** — 취소했던 신청은 같은 행을 되살린다(`UNIQUE(form_id, user_id)`).
- **신청자 관리** — 목록, 참석 처리, CSV 내려받기, 현장 등록.
- **QR 체크인** — 1분마다 바뀌는 HMAC 토큰. 부원은 폰 기본 카메라로 찍는다.
- **활동 이력** — `/me/activities`.

## 설계 결정

- **행사는 `event_board` 를 재사용한다.** 글 없이 신청만 받는 행사는 없다는 판단.
- **FK 가 아니라 ID 로 묶는다.** 제목·기간을 스냅샷으로 복사해 두어, 글이 휴지통에 가도 이력이 빈칸이 되지 않는다. 글을 수정하면 스냅샷을 갱신한다.
- **행사 참석은 코어 정기모임 출석과 분리한다.** 성격이 다르다.
- **정원은 폼 행에 비관적 락을 잡고 센다.** 동시에 눌러도 정원을 넘지 않는다.
- **신청 가능 여부 판정을 한 곳(`blockedBy`)에 모았다.** 조회가 주는 버튼 상태와 실제 처리 결과가 어긋나지 않는다.

## 확인

- 테스트 260개 통과.
- 마이그레이션은 실제 PostgreSQL 16 에 적용해 제약 5개가 의도대로 거절하는지 확인했다.

## 배포 순서

**이 PR 을 먼저 올리고 Web 을 나중에 올린다.** 반대로 하면 Web 이 없는 엔드포인트를 부른다.

`EVENT_CHECKIN_SECRET` 을 주지 않으면 기동 때 임의 생성한다. 서버 한 대라 동작에는 문제가 없지만, 재시작하면 그 순간 떠 있던 QR 이 무효가 된다(화면이 60초마다 새로 받아 저절로 회복된다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW