### PR TITLE
feat: 신청 폼에 '작성 중' 상태를 둔다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/AdminEventFormController.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/AdminEventFormController.java
@@ -55,6 +55,13 @@ public class AdminEventFormController {
     return ResponseEntity.ok(ApiResponse.ok(FORM_UPDATED));
   }
 
+  /** 부원에게 공개한다. 이 요청 전까지 행사 상세에는 신청 영역이 아예 그려지지 않는다. */
+  @PostMapping("/publish")
+  public ResponseEntity<ApiResponse<Void, Void>> publishForm(@PathVariable Long eventBoardId) {
+    eventFormAdminService.publishForm(eventBoardId);
+    return ResponseEntity.ok(ApiResponse.ok(FORM_PUBLISHED));
+  }
+
   @DeleteMapping
   public ResponseEntity<ApiResponse<Void, Void>> deleteForm(@PathVariable Long eventBoardId) {
     eventFormAdminService.deleteForm(eventBoardId);

--- a/src/main/java/inha/gdgoc/domain/eventapplication/controller/message/EventApplicationMessage.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/controller/message/EventApplicationMessage.java
@@ -4,6 +4,7 @@ public class EventApplicationMessage {
 
   public static final String FORM_CREATED = "신청 폼을 만들었습니다.";
   public static final String FORM_UPDATED = "신청 설정을 저장했습니다.";
+  public static final String FORM_PUBLISHED = "신청 폼을 공개했습니다.";
   public static final String FORM_DELETED = "신청 받기를 해제했습니다.";
   public static final String FORM_RETRIEVED = "신청 폼을 조회했습니다.";
   public static final String QUESTION_CREATED = "질문을 추가했습니다.";

--- a/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/EventFormResponse.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/dto/response/EventFormResponse.java
@@ -10,6 +10,8 @@ import java.util.List;
  * 운영진이 보는 신청 폼.
  *
  * <p>appliedCount 는 폼을 어디까지 고칠 수 있는지 가르는 값이라 함께 내려준다. 0 이면 무엇이든 바꿀 수 있고, 1 이상이면 유형·선택지·필수 강화가 막힌다.
+ *
+ * <p>publishedAt 이 null 이면 아직 만드는 중이라 부원에게 보이지 않는다. 운영진 화면만 이 상태를 볼 수 있다.
  */
 public record EventFormResponse(
     Long id,
@@ -22,6 +24,7 @@ public record EventFormResponse(
     Integer capacity,
     UserRole minRole,
     boolean isOpen,
+    Instant publishedAt,
     long appliedCount,
     List<QuestionResponse> questions) {
 
@@ -37,6 +40,7 @@ public record EventFormResponse(
         form.getCapacity(),
         form.getMinRole(),
         form.isOpen(),
+        form.getPublishedAt(),
         appliedCount,
         form.activeQuestions().stream().map(QuestionResponse::from).toList());
   }

--- a/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplicationForm.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/entity/EventApplicationForm.java
@@ -67,6 +67,15 @@ public class EventApplicationForm extends BaseEntity {
   @Column(name = "is_open", nullable = false)
   private boolean isOpen;
 
+  /**
+   * 발행 시각. NULL 이면 아직 만드는 중이라 부원에게 보이지 않는다.
+   *
+   * <p>{@code isOpen} 과는 다른 축이다 — 발행은 "존재를 드러냈는가", isOpen 은 "지금 받는가". 발행은 되돌리지 않는다. 이미 신청한
+   * 사람의 화면이 통째로 사라지면 안 되고, 그만 받고 싶을 때는 isOpen 을 내리면 된다.
+   */
+  @Column(name = "published_at")
+  private Instant publishedAt;
+
   @OneToMany(mappedBy = "form", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderBy("sortOrder ASC, id ASC")
   private List<EventFormQuestion> questions = new ArrayList<>();
@@ -103,6 +112,17 @@ public class EventApplicationForm extends BaseEntity {
     if (capacity != null) this.capacity = capacity;
     if (minRole != null) this.minRole = minRole;
     if (isOpen != null) this.isOpen = isOpen;
+  }
+
+  /** 부원에게 공개한다. 이미 발행된 폼은 그대로 둔다 — 발행일이 밀리면 안 된다. */
+  public void publish(Instant now) {
+    if (this.publishedAt == null) {
+      this.publishedAt = now;
+    }
+  }
+
+  public boolean isPublished() {
+    return this.publishedAt != null;
   }
 
   /** 정원을 무제한으로 되돌린다. {@link #updateSettings} 로는 null 을 넣을 수 없기 때문이다. */

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicationService.java
@@ -104,6 +104,7 @@ public class EventApplicationService {
     EventApplicationForm form =
         formRepository
             .findByEventBoardIdForUpdate(eventBoardId)
+            .filter(EventApplicationForm::isPublished)
             .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
 
     EventApplication existing =
@@ -189,9 +190,16 @@ public class EventApplicationService {
 
 
 
+  /**
+   * 부원에게 보이는 폼만 찾는다.
+   *
+   * <p>발행 전 폼은 없는 것으로 다룬다. 반쯤 만들어진 질문들이 행사 상세에 뜨면 안 되고, 웹은 404 를 "신청을 받지 않는 행사" 로 읽어 신청 영역을
+   * 통째로 그리지 않는다.
+   */
   private EventApplicationForm findForm(Long eventBoardId) {
     return formRepository
         .findByEventBoardId(eventBoardId)
+        .filter(EventApplicationForm::isPublished)
         .orElseThrow(() -> new BusinessException(FORM_NOT_FOUND));
   }
 

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
@@ -15,11 +15,14 @@ import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormReposit
 import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
 import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
  * 취소를 뺀 {@code APPLIED} 만 센다.
  */
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class EventFormAdminService {
 
@@ -38,6 +40,34 @@ public class EventFormAdminService {
   private final EventApplicationRepository applicationRepository;
   private final EventBoardRepository eventBoardRepository;
   private final EventFormValidator validator;
+  private final Clock clock;
+
+  @Autowired
+  public EventFormAdminService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      EventBoardRepository eventBoardRepository,
+      EventFormValidator validator) {
+    this(
+        formRepository,
+        applicationRepository,
+        eventBoardRepository,
+        validator,
+        Clock.system(ZoneId.of("Asia/Seoul")));
+  }
+
+  EventFormAdminService(
+      EventApplicationFormRepository formRepository,
+      EventApplicationRepository applicationRepository,
+      EventBoardRepository eventBoardRepository,
+      EventFormValidator validator,
+      Clock clock) {
+    this.formRepository = formRepository;
+    this.applicationRepository = applicationRepository;
+    this.eventBoardRepository = eventBoardRepository;
+    this.validator = validator;
+    this.clock = clock;
+  }
 
   public EventFormResponse getForm(Long eventBoardId) {
     EventApplicationForm form = findForm(eventBoardId);
@@ -82,6 +112,17 @@ public class EventFormAdminService {
         && !form.getOpensAt().isBefore(form.getClosesAt())) {
       throw new BusinessException(PERIOD_INVALID);
     }
+  }
+
+  /**
+   * 부원에게 공개한다.
+   *
+   * <p>되돌리는 길은 두지 않는다. 이미 신청한 사람의 화면이 통째로 사라지면 안 되기 때문이다. 그만 받고 싶으면 {@code isOpen} 을 내리고, 아무도
+   * 신청하지 않았다면 폼째로 지우면 된다.
+   */
+  @Transactional
+  public void publishForm(Long eventBoardId) {
+    findForm(eventBoardId).publish(Instant.now(clock));
   }
 
   /** 신청 받기를 해제한다. 신청자가 있으면 지우지 않고 마감으로 닫도록 안내한다. */

--- a/src/main/resources/db/migration/V20260827_2__add_event_form_published_at.sql
+++ b/src/main/resources/db/migration/V20260827_2__add_event_form_published_at.sql
@@ -1,0 +1,20 @@
+-- 신청 폼에 '작성 중' 상태를 준다.
+--
+-- 폼을 만들자마자 부원에게 보이면 질문을 다 넣기 전 반쯤 만들어진 폼이 노출된다.
+-- published_at 이 NULL 인 동안은 공개 조회가 404 를 주고, 운영진 화면에서만 보인다.
+--
+-- is_open 과는 다른 축이다.
+--   published_at IS NULL  : 아직 만드는 중 — 부원에게 아무것도 안 보인다
+--   published_at 있음 + is_open : 신청 받는 중
+--   published_at 있음 + !is_open: 마감 — 폼은 보이되 신청 버튼이 잠긴다
+--
+-- 발행은 되돌리지 않는다. 이미 신청한 사람의 화면이 통째로 사라지면 안 되기 때문이고,
+-- 그만 받고 싶을 때는 is_open 을 내리면 된다.
+ALTER TABLE event_application_form
+    ADD COLUMN published_at TIMESTAMPTZ NULL;
+
+-- 이 컬럼이 생기기 전에 만들어진 폼은 이미 부원에게 보이고 있었다.
+-- NULL 로 두면 그 폼들이 갑자기 사라지므로 발행된 것으로 본다.
+UPDATE event_application_form
+SET published_at = created_at
+WHERE published_at IS NULL;

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminServiceTest.java
@@ -155,6 +155,8 @@ class EventApplicantAdminServiceTest {
             UserRole.MEMBER,
             true);
     ReflectionTestUtils.setField(form, "id", id);
+    // 부원에게 보이는 경로는 발행된 폼만 찾는다. 픽스처도 발행 상태로 둔다.
+    form.publish(Instant.parse("2026-08-01T00:00:00Z"));
     return form;
   }
 

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicationServiceTest.java
@@ -188,6 +188,33 @@ class EventApplicationServiceTest {
     verify(applicationRepository, never()).delete(any());
   }
 
+  @Test
+  @DisplayName("발행 전 폼은 부원에게 없는 것으로 보인다")
+  void unpublishedFormIsInvisible() {
+    // 만드는 중인 폼이 행사 상세에 뜨면 질문을 다 넣기 전에 노출된다.
+    // 웹은 404 를 "신청을 받지 않는 행사" 로 읽어 신청 영역을 아예 그리지 않는다.
+    givenFormForRead(unpublishedForm());
+
+    assertError(
+        () -> service.getForm(BOARD_ID, USER_ID, UserRole.MEMBER),
+        EventApplicationErrorCode.FORM_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("발행 전 폼에는 주소를 알아도 신청할 수 없다")
+  void cannotApplyToUnpublishedForm() {
+    givenForm(unpublishedForm());
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.FORM_NOT_FOUND);
+    verify(applicationRepository, never()).save(any());
+  }
+
+  private static EventApplicationForm unpublishedForm() {
+    EventApplicationForm form = form(UserRole.MEMBER, null, null, null, true);
+    ReflectionTestUtils.setField(form, "publishedAt", null);
+    return form;
+  }
+
   private void apply(UserRole role) {
     service.apply(BOARD_ID, new EventApplicationSubmitRequest(List.of()), USER_ID, role);
   }
@@ -218,6 +245,8 @@ class EventApplicationServiceTest {
             minRole,
             isOpen);
     ReflectionTestUtils.setField(form, "id", FORM_ID);
+    // 부원에게 보이는 경로는 발행된 폼만 찾는다. 픽스처도 발행 상태로 둔다.
+    form.publish(Instant.parse("2026-08-01T00:00:00Z"));
     return form;
   }
 

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinServiceTest.java
@@ -163,6 +163,8 @@ class EventCheckinServiceTest {
             UserRole.MEMBER,
             true);
     ReflectionTestUtils.setField(form, "id", FORM_ID);
+    // 부원에게 보이는 경로는 발행된 폼만 찾는다. 픽스처도 발행 상태로 둔다.
+    form.publish(Instant.parse("2026-08-01T00:00:00Z"));
     return form;
   }
 


### PR DESCRIPTION
[#355](https://github.com/GDGoCINHA/24-2_GDGoC_Server/pull/355) 후속. **Web PR 보다 먼저 머지한다.**

## 왜

폼을 만들자마자 부원에게 보여서, 질문을 다 넣기 전 반쯤 만들어진 폼이 행사 상세에 떴다. 신청 폼은 한 번에 완성하기 어려운 물건인데 만드는 과정이 그대로 노출되는 셈이다.

`is_open` 을 끄는 것으로는 부족하다 — 그러면 부원이 **폼과 질문을 다 보면서 버튼만 잠긴** 상태가 된다.

## 무엇

- `event_application_form.published_at` 추가. NULL 인 동안 부원 쪽 조회(`GET /board/events/{id}/form`)와 신청이 `FORM_NOT_FOUND` 를 준다. 웹은 404 를 "신청을 받지 않는 행사" 로 읽어 신청 영역을 아예 그리지 않는다.
- `POST /admin/events/{eventBoardId}/form/publish` 추가.
- `EventFormResponse` 에 `publishedAt` 추가.

## 두 축은 다르다

| | 부원에게 | 신청 |
|---|---|---|
| `published_at IS NULL` | 안 보임 | — |
| 발행 + `is_open` | 보임 | 받는 중 |
| 발행 + `!is_open` | 보임 | 마감 |

**발행은 되돌리지 않는다.** 이미 신청한 사람의 화면이 통째로 사라지면 안 되기 때문이고, 그만 받고 싶으면 `is_open` 을 내리면 된다. 아무도 신청하지 않았다면 폼째로 지울 수 있다.

## 마이그레이션

기존 행을 `published_at = created_at` 으로 채운다. 이 컬럼이 생기기 전 폼들은 이미 부원에게 보이고 있었으므로 NULL 로 두면 갑자기 사라진다. 실제 PostgreSQL 16 에 적용해 기존 행 backfill 과 새 행 NULL 을 확인했다.

## 확인

테스트 262개 통과. 가시성 변경이므로 발행 전 폼이 조회·신청 양쪽에서 404 가 되는 테스트를 추가했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW