### PR TITLE
feat(recruit-member): 부원 지원에 로그인을 요구하고 신원을 계정에서 가져온다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/controller/RecruitMemberController.java
@@ -94,28 +94,39 @@ public class RecruitMemberController {
         return ResponseEntity.ok(recruitMemberPeriodService.getPeriod());
     }
 
+    /**
+     * 지원 접수. 로그인이 필요하다.
+     *
+     * <p>이름·학번·이메일·전화·학과는 계정에서 가져오므로 폼이 보내도 무시한다. 이미 지원한 사람은 화면이 폼을 그리기 전에
+     * {@code GET /applications/me} 로 걸러낸다 — 다 채우고 제출한 뒤에 "중복" 을 보는 것은 사고로 읽힌다.
+     */
+    @PreAuthorize("isAuthenticated()")
     @PostMapping(value = "/apply", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Void, Void>> recruitMemberAdd(
+            @AuthenticationPrincipal CustomUserDetails me,
             @RequestBody Map<String, Object> applicationRequest
     ) {
         recruitMemberPeriodService.validateOpen();
-        recruitMemberService.addRecruitMember(applicationRequest, null);
+        recruitMemberService.addRecruitMember(applicationRequest, null, me.getUserId());
 
         return ResponseEntity.ok(ApiResponse.ok(MEMBER_SAVE_SUCCESS));
     }
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping(value = "/apply", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void, Void>> recruitMemberAddMultipart(
+            @AuthenticationPrincipal CustomUserDetails me,
             @RequestPart("request") Map<String, Object> applicationRequest,
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
         recruitMemberPeriodService.validateOpen();
-        recruitMemberService.addRecruitMember(applicationRequest, file);
+        recruitMemberService.addRecruitMember(applicationRequest, file, me.getUserId());
 
         return ResponseEntity.ok(ApiResponse.ok(MEMBER_SAVE_SUCCESS));
     }
 
     /** 증빙 파일도 지원의 일부다. 기간 밖에 업로드 URL 만 받아두는 길을 열어두지 않는다. */
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/apply/proof-file/presigned-upload")
     public ResponseEntity<ApiResponse<PresignedUploadResponse, Void>> createProofFilePresignedUpload(
             @Valid @RequestBody ProofFilePresignedUploadRequest request

--- a/src/main/java/inha/gdgoc/domain/recruit/member/dto/request/RecruitMemberRequest.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/dto/request/RecruitMemberRequest.java
@@ -28,6 +28,27 @@ public class RecruitMemberRequest {
     private String major;
     private Boolean isPayed;
 
+    /**
+     * 신원을 로그인한 계정의 값으로 갈아끼운다.
+     *
+     * <p>폼이 이름·학번·이메일·전화·학과를 보내더라도 무시한다. 회원가입 때 이미 받은 값이고, 지원서와 계정을 잇는 키가
+     * 이메일이라 타이핑에 맡기면 오타 하나로 영영 안 이어진다.
+     */
+    public RecruitMemberRequest withIdentity(
+            String name, String studentId, String email, String phoneNumber, String major) {
+        return RecruitMemberRequest.builder()
+                .name(name)
+                .studentId(studentId)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .major(major)
+                .enrolledClassification(this.enrolledClassification)
+                .gender(this.gender)
+                .birth(this.birth)
+                .isPayed(this.isPayed)
+                .build();
+    }
+
     public RecruitMember toEntity(AdmissionSemester admissionSemester, MajorNormalizer majorNormalizer) {
         String cleanPhone = phoneNumber.replaceAll("[^0-9]", "");
         return RecruitMember.builder()

--- a/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/repository/RecruitMemberRepository.java
@@ -17,6 +17,8 @@ public interface RecruitMemberRepository
      */
     boolean existsByStudentIdAndAdmissionSemester(String studentId, AdmissionSemester admissionSemester);
 
+    Optional<RecruitMember> findByStudentIdAndAdmissionSemester(String studentId, AdmissionSemester admissionSemester);
+
     boolean existsByPhoneNumberAndAdmissionSemester(String phoneNumber, AdmissionSemester admissionSemester);
 
     boolean existsByEmailIgnoreCaseAndAdmissionSemester(String email, AdmissionSemester admissionSemester);

--- a/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
+++ b/src/main/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberService.java
@@ -36,6 +36,7 @@ import inha.gdgoc.global.util.MajorNormalizer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -61,8 +62,16 @@ public class RecruitMemberService {
     private final S3Service s3Service;
     private final MajorNormalizer majorNormalizer;
 
+    /**
+     * 지원을 접수한다.
+     *
+     * <p>신원(이름·학번·이메일·전화·학과)은 폼이 아니라 로그인한 계정에서 가져온다. 가입 때 이미 받은 값이고,
+     * 지원서와 계정을 잇는 키가 이메일이라 타이핑에 맡기면 오타 하나로 영영 안 이어진다.
+     */
     @Transactional
-    public void addRecruitMember(Map<String, Object> requestPayload, MultipartFile file) {
+    public void addRecruitMember(Map<String, Object> requestPayload, MultipartFile file, Long userId) {
+        User applicant = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
         RecruitMemberRequest memberRequest;
         Map<String, Object> answers;
 
@@ -74,6 +83,13 @@ public class RecruitMemberService {
             memberRequest = buildMemberFromNumberedPayload(requestPayload);
             answers = buildAnswersFromNumberedPayload(requestPayload);
         }
+
+        memberRequest = memberRequest.withIdentity(
+                applicant.getName(),
+                applicant.getStudentId(),
+                applicant.getEmail(),
+                applicant.getPhoneNumber(),
+                applicant.getMajor());
 
         log.info("[recruit-member] 지원 접수 - studentId={}, name={}, hasProofFile={}",
                 memberRequest.getStudentId(), memberRequest.getName(), file != null && !file.isEmpty());
@@ -207,12 +223,39 @@ public class RecruitMemberService {
     public SpecifiedMemberResponse findMyApplication(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+        AdmissionSemester semester = semesterCalculator.currentSemester();
         RecruitMember member = recruitMemberRepository
-                .findByEmailIgnoreCaseAndAdmissionSemester(
-                        user.getEmail().trim(), semesterCalculator.currentSemester())
+                .findByEmailIgnoreCaseAndAdmissionSemester(user.getEmail().trim(), semester)
+                .or(() -> findByAccountStudentId(user, semester))
                 .orElseThrow(() -> new RecruitMemberException(RECRUIT_MEMBER_NOT_FOUND));
 
         return toSpecifiedMemberResponse(member);
+    }
+
+    /**
+     * 이메일로 못 찾았을 때의 대비책.
+     *
+     * <p>로그인 필수로 바뀌기 전에는 지원 폼에 이메일을 직접 적었다. 자기 계정과 다른 @inha.edu 주소를 적은 사람은
+     * 이메일만으로는 영영 안 이어진다.
+     *
+     * <p>학번만으로 찾으면 오타로 남의 학번을 적은 지원서가 걸릴 수 있어 <b>이름까지 같을 때만</b> 인정한다.
+     */
+    private Optional<RecruitMember> findByAccountStudentId(User user, AdmissionSemester semester) {
+        if (user.getStudentId() == null || user.getStudentId().isBlank()) {
+            return Optional.empty();
+        }
+        String accountName = compactName(user.getName());
+        if (accountName.isEmpty()) {
+            return Optional.empty();
+        }
+        return recruitMemberRepository
+                .findByStudentIdAndAdmissionSemester(user.getStudentId().trim(), semester)
+                .filter(found -> compactName(found.getName()).equals(accountName));
+    }
+
+    /** 이름 비교에서 공백만 다른 경우("홍 길동")를 같은 것으로 본다. */
+    private String compactName(String name) {
+        return name == null ? "" : name.replaceAll("\\s+", "");
     }
 
     private SpecifiedMemberResponse toSpecifiedMemberResponse(RecruitMember member) {
@@ -242,8 +285,8 @@ public class RecruitMemberService {
     /**
      * 한 학기에 한 번만 받는다 — 이메일·학번·전화번호 중 하나라도 겹치면 막는다.
      *
-     * <p>화면에서도 중복 확인 버튼으로 걸러내지만 그건 안내일 뿐이다. 지원 API 는 인증 없이 열려 있어
-     * 주소를 직접 치면 그대로 들어온다 — 실제 차단은 여기서 한다.
+     * <p>화면에서도 지원 이력을 먼저 조회해 폼 자체를 막지만 그건 안내일 뿐이다. 주소를 직접 치면
+     * 그대로 들어오므로 실제 차단은 여기서 한다.
      *
      * <p>학번·전화번호는 DB 에도 (값, 학기) 복합 UNIQUE 가 있다. 그것만 믿으면 중복 제출이
      * 제약 위반 500 으로 나가므로, 여기서 먼저 걸러 409 로 답한다.

--- a/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
+++ b/src/main/java/inha/gdgoc/global/security/SecurityConfig.java
@@ -51,7 +51,6 @@ public class SecurityConfig {
                     "/api/v1/auth/**",
                     "/api/v1/test/**",
                     "/api/v1/game/**",
-                    "/api/v1/recruit/member/apply/**",
                     "/api/v1/recruit/member/check/**",
                     "/api/v1/recruit/member/memo",
                     "/api/v1/recruit/core/period",

--- a/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
+++ b/src/test/java/inha/gdgoc/domain/recruit/member/service/RecruitMemberApplicationLimitTest.java
@@ -32,6 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>전에는 서버가 중복을 전혀 보지 않았다. 화면의 중복 확인 버튼이 유일한 장치였고, 지원 API 는
  * 인증 없이 열려 있어 주소를 직접 치면 같은 사람이 몇 번이든 지원할 수 있었다.
  *
+ * <p>지금은 지원에 로그인이 필요하고 <b>신원(이름·학번·이메일·전화·학과)은 계정에서 가져온다.</b>
+ * 그래서 여기서 "같은 사람" 은 폼에 적은 값이 아니라 계정을 뜻한다.
+ *
  * <p>반대로 <b>학기가 바뀌어도 재지원이 안 되는</b> 문제도 있었다. 학번·전화번호에 전역 UNIQUE 가
  * 걸려 있어 2026-1 지원자가 2026-2 에 다시 내면 제약 위반 500 이 났다. 이제 (값, 학기) 복합이다.
  */
@@ -61,32 +64,48 @@ class RecruitMemberApplicationLimitTest {
     }
 
     @Test
-    void 같은_이메일로_같은_학기에_두_번_지원하면_막힌다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+    void 같은_계정으로_같은_학기에_두_번_지원하면_막힌다() {
+        User account = userRepository.save(user("hong@inha.edu"));
+        apply(account);
 
-        // 학번·전화번호를 바꿔도 이메일이 같으면 막혀야 한다.
-        assertThatThrownBy(() ->
-            recruitMemberService.addRecruitMember(payload("12200002", "01000000002", "hong@inha.edu"), null))
+        assertThatThrownBy(() -> apply(account))
             .isInstanceOf(RecruitMemberException.class)
             .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
 
         assertThat(recruitMemberRepository.count()).isEqualTo(1);
     }
 
+    // 폼이 보낸 신원을 그대로 믿으면 남의 이름·학번으로 지원서를 밀어 넣을 수 있다.
+    @Test
+    void 신원은_폼이_아니라_계정에서_가져온다() {
+        User account = userRepository.save(user("hong@inha.edu"));
+
+        recruitMemberService.addRecruitMember(
+            payload("99999999", "01099999999", "someone-else@inha.edu"), null, account.getId());
+
+        RecruitMember saved = recruitMemberRepository.findAll().get(0);
+        assertThat(saved.getName()).isEqualTo("홍길동");
+        assertThat(saved.getStudentId()).isEqualTo("12200001");
+        assertThat(saved.getPhoneNumber()).isEqualTo("01000000001");
+        assertThat(saved.getEmail()).isEqualTo("hong@inha.edu");
+    }
+
     // 이메일은 대소문자를 가리지 않는다. Hong@ 으로 다시 내는 우회를 막는다.
     @Test
     void 대소문자만_다른_이메일도_같은_지원으로_본다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+        // 학번·전화는 겹치지 않게 두어 이메일 검사만 걸리게 한다.
+        recruitMemberRepository.save(member("12209999", "01099999999", "hong@inha.edu"));
 
-        assertThatThrownBy(() ->
-            recruitMemberService.addRecruitMember(payload("12200002", "01000000002", "HONG@inha.edu"), null))
-            .isInstanceOf(RecruitMemberException.class);
+        User account = userRepository.save(user("HONG@inha.edu"));
+        assertThatThrownBy(() -> apply(account))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
     }
 
     @Test
-    void 이메일이_다르면_지원할_수_있다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
-        recruitMemberService.addRecruitMember(payload("12200002", "01000000002", "kim@inha.edu"), null);
+    void 다른_계정이면_지원할_수_있다() {
+        apply(userRepository.save(user("hong@inha.edu", "12200001", "01000000001")));
+        apply(userRepository.save(user("kim@inha.edu", "12200002", "01000000002")));
 
         assertThat(recruitMemberRepository.count()).isEqualTo(2);
     }
@@ -98,28 +117,28 @@ class RecruitMemberApplicationLimitTest {
             member("12200001", "01000000001", "hong@inha.edu", PAST_SEMESTER));
 
         // 같은 사람(학번·전화·이메일 전부 동일)이 이번 학기에 다시 낸다.
-        recruitMemberService.addRecruitMember(
-            payload("12200001", "01000000001", "hong@inha.edu"), null);
+        apply(userRepository.save(user("hong@inha.edu")));
 
         assertThat(recruitMemberRepository.count()).isEqualTo(2);
     }
 
     @Test
     void 같은_학기에_학번이_겹치면_막힌다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "a@inha.edu"), null);
+        apply(userRepository.save(user("a@inha.edu", "12200001", "01000000001")));
 
+        // 계정이 둘이어도 학번이 같으면 같은 사람이다.
         assertThatThrownBy(() ->
-            recruitMemberService.addRecruitMember(payload("12200001", "01000000002", "b@inha.edu"), null))
+            apply(userRepository.save(user("b@inha.edu", "12200001", "01000000002"))))
             .isInstanceOf(RecruitMemberException.class)
             .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
     }
 
     @Test
     void 같은_학기에_전화번호가_겹치면_막힌다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "a@inha.edu"), null);
+        apply(userRepository.save(user("a@inha.edu", "12200001", "01000000001")));
 
         assertThatThrownBy(() ->
-            recruitMemberService.addRecruitMember(payload("12200002", "01000000001", "b@inha.edu"), null))
+            apply(userRepository.save(user("b@inha.edu", "12200002", "01000000001"))))
             .isInstanceOf(RecruitMemberException.class)
             .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_ALREADY_APPLIED);
     }
@@ -137,7 +156,7 @@ class RecruitMemberApplicationLimitTest {
 
     @Test
     void 중복_확인_3종은_이번_학기_지원서를_센다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@inha.edu"), null);
+        apply(userRepository.save(user("hong@inha.edu")));
 
         assertThat(recruitMemberService.isRegisteredStudentId("12200001").isExists()).isTrue();
         assertThat(recruitMemberService.isRegisteredPhoneNumber("01000000001").isExists()).isTrue();
@@ -168,11 +187,46 @@ class RecruitMemberApplicationLimitTest {
         assertThat(response.admissionSemester()).isEqualTo(currentSemester());
     }
 
-    // 남의 지원서가 새어 나가면 안 된다. 이메일이 다르면 없는 것으로 본다.
+    // 남의 지원서가 새어 나가면 안 된다. 이메일도 학번도 다르면 없는 것으로 본다.
     @Test
     void 지원_이력이_없으면_찾을_수_없다() {
         recruitMemberRepository.save(member("12200001", "01000000001", "hong@inha.edu"));
-        User user = userRepository.save(user("kim@inha.edu"));
+        User user = userRepository.save(user("kim@inha.edu", "12209999", "01099999999"));
+
+        assertThatThrownBy(() -> recruitMemberService.findMyApplication(user.getId()))
+            .isInstanceOf(RecruitMemberException.class)
+            .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_NOT_FOUND);
+    }
+
+    // 로그인 필수가 되기 전에는 폼에 이메일을 직접 적었다. 계정과 다른 @inha.edu 주소를 적은
+    // 사람은 이메일만으로는 영영 안 이어져 「지원 이력 없음」 을 보고 또 지원하게 된다.
+    @Test
+    void 이메일이_달라도_학번과_이름이_같으면_내_지원서로_본다() {
+        recruitMemberRepository.save(member("12200001", "01000000001", "typo@inha.edu"));
+        User user = userRepository.save(user("hong@inha.edu", "12200001", "01000000001"));
+
+        SpecifiedMemberResponse response = recruitMemberService.findMyApplication(user.getId());
+
+        assertThat(response.email()).isEqualTo("typo@inha.edu");
+    }
+
+    // 이름 표기에 공백이 섞이는 것까지 다른 사람으로 보면 대비책이 무용지물이 된다.
+    @Test
+    void 이름의_공백_차이는_같은_사람으로_본다() {
+        recruitMemberRepository.save(
+            member("홍 길동", "12200001", "01000000001", "typo@inha.edu", currentSemester()));
+        User user = userRepository.save(user("hong@inha.edu", "12200001", "01000000001"));
+
+        assertThat(recruitMemberService.findMyApplication(user.getId()).studentId())
+            .isEqualTo("12200001");
+    }
+
+    // 학번만으로 이어 붙이면 오타로 남의 학번을 적은 지원서가 딸려 나온다.
+    @Test
+    void 학번이_같아도_이름이_다르면_내_지원서가_아니다() {
+        recruitMemberRepository.save(
+            member("김철수", "12200001", "01000000001", "typo@inha.edu", currentSemester()));
+        User user = userRepository.save(user("hong@inha.edu", "12200001", "01000000009"));
 
         assertThatThrownBy(() -> recruitMemberService.findMyApplication(user.getId()))
             .isInstanceOf(RecruitMemberException.class)
@@ -180,11 +234,11 @@ class RecruitMemberApplicationLimitTest {
     }
 
     // 이메일이 지원서와 계정을 잇는 유일한 키다. 다른 도메인으로 들어오면 나중에 로그인해도
-    // 영영 이어지지 않아 MEMBER 승격이 안 된다. 화면이 도메인을 고정하지만 API 는 열려 있다.
+    // 영영 이어지지 않아 MEMBER 승격이 안 된다. 로그인이 @inha.edu 전용이라 여기까지 올 일은
+    // 거의 없지만, 계정 이메일을 그대로 쓰게 된 지금도 검사는 남겨 둔다.
     @Test
     void 인하대_이메일이_아니면_지원할_수_없다() {
-        assertThatThrownBy(() ->
-            recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@gmail.com"), null))
+        assertThatThrownBy(() -> apply(userRepository.save(user("hong@gmail.com"))))
             .isInstanceOf(RecruitMemberException.class)
             .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN);
 
@@ -193,7 +247,7 @@ class RecruitMemberApplicationLimitTest {
 
     @Test
     void 인하대_이메일은_대소문자를_가리지_않는다() {
-        recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@INHA.edu"), null);
+        apply(userRepository.save(user("hong@INHA.edu")));
 
         assertThat(recruitMemberRepository.count()).isEqualTo(1);
     }
@@ -201,8 +255,7 @@ class RecruitMemberApplicationLimitTest {
     // inha.edu 로 끝나기만 하면 통과하는 검사는 fake-inha.edu 같은 도메인을 놓친다.
     @Test
     void 인하대_도메인을_흉내낸_주소는_막힌다() {
-        assertThatThrownBy(() ->
-            recruitMemberService.addRecruitMember(payload("12200001", "01000000001", "hong@fake-inha.edu"), null))
+        assertThatThrownBy(() -> apply(userRepository.save(user("hong@fake-inha.edu"))))
             .isInstanceOf(RecruitMemberException.class)
             .hasFieldOrPropertyWithValue("errorCode", RecruitMemberErrorCode.RECRUIT_MEMBER_INVALID_EMAIL_DOMAIN);
     }
@@ -269,6 +322,12 @@ class RecruitMemberApplicationLimitTest {
         assertThat(recruitMemberRepository.findById(application.getId()).orElseThrow().getIsPayed()).isTrue();
     }
 
+    /** 지원 한 건. 신원은 계정에서 오므로 payload 에 적은 값은 무시된다. */
+    private void apply(User account) {
+        recruitMemberService.addRecruitMember(
+            payload("00000000", "01000000000", "ignored@inha.edu"), null, account.getId());
+    }
+
     private UserRole roleOf(User account) {
         return userRepository.findById(account.getId()).orElseThrow().getUserRole();
     }
@@ -306,8 +365,18 @@ class RecruitMemberApplicationLimitTest {
         String email,
         AdmissionSemester semester
     ) {
+        return member("홍길동", studentId, phoneNumber, email, semester);
+    }
+
+    private RecruitMember member(
+        String name,
+        String studentId,
+        String phoneNumber,
+        String email,
+        AdmissionSemester semester
+    ) {
         return RecruitMember.builder()
-            .name("홍길동")
+            .name(name)
             .studentId(studentId)
             .enrolledClassification(EnrolledClassification.FULL_REGISTRATION)
             .phoneNumber(phoneNumber)
@@ -329,12 +398,16 @@ class RecruitMemberApplicationLimitTest {
     }
 
     private User user(String email) {
+        return user(email, "12200001", "01000000001");
+    }
+
+    private User user(String email, String studentId, String phoneNumber) {
         return User.builder()
             .name("홍길동")
-            .oauthSubject("oauth-" + email)
+            .oauthSubject("oauth-" + email + "-" + studentId)
             .major("CSE")
-            .studentId("12200001")
-            .phoneNumber("01000000001")
+            .studentId(studentId)
+            .phoneNumber(phoneNumber)
             .email(email)
             .build();
     }


### PR DESCRIPTION
## 왜

이미 지원한 사람이 「지원하기」를 다시 눌러 폼을 다 채우고 제출한 뒤에야 "중복된 학번입니다" 를 만난다. 정상 동작인데도 뭔가 잘못된 것처럼 읽혀서 사전에 차단한다.

## 무엇

- `/recruit/member/apply` 계열을 `permitAll` 에서 빼고 `@PreAuthorize("isAuthenticated()")` 를 건다.
- **신원은 계정에서 가져온다.** 이름·학번·이메일·전화·학과는 폼이 보내도 무시하고 로그인 계정 값으로 덮어쓴다(`RecruitMemberRequest.withIdentity`). 지원서와 계정을 잇는 키가 이메일인데 타이핑에 맡기면 오타 하나로 영영 안 이어져 MEMBER 승격이 안 된다.
- `findMyApplication` 이 이메일로 못 찾으면 **학번+이름**으로 한 번 더 본다. 로그인 필수 이전 지원자 중 계정과 다른 `@inha.edu` 주소를 적은 사람이 있다. 학번만 보면 오타로 남의 지원서가 걸리므로 이름까지 같을 때만 인정하고, 공백 차이는 무시한다.

## 배포 순서 — Server 를 먼저

Web(#PR)이 `Authorization` 을 보내기 시작하기 전까지 짧은 창에서 지원 제출이 401 이 된다. 운영 모집이 열려 있으므로 **머지 후 곧바로 Web 을 올린다.**

## 확인

- `./gradlew cleanTest test` → 266 통과, 실패 0 (지원 제한 테스트 19 → 23)
- 추가한 테스트: 신원이 폼이 아니라 계정에서 오는지, 이메일이 달라도 학번+이름이 같으면 내 지원서로 보는지, 이름이 다르면 안 보는지, 이름의 공백 차이는 같게 보는지
- dev 배포 확인: 무인증 `POST /recruit/member/apply` 가 `400 → 401`, 대조군 `check/student-id` 는 `400` 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW