### PR TITLE
fix(event-application): 신청자 학과가 'ME' 같은 코드로 보이던 문제

### DIFF
--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriter.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriter.java
@@ -3,6 +3,7 @@ package inha.gdgoc.domain.eventapplication.service;
 import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
 import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
 import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
+import inha.gdgoc.global.util.MajorNormalizer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -22,6 +23,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ApplicantCsvWriter {
+
+  private final MajorNormalizer majorNormalizer;
+
+  public ApplicantCsvWriter(MajorNormalizer majorNormalizer) {
+    this.majorNormalizer = majorNormalizer;
+  }
 
   private static final byte[] UTF8_BOM = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -47,7 +54,8 @@ public class ApplicantCsvWriter {
       List<String> cells = new java.util.ArrayList<>();
       cells.add(applicant.name());
       cells.add(applicant.studentId());
-      cells.add(applicant.major());
+      // 저장된 값은 'ME' 같은 코드다. 스프레드시트를 여는 사람에게는 학과명이어야 한다.
+      cells.add(majorNormalizer.toLabel(applicant.major()));
       cells.add(applicant.email());
       cells.add(applicant.phoneNumber());
       cells.add(format(applicant.appliedAt()));

--- a/src/main/java/inha/gdgoc/global/util/MajorNormalizer.java
+++ b/src/main/java/inha/gdgoc/global/util/MajorNormalizer.java
@@ -2,6 +2,7 @@ package inha.gdgoc.global.util;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -101,6 +102,15 @@ public class MajorNormalizer {
 
     private static final Set<String> KNOWN_CODES = Set.copyOf(LABEL_TO_CODE.values());
 
+    /**
+     * 코드 → 사람이 읽는 학과명. ALIASES 는 넣지 않는다 — 별칭은 받아들이는 입력이지 내보낼 이름이 아니다.
+     *
+     * <p>LABEL_TO_CODE 에 같은 코드가 두 번 나오면 여기서 IllegalStateException 으로 기동이 실패한다. 이름이 하나로 정해지지 않는
+     * 상태를 조용히 넘기는 것보다 낫다.
+     */
+    private static final Map<String, String> CODE_TO_LABEL = LABEL_TO_CODE.entrySet().stream()
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getValue, Map.Entry::getKey));
+
     public String normalize(String major) {
         if (major == null) {
             return null;
@@ -125,5 +135,19 @@ public class MajorNormalizer {
 
     public boolean isKnownCode(String code) {
         return code != null && KNOWN_CODES.contains(code);
+    }
+
+    /**
+     * 저장된 코드를 사람이 읽는 학과명으로 되돌린다.
+     *
+     * <p>모르는 값은 그대로 돌려준다. 학과가 신설되거나 옛 데이터가 코드가 아닌 값을 들고 있어도 빈칸이 되지 않는다 — 원본이 보이는 편이
+     * 아무것도 안 보이는 것보다 낫다.
+     */
+    public String toLabel(String code) {
+        if (code == null) {
+            return null;
+        }
+        String trimmed = code.trim();
+        return CODE_TO_LABEL.getOrDefault(trimmed, trimmed);
     }
 }

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriterTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/ApplicantCsvWriterTest.java
@@ -2,6 +2,7 @@ package inha.gdgoc.domain.eventapplication.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import inha.gdgoc.global.util.MajorNormalizer;
 import inha.gdgoc.domain.eventapplication.dto.response.ApplicantResponse;
 import inha.gdgoc.domain.eventapplication.entity.EventFormQuestion;
 import inha.gdgoc.domain.eventapplication.entity.QuestionOption;
@@ -19,7 +20,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class ApplicantCsvWriterTest {
 
-  private final ApplicantCsvWriter writer = new ApplicantCsvWriter();
+  private final ApplicantCsvWriter writer = new ApplicantCsvWriter(new MajorNormalizer());
 
   @Test
   @DisplayName("UTF-8 BOM 으로 시작한다")
@@ -125,6 +126,39 @@ class ApplicantCsvWriterTest {
     assertThat(csv).contains("\"서버리스, 배포\"");
   }
 
+  // 스프레드시트를 여는 사람에게 'CSE' 는 아무 뜻이 없다. 화면 표는 예전부터 라벨로 보여 줬는데
+  // CSV 만 코드가 나갔다.
+  @Test
+  @DisplayName("학과는 코드가 아니라 학과명으로 적는다")
+  void majorCodeBecomesLabel() {
+    String csv = text(writer.write(List.of(), List.of(applicant(Map.of()))));
+
+    assertThat(csv).contains("컴퓨터공학과").doesNotContain("CSE");
+  }
+
+  // 학과가 신설되면 매핑에 없는 코드가 들어온다. 빈칸이 되면 누구 지원선지 알 수 없다.
+  @Test
+  @DisplayName("모르는 학과 값은 그대로 적는다")
+  void unknownMajorStaysAsIs() {
+    ApplicantResponse applicant =
+        new ApplicantResponse(
+            1L,
+            7L,
+            "홍길동",
+            "12201234",
+            "NEWDEPT",
+            "hong@test.io",
+            "01000000000",
+            ApplicationStatus.APPLIED,
+            EventAttendanceStatus.PENDING,
+            Instant.parse("2026-09-01T03:00:00Z"),
+            null,
+            null,
+            Map.of());
+
+    assertThat(text(writer.write(List.of(), List.of(applicant)))).contains("NEWDEPT");
+  }
+
   @Test
   @DisplayName("선택지에서 사라진 값은 저장된 그대로 적는다")
   void unknownOptionValueStaysAsIs() {
@@ -158,7 +192,8 @@ class ApplicantCsvWriterTest {
         7L,
         "홍길동",
         "12201234",
-        "컴퓨터공학과",
+        // DB 에 실제로 담기는 값은 코드다. 라벨을 넣어 두면 코드 노출 결함을 못 잡는다.
+        "CSE",
         "hong@test.io",
         "01000000000",
         ApplicationStatus.APPLIED,

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicantAdminServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import inha.gdgoc.global.util.MajorNormalizer;
 import inha.gdgoc.domain.eventapplication.dto.request.AttendanceUpdateRequest;
 import inha.gdgoc.domain.eventapplication.dto.request.ProxyApplicationRequest;
 import inha.gdgoc.domain.eventapplication.entity.EventApplication;
@@ -56,7 +57,7 @@ class EventApplicantAdminServiceTest {
             applicationRepository,
             userRepository,
             new AnswerCodec(new ObjectMapper()),
-            new ApplicantCsvWriter(),
+            new ApplicantCsvWriter(new MajorNormalizer()),
             Clock.fixed(NOW, ZoneOffset.UTC));
   }
 


### PR DESCRIPTION
## 증상

행사 신청자 내역과 CSV 에서 학과가 `ME` 로 뜬다. `기계공학과` 로 보여야 한다.

## 원인

DB 에는 학과가 **코드**로 담긴다. 부원·유저·코어 관리자 표는 예전부터 라벨로 바꿔 보여 줬는데, 이번에 만든 행사 신청자 표와 CSV 만 그 단계를 빠뜨렸다.

- CSV: `MajorNormalizer` 에 코드 → 학과명 역방향(`toLabel`)을 추가해 쓴다. 라벨 표는 이미 그 클래스에 있으므로 새로 만들지 않는다.
- 모르는 코드는 그대로 내보낸다 — 학과가 신설돼도 빈칸이 되지 않는다.

Web 쪽(`formatMajorLabel`)은 별도 PR: GDGoCINHA/24-2_GDGoC_Web#(웹 PR)

## 왜 테스트가 못 잡았나

`ApplicantCsvWriterTest` 의 픽스처가 학과를 `"컴퓨터공학과"` 라는 **라벨**로 들고 있었다. 실제 저장 형식이 아니라서 코드 노출이 드러날 수 없었다. 픽스처를 `"CSE"` 로 바꾸고 회귀 테스트 2개를 붙였다.

## 확인

- `./gradlew cleanTest test` → **271 통과, 실패 0** (CSV 테스트 10 → 12개)
  - 학과는 코드가 아니라 학과명으로 적는다
  - 모르는 학과 값은 그대로 적는다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW