### PR TITLE
fix(event-application): 체크인 토큰 창을 60초에서 3분으로 늘린다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenService.java
@@ -17,16 +17,21 @@ import org.springframework.stereotype.Component;
 /**
  * QR 체크인 토큰.
  *
- * <p>행사장에 띄운 QR 을 찍어서 안 온 사람에게 보내는 것이 이 방식의 유일한 약점이다. 토큰을 {@code HMAC(비밀키, 폼ID + 분단위 시각)} 으로 계산해 60
- * 초마다 갈아치우면 사진으로 받은 QR 은 무효가 된다. 저장 테이블이 필요 없다.
+ * <p>행사장에 띄운 QR 을 찍어서 안 온 사람에게 보내는 것이 이 방식의 유일한 약점이다. 토큰을 {@code HMAC(비밀키, 폼ID + 창 번호)} 로 계산해 주기적으로
+ * 갈아치우면 사진으로 받은 QR 은 무효가 된다. 저장 테이블이 필요 없다.
  *
- * <p>검증할 때 현재 분과 직전 분을 모두 받아준다. 59 초에 찍은 사람이 경계를 넘었다고 실패하면 안 되기 때문이다.
+ * <p>검증할 때 현재 창과 직전 창을 모두 받아준다. 창이 끝나갈 때 찍은 사람이 경계를 넘었다고 실패하면 안 되기 때문이다. 그래서 실제 유효 시간은 찍은 시점에
+ * 따라 {@link #WINDOW_SECONDS} 의 1~2 배다.
+ *
+ * <p><b>창을 60 초에서 180 초로 늘렸다(2026-08-27).</b> QR 을 찍은 사람이 로그인되어 있지 않으면 구글 로그인을 거쳐 돌아오는데, 60 초로는 그 왕복이
+ * 자주 넘쳤다. 만료되면 안내가 뜨고 다시 찍으면 되지만 입구에서 두 번 찍게 만든다. 늘려서 잃는 것은 QR 사진을 전달할 여유가 몇 분 늘어나는 것인데, 그건
+ * 애초에 토큰 수명으로 막을 수 없다 — 실질적인 억제는 운영진이 체크인 명단을 본다는 데서 온다.
  */
 @Slf4j
 @Component
 public class EventCheckinTokenService {
 
-  private static final long WINDOW_SECONDS = 60;
+  private static final long WINDOW_SECONDS = 180;
   private static final int TOKEN_LENGTH = 10;
 
   private final byte[] secret;

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinServiceTest.java
@@ -79,9 +79,10 @@ class EventCheckinServiceTest {
     EventApplicationForm form = form();
     givenForm(form);
 
-    // 3분 전에 찍힌 QR 사진으로 시도하는 상황이다.
+    // 한참 전에 찍힌 QR 사진으로 시도하는 상황이다.
+    // 창 길이의 배수로 적으면 창을 늘릴 때마다 이 테스트가 조용히 무의미해진다 — 넉넉히 벌린다.
     String staleToken =
-        new EventCheckinTokenService("s", Clock.fixed(DURING_EVENT.minusSeconds(180), ZoneOffset.UTC))
+        new EventCheckinTokenService("s", Clock.fixed(DURING_EVENT.minusSeconds(3600), ZoneOffset.UTC))
             .issue(FORM_ID);
 
     assertError(

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenServiceTest.java
@@ -18,19 +18,22 @@ class EventCheckinTokenServiceTest {
   private static final String SECRET = "test-secret-for-checkin";
   private static final Instant BASE = Instant.parse("2026-09-01T03:00:00Z");
 
-  @Test
-  @DisplayName("같은 분 안에서는 같은 토큰이 나온다")
-  void stableWithinWindow() {
-    EventCheckinTokenService at00 = service(BASE);
-    EventCheckinTokenService at59 = service(BASE.plusSeconds(59));
+  /** 창 길이. 서비스의 WINDOW_SECONDS 와 같아야 한다. */
+  private static final long WINDOW = 180;
 
-    assertThat(at00.issue(1L)).isEqualTo(at59.issue(1L));
+  @Test
+  @DisplayName("같은 창 안에서는 같은 토큰이 나온다")
+  void stableWithinWindow() {
+    EventCheckinTokenService atStart = service(BASE);
+    EventCheckinTokenService atEnd = service(BASE.plusSeconds(WINDOW - 1));
+
+    assertThat(atStart.issue(1L)).isEqualTo(atEnd.issue(1L));
   }
 
   @Test
-  @DisplayName("1분이 지나면 토큰이 바뀐다")
-  void rotatesEveryMinute() {
-    assertThat(service(BASE).issue(1L)).isNotEqualTo(service(BASE.plusSeconds(60)).issue(1L));
+  @DisplayName("창이 지나면 토큰이 바뀐다")
+  void rotatesEveryWindow() {
+    assertThat(service(BASE).issue(1L)).isNotEqualTo(service(BASE.plusSeconds(WINDOW)).issue(1L));
   }
 
   @Test
@@ -42,14 +45,26 @@ class EventCheckinTokenServiceTest {
   }
 
   @Test
-  @DisplayName("직전 분에 발급된 토큰도 받아준다")
+  @DisplayName("직전 창에 발급된 토큰도 받아준다")
   void acceptsPreviousWindow() {
-    String issuedEarlier = service(BASE.plusSeconds(59)).issue(1L);
+    String issuedEarlier = service(BASE.plusSeconds(WINDOW - 1)).issue(1L);
 
-    // 59초에 QR 을 찍고 1초 뒤에 요청이 도착하는 것은 정상적인 상황이다.
-    EventCheckinTokenService oneSecondLater = service(BASE.plusSeconds(61));
+    // 창이 끝나갈 때 QR 을 찍고 1초 뒤에 요청이 도착하는 것은 정상적인 상황이다.
+    EventCheckinTokenService oneSecondLater = service(BASE.plusSeconds(WINDOW + 1));
 
     assertThat(oneSecondLater.verify(1L, issuedEarlier)).isTrue();
+  }
+
+  // 이 테스트가 지키는 것이 창을 늘린 이유 자체다. 창이 끝나갈 때 찍어도 최소 WINDOW 초가 남는다.
+  @Test
+  @DisplayName("창이 끝나갈 때 찍어도 로그인 왕복만큼은 버틴다")
+  void survivesLoginRoundTrip() {
+    String scannedAtWindowEnd = service(BASE.plusSeconds(WINDOW - 1)).issue(1L);
+
+    EventCheckinTokenService almostThreeMinutesLater =
+        service(BASE.plusSeconds(WINDOW - 1 + 175));
+
+    assertThat(almostThreeMinutesLater.verify(1L, scannedAtWindowEnd)).isTrue();
   }
 
   @Test
@@ -58,7 +73,7 @@ class EventCheckinTokenServiceTest {
     String old = service(BASE).issue(1L);
 
     // 사진으로 전달된 QR 이 걸리는 지점이다.
-    assertThat(service(BASE.plusSeconds(180)).verify(1L, old)).isFalse();
+    assertThat(service(BASE.plusSeconds(WINDOW * 3)).verify(1L, old)).isFalse();
   }
 
   @Test
@@ -89,10 +104,10 @@ class EventCheckinTokenServiceTest {
   }
 
   @Test
-  @DisplayName("남은 초는 다음 분까지의 거리다")
+  @DisplayName("남은 초는 다음 창까지의 거리다")
   void remainingSecondsCountsDown() {
-    assertThat(service(BASE).remainingSeconds()).isEqualTo(60);
-    assertThat(service(BASE.plusSeconds(45)).remainingSeconds()).isEqualTo(15);
+    assertThat(service(BASE).remainingSeconds()).isEqualTo(WINDOW);
+    assertThat(service(BASE.plusSeconds(45)).remainingSeconds()).isEqualTo(WINDOW - 45);
   }
 
   private static EventCheckinTokenService service(Instant now) {


### PR DESCRIPTION
## 왜

QR 을 찍은 사람이 **로그인되어 있지 않으면** 구글 로그인을 거쳐 같은 주소로 돌아온다. 60초 창으로는 그 왕복이 자주 넘쳤다.

만료되면 `"QR 이 만료되었습니다. 화면의 QR 을 다시 찍어주세요."` 가 뜨고 다시 찍으면 되지만(그땐 로그인 상태라 즉시 통과), **입구에서 두 번 찍게 만든다.**

## 무엇

`WINDOW_SECONDS` 60 → 180.

검증이 현재 창과 직전 창을 받아주므로 실제 유효 시간은 찍은 시점에 따라 **3~6분**이고, **창이 끝나갈 때 찍은 최악의 경우에도 3분이 보장**된다.

## 늘려도 되는 이유

늘려서 잃는 것은 QR 사진을 안 온 사람에게 전달할 여유가 몇 분 늘어나는 것인데, 그건 **애초에 토큰 수명으로 막을 수 없다** — 60초여도 옆자리에서 캡처를 보내면 그만이다. 실질적인 억제는 운영진이 체크인 명단을 본다는 데서 온다.

## 확인

- `./gradlew cleanTest test` → **272 통과, 실패 0**
- 추가: `창이 끝나갈 때 찍어도 로그인 왕복만큼은 버틴다`
- `EventCheckinServiceTest` 의 「만료된 토큰」이 `-180초` 로 적혀 있어 이 변경으로 **유효 범위에 들어와 실패**했다. 창 길이의 배수로 적으면 창을 늘릴 때마다 조용히 무의미해지므로 넉넉히(`-3600초`) 벌렸다.

Web(카운트다운 표기): GDGoCINHA/24-2_GDGoC_Web#(웹 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW