### PR TITLE
fix(event-application): 「QR 새로 받기」가 눌러도 아무것도 안 바뀌던 문제

### DIFF
--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinService.java
@@ -58,7 +58,7 @@ public class EventCheckinService {
   public CheckinTokenResponse issueToken(Long eventBoardId) {
     EventApplicationForm form = findForm(eventBoardId);
     return new CheckinTokenResponse(
-        eventBoardId, tokenService.issue(form.getId()), tokenService.remainingSeconds());
+        eventBoardId, tokenService.issue(form.getId()), tokenService.lifetimeSeconds());
   }
 
   @Transactional

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenService.java
@@ -17,22 +17,31 @@ import org.springframework.stereotype.Component;
 /**
  * QR 체크인 토큰.
  *
- * <p>행사장에 띄운 QR 을 찍어서 안 온 사람에게 보내는 것이 이 방식의 유일한 약점이다. 토큰을 {@code HMAC(비밀키, 폼ID + 창 번호)} 로 계산해 주기적으로
- * 갈아치우면 사진으로 받은 QR 은 무효가 된다. 저장 테이블이 필요 없다.
+ * <p>행사장에 띄운 QR 을 찍어서 안 온 사람에게 보내는 것이 이 방식의 유일한 약점이다. 토큰을 주기적으로 갈아치우면 사진으로 받은 QR 은 곧 무효가 된다.
  *
- * <p>검증할 때 현재 창과 직전 창을 모두 받아준다. 창이 끝나갈 때 찍은 사람이 경계를 넘었다고 실패하면 안 되기 때문이다. 그래서 실제 유효 시간은 찍은 시점에
- * 따라 {@link #WINDOW_SECONDS} 의 1~2 배다.
+ * <p><b>토큰이 자기 만료 시각을 들고 다닌다.</b> {@code <만료시각>.<서명>} 형태이고 서명이 만료 시각까지 덮으므로 시간을 늘려 적을 수 없다. 저장
+ * 테이블도, 서버 메모리 상태도 필요 없다.
  *
- * <p><b>창을 60 초에서 180 초로 늘렸다(2026-08-27).</b> QR 을 찍은 사람이 로그인되어 있지 않으면 구글 로그인을 거쳐 돌아오는데, 60 초로는 그 왕복이
- * 자주 넘쳤다. 만료되면 안내가 뜨고 다시 찍으면 되지만 입구에서 두 번 찍게 만든다. 늘려서 잃는 것은 QR 사진을 전달할 여유가 몇 분 늘어나는 것인데, 그건
- * 애초에 토큰 수명으로 막을 수 없다 — 실질적인 억제는 운영진이 체크인 명단을 본다는 데서 온다.
+ * <p>예전에는 {@code HMAC(비밀키, 폼ID + 벽시계창번호)} 였다. 창 번호가 벽시계에서 나오는 탓에 <b>같은 창 안에서는 몇 번을 다시 발급해도 같은
+ * 토큰이 나왔고</b>, 남은 시간도 "발급 후 경과" 가 아니라 다음 경계까지의 거리였다. 관리자 화면의 「QR 새로 받기」 가 눌러도 아무것도 안 바뀌는 버튼이
+ * 됐던 이유다. 지금은 발급할 때마다 새 토큰이 나오고 수명이 항상 정확히 {@link #LIFETIME_SECONDS} 초다.
  */
 @Slf4j
 @Component
 public class EventCheckinTokenService {
 
-  private static final long WINDOW_SECONDS = 180;
-  private static final int TOKEN_LENGTH = 10;
+  /**
+   * 토큰 하나의 수명.
+   *
+   * <p>QR 을 찍은 사람이 로그인되어 있지 않으면 구글 로그인을 거쳐 돌아온다. 60 초로는 그 왕복이 자주 넘쳐 입구에서 두 번 찍게 만들었다. 늘려서 잃는
+   * 것은 QR 사진을 전달할 여유인데, 그건 애초에 토큰 수명으로 막을 수 없다 — 실질적인 억제는 운영진이 체크인 명단을 본다는 데서 온다.
+   */
+  private static final long LIFETIME_SECONDS = 180;
+
+  private static final int SIGNATURE_LENGTH = 10;
+  private static final char SEPARATOR = '.';
+  /** 만료 시각을 36진수로 적어 QR 에 들어가는 글자를 줄인다. */
+  private static final int EXPIRY_RADIX = 36;
 
   private final byte[] secret;
   private final Clock clock;
@@ -45,7 +54,7 @@ public class EventCheckinTokenService {
   EventCheckinTokenService(String configuredSecret, Clock clock) {
     this.clock = clock;
     if (configuredSecret == null || configuredSecret.isBlank()) {
-      // 설정이 없으면 기동할 때마다 새로 만든다. 60 초짜리 토큰이라 재시작으로 무효가 되어도
+      // 설정이 없으면 기동할 때마다 새로 만든다. 3 분짜리 토큰이라 재시작으로 무효가 되어도
       // 화면을 새로고침하면 그만이다. 다만 서버를 여러 대로 늘리면 인스턴스마다 키가 달라져
       // 검증이 실패하므로, 그때는 app.event-checkin.secret 을 반드시 넣어야 한다.
       byte[] generated = new byte[32];
@@ -57,35 +66,49 @@ public class EventCheckinTokenService {
     }
   }
 
-  /** 지금 화면에 띄울 토큰. */
+  /** 지금 화면에 띄울 토큰. 부를 때마다 만료 시각이 밀려 새 토큰이 나온다. */
   public String issue(Long formId) {
-    return sign(formId, currentWindow());
+    long expiresAt = Instant.now(clock).getEpochSecond() + LIFETIME_SECONDS;
+    return Long.toString(expiresAt, EXPIRY_RADIX) + SEPARATOR + sign(formId, expiresAt);
   }
 
-  /** 이 토큰이 바뀌기까지 남은 초. 관리자 화면이 카운트다운에 쓴다. */
-  public long remainingSeconds() {
-    long epochSecond = Instant.now(clock).getEpochSecond();
-    return WINDOW_SECONDS - (epochSecond % WINDOW_SECONDS);
+  /** 방금 발급한 토큰이 살아 있는 시간. 관리자 화면이 카운트다운에 쓴다. */
+  public long lifetimeSeconds() {
+    return LIFETIME_SECONDS;
   }
 
   public boolean verify(Long formId, String token) {
     if (token == null || token.isBlank()) {
       return false;
     }
-    long window = currentWindow();
-    return matches(token, sign(formId, window)) || matches(token, sign(formId, window - 1));
+    int separator = token.indexOf(SEPARATOR);
+    if (separator <= 0 || separator == token.length() - 1) {
+      return false;
+    }
+
+    long expiresAt;
+    try {
+      expiresAt = Long.parseLong(token.substring(0, separator), EXPIRY_RADIX);
+    } catch (NumberFormatException e) {
+      return false;
+    }
+    if (Instant.now(clock).getEpochSecond() > expiresAt) {
+      return false;
+    }
+
+    // 서명을 만료 시각까지 덮으므로 시간을 늘려 적으면 서명이 안 맞는다.
+    return matches(token.substring(separator + 1), sign(formId, expiresAt));
   }
 
-  private long currentWindow() {
-    return Instant.now(clock).getEpochSecond() / WINDOW_SECONDS;
-  }
-
-  private String sign(Long formId, long window) {
+  private String sign(Long formId, long expiresAt) {
     try {
       Mac mac = Mac.getInstance("HmacSHA256");
       mac.init(new SecretKeySpec(secret, "HmacSHA256"));
-      byte[] raw = mac.doFinal((formId + ":" + window).getBytes(StandardCharsets.UTF_8));
-      return Base64.getUrlEncoder().withoutPadding().encodeToString(raw).substring(0, TOKEN_LENGTH);
+      byte[] raw = mac.doFinal((formId + ":" + expiresAt).getBytes(StandardCharsets.UTF_8));
+      return Base64.getUrlEncoder()
+          .withoutPadding()
+          .encodeToString(raw)
+          .substring(0, SIGNATURE_LENGTH);
     } catch (Exception e) {
       // HmacSHA256 은 모든 JDK 에 있다. 여기 오면 런타임이 이상한 것이다.
       throw new IllegalStateException("체크인 토큰을 만들 수 없다", e);

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventCheckinTokenServiceTest.java
@@ -9,31 +9,70 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * QR 토큰의 회전 규칙.
+ * QR 토큰의 수명 규칙.
  *
  * <p>이 규칙이 무너지면 QR 사진을 받은 사람이 오지 않고도 출석 처리된다.
+ *
+ * <p>토큰이 자기 만료 시각을 들고 다니므로 <b>발급할 때마다 다른 값</b>이 나오고 수명은 항상 정확히 {@link #LIFETIME} 초다. 예전 벽시계 창
+ * 방식에서는 같은 창 안에서 몇 번을 발급해도 같은 토큰이 나왔다.
  */
 class EventCheckinTokenServiceTest {
 
   private static final String SECRET = "test-secret-for-checkin";
   private static final Instant BASE = Instant.parse("2026-09-01T03:00:00Z");
 
-  /** 창 길이. 서비스의 WINDOW_SECONDS 와 같아야 한다. */
-  private static final long WINDOW = 180;
+  /** 서비스의 LIFETIME_SECONDS 와 같아야 한다. */
+  private static final long LIFETIME = 180;
 
+  // 「QR 새로 받기」 가 눌러도 아무것도 안 바뀌는 버튼이었던 이유가 여기였다.
   @Test
-  @DisplayName("같은 창 안에서는 같은 토큰이 나온다")
-  void stableWithinWindow() {
-    EventCheckinTokenService atStart = service(BASE);
-    EventCheckinTokenService atEnd = service(BASE.plusSeconds(WINDOW - 1));
+  @DisplayName("다시 발급하면 다른 토큰이 나온다")
+  void reissueGivesNewToken() {
+    String first = service(BASE).issue(1L);
+    String second = service(BASE.plusSeconds(1)).issue(1L);
 
-    assertThat(atStart.issue(1L)).isEqualTo(atEnd.issue(1L));
+    assertThat(second).isNotEqualTo(first);
   }
 
   @Test
-  @DisplayName("창이 지나면 토큰이 바뀐다")
-  void rotatesEveryWindow() {
-    assertThat(service(BASE).issue(1L)).isNotEqualTo(service(BASE.plusSeconds(WINDOW)).issue(1L));
+  @DisplayName("발급 직후에는 수명만큼 남는다")
+  void freshTokenHasFullLifetime() {
+    assertThat(service(BASE).lifetimeSeconds()).isEqualTo(LIFETIME);
+  }
+
+  @Test
+  @DisplayName("수명 안이면 받아준다")
+  void acceptsWithinLifetime() {
+    String token = service(BASE).issue(1L);
+
+    assertThat(service(BASE.plusSeconds(LIFETIME - 1)).verify(1L, token)).isTrue();
+  }
+
+  // 창 방식에서는 찍은 시점에 따라 수명이 1~2배로 들쭉날쭉했다. 지금은 언제 찍어도 같다.
+  @Test
+  @DisplayName("만료 시각 정각까지는 받아준다")
+  void acceptsAtExactExpiry() {
+    String token = service(BASE).issue(1L);
+
+    assertThat(service(BASE.plusSeconds(LIFETIME)).verify(1L, token)).isTrue();
+  }
+
+  @Test
+  @DisplayName("수명이 지나면 거절한다")
+  void rejectsExpired() {
+    String token = service(BASE).issue(1L);
+
+    // 사진으로 전달된 QR 이 걸리는 지점이다.
+    assertThat(service(BASE.plusSeconds(LIFETIME + 1)).verify(1L, token)).isFalse();
+  }
+
+  // 로그인 왕복을 버티게 하려고 수명을 60초에서 늘렸다. 그 보장이 이 테스트다.
+  @Test
+  @DisplayName("구글 로그인 왕복만큼은 버틴다")
+  void survivesLoginRoundTrip() {
+    String token = service(BASE).issue(1L);
+
+    assertThat(service(BASE.plusSeconds(150)).verify(1L, token)).isTrue();
   }
 
   @Test
@@ -45,43 +84,25 @@ class EventCheckinTokenServiceTest {
   }
 
   @Test
-  @DisplayName("직전 창에 발급된 토큰도 받아준다")
-  void acceptsPreviousWindow() {
-    String issuedEarlier = service(BASE.plusSeconds(WINDOW - 1)).issue(1L);
-
-    // 창이 끝나갈 때 QR 을 찍고 1초 뒤에 요청이 도착하는 것은 정상적인 상황이다.
-    EventCheckinTokenService oneSecondLater = service(BASE.plusSeconds(WINDOW + 1));
-
-    assertThat(oneSecondLater.verify(1L, issuedEarlier)).isTrue();
-  }
-
-  // 이 테스트가 지키는 것이 창을 늘린 이유 자체다. 창이 끝나갈 때 찍어도 최소 WINDOW 초가 남는다.
-  @Test
-  @DisplayName("창이 끝나갈 때 찍어도 로그인 왕복만큼은 버틴다")
-  void survivesLoginRoundTrip() {
-    String scannedAtWindowEnd = service(BASE.plusSeconds(WINDOW - 1)).issue(1L);
-
-    EventCheckinTokenService almostThreeMinutesLater =
-        service(BASE.plusSeconds(WINDOW - 1 + 175));
-
-    assertThat(almostThreeMinutesLater.verify(1L, scannedAtWindowEnd)).isTrue();
-  }
-
-  @Test
-  @DisplayName("두 번 이상 지난 토큰은 거절한다")
-  void rejectsOlderThanOneWindow() {
-    String old = service(BASE).issue(1L);
-
-    // 사진으로 전달된 QR 이 걸리는 지점이다.
-    assertThat(service(BASE.plusSeconds(WINDOW * 3)).verify(1L, old)).isFalse();
-  }
-
-  @Test
   @DisplayName("다른 행사의 토큰으로는 체크인할 수 없다")
   void rejectsTokenOfAnotherForm() {
     EventCheckinTokenService service = service(BASE);
 
     assertThat(service.verify(2L, service.issue(1L))).isFalse();
+  }
+
+  // 서명이 만료 시각까지 덮는다. 안 그러면 앞자리만 바꿔 영구 토큰을 만들 수 있다.
+  @Test
+  @DisplayName("만료 시각을 늘려 적으면 거절한다")
+  void rejectsTamperedExpiry() {
+    EventCheckinTokenService service = service(BASE);
+    String token = service.issue(1L);
+    String signature = token.substring(token.indexOf('.') + 1);
+    long farFuture = BASE.getEpochSecond() + 86400;
+
+    String forged = Long.toString(farFuture, 36) + "." + signature;
+
+    assertThat(service.verify(1L, forged)).isFalse();
   }
 
   @Test
@@ -92,6 +113,11 @@ class EventCheckinTokenServiceTest {
     assertThat(service.verify(1L, null)).isFalse();
     assertThat(service.verify(1L, "")).isFalse();
     assertThat(service.verify(1L, "AAAAAAAAAA")).isFalse();
+    assertThat(service.verify(1L, ".")).isFalse();
+    assertThat(service.verify(1L, ".AAAAAAAAAA")).isFalse();
+    assertThat(service.verify(1L, "zzz.")).isFalse();
+    // 36진수로 못 읽는 만료 시각
+    assertThat(service.verify(1L, "!!!.AAAAAAAAAA")).isFalse();
   }
 
   @Test
@@ -101,13 +127,6 @@ class EventCheckinTokenServiceTest {
         new EventCheckinTokenService("another-secret", Clock.fixed(BASE, ZoneOffset.UTC));
 
     assertThat(other.verify(1L, service(BASE).issue(1L))).isFalse();
-  }
-
-  @Test
-  @DisplayName("남은 초는 다음 창까지의 거리다")
-  void remainingSecondsCountsDown() {
-    assertThat(service(BASE).remainingSeconds()).isEqualTo(WINDOW);
-    assertThat(service(BASE.plusSeconds(45)).remainingSeconds()).isEqualTo(WINDOW - 45);
   }
 
   private static EventCheckinTokenService service(Instant now) {


### PR DESCRIPTION
## 증상

관리자 QR 화면에서 「QR 새로 받기」를 눌러도 QR 도 남은 시간도 그대로다.

## 원인

토큰이 `HMAC(비밀키, 폼ID + 벽시계창번호)` 였고 창 번호가 `epoch / 180` 이다. 그래서 **같은 3분 구간 안에서는 몇 번을 다시 발급해도 같은 토큰**이 나왔고, `remainingSeconds()` 도 "발급 후 경과" 가 아니라 다음 경계까지의 거리라 초기화될 수가 없었다. 버튼이 약속하는 일을 구조적으로 할 수 없는 상태였다.

## 무엇

토큰이 **자기 만료 시각을 들고 다니게** 바꾼다.

```
<만료시각(36진수)>.<HMAC(비밀키, 폼ID + 만료시각)>
```

- 발급할 때마다 만료 시각이 밀리므로 **새 토큰**이 나온다 → 버튼이 실제로 동작한다.
- 서명이 만료 시각까지 덮으므로 **앞자리만 늘려 적을 수 없다.**
- 저장 테이블도 서버 메모리 상태도 **여전히 필요 없다.**

덤으로 수명이 일정해졌다. 창 방식에서는 찍은 시점에 따라 3~6분으로 들쭉날쭉했는데 이제 언제 찍어도 정확히 3분이다.

## 확인

`./gradlew cleanTest test` → **273 통과, 실패 0**

추가한 것:
- 다시 발급하면 다른 토큰이 나온다 ← 이 버그를 직접 막는다
- 만료 시각 정각까지는 받아준다 / 수명이 지나면 거절한다
- **만료 시각을 늘려 적으면 거절한다** (서명이 만료 시각을 덮는지)
- 구글 로그인 왕복만큼은 버틴다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW