### PR TITLE
fix(event-application): 끝난 행사에 신청·폼 생성이 되던 문제

### DIFF
--- a/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
@@ -11,7 +11,8 @@ public enum EventApplicationErrorCode implements ErrorCode {
   EVENT_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "행사를 찾을 수 없습니다."),
   FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "이 행사는 신청을 받고 있지 않습니다."),
   FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 신청 폼이 있는 행사입니다."),
-  FORM_HAS_APPLICATIONS(HttpStatus.BAD_REQUEST, "신청자가 있어 신청 받기를 해제할 수 없습니다. 마감으로 닫아주세요."),
+  FORM_HAS_APPLICATIONS(HttpStatus.BAD_REQUEST, "신청자가 있어 신청 폼을 삭제할 수 없습니다. 그만 받으려면 마감해 주세요."),
+  EVENT_ENDED(HttpStatus.BAD_REQUEST, "이미 끝난 행사입니다."),
   QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문을 찾을 수 없습니다."),
 
   OPTIONS_REQUIRED(HttpStatus.BAD_REQUEST, "선택형 질문에는 선택지가 필요합니다."),

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicationService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventApplicationService.java
@@ -18,6 +18,7 @@ import inha.gdgoc.global.exception.BusinessException;
 import inha.gdgoc.global.exception.GlobalErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -34,6 +35,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class EventApplicationService {
+
+  /** 행사 날짜는 달력 날짜다. 테스트가 시계를 UTC 로 고정해도 판정은 한국 날짜로 한다. */
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
   private final EventApplicationFormRepository formRepository;
   private final EventApplicationRepository applicationRepository;
@@ -163,6 +167,10 @@ public class EventApplicationService {
   /** 신청을 막는 첫 번째 사유. 없으면 null 이다. */
   private EventApplicationErrorCode blockedBy(
       EventApplicationForm form, UserRole role, long applied, Instant now) {
+    // 끝난 행사가 제일 먼저다. 되돌릴 수 없는 사유이고, 나머지 안내는 뒷북이 된다.
+    if (hasEnded(form, now)) {
+      return EVENT_ENDED;
+    }
     if (!form.isOpen()) {
       return FORM_CLOSED;
     }
@@ -179,6 +187,20 @@ public class EventApplicationService {
       return CAPACITY_FULL;
     }
     return null;
+  }
+
+  /**
+   * 행사가 끝났는가. 종료일 24:00 까지는 받는다.
+   *
+   * <p>closesAt 을 안 넣은 폼이 대부분이라 그것만 믿으면 끝난 행사에 신청이 계속 들어온다. 체크인은 예전부터 행사 기간을 봤는데 신청만 안 보고
+   * 있었다. 시작 전은 막지 않는다 — 현장에서 받는 경우가 있다.
+   */
+  private boolean hasEnded(EventApplicationForm form, Instant now) {
+    LocalDate endDate = form.getEventEndDate();
+    if (endDate == null) {
+      return false;
+    }
+    return now.atZone(KST).toLocalDate().isAfter(endDate);
   }
 
   private Map<Long, Object> toAnswerMap(EventApplicationSubmitRequest req) {

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
@@ -16,6 +16,7 @@ import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
 import inha.gdgoc.domain.user.enums.UserRole;
 import inha.gdgoc.global.exception.BusinessException;
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -81,6 +82,11 @@ public class EventFormAdminService {
       throw new BusinessException(FORM_ALREADY_EXISTS);
     }
     EventBoard board = findLiveBoard(eventBoardId);
+    // 끝난 행사에 신청 폼을 만들어 봐야 아무도 신청할 수 없다. 날짜를 잘못 넣었다면 글을 먼저 고친다.
+    if (board.getEventEndDate() != null
+        && board.getEventEndDate().isBefore(LocalDate.now(clock))) {
+      throw new BusinessException(EVENT_ENDED);
+    }
 
     EventApplicationForm form =
         EventApplicationForm.create(

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicationServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventApplicationServiceTest.java
@@ -188,6 +188,35 @@ class EventApplicationServiceTest {
     verify(applicationRepository, never()).delete(any());
   }
 
+  // closesAt 을 안 넣은 폼이 대부분이라 그것만 믿으면 끝난 행사에 신청이 계속 들어온다.
+  @Test
+  @DisplayName("끝난 행사에는 신청할 수 없다")
+  void rejectsAfterEventEnded() {
+    givenForm(endedForm());
+    givenNoExistingApplication();
+
+    assertError(() -> apply(UserRole.MEMBER), EventApplicationErrorCode.EVENT_ENDED);
+    verify(applicationRepository, never()).save(any());
+  }
+
+  // 종료일 당일은 아직 행사 중이다. 뒤풀이 자리에서 받는 신청을 막으면 안 된다.
+  @Test
+  @DisplayName("행사 종료일 당일에는 신청할 수 있다")
+  void allowsOnLastEventDay() {
+    // NOW 는 2026-09-01 12:00 KST 이고 픽스처의 종료일이 그날이다.
+    EventApplicationForm form =
+        form(UserRole.MEMBER, null, null, null, true, LocalDate.of(2026, 9, 1));
+    givenForm(form);
+    givenNoExistingApplication();
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user()));
+
+    assertThatCode(() -> apply(UserRole.MEMBER)).doesNotThrowAnyException();
+  }
+
+  private static EventApplicationForm endedForm() {
+    return form(UserRole.MEMBER, null, null, null, true, LocalDate.of(2026, 8, 31));
+  }
+
   @Test
   @DisplayName("발행 전 폼은 부원에게 없는 것으로 보인다")
   void unpublishedFormIsInvisible() {
@@ -233,12 +262,22 @@ class EventApplicationServiceTest {
 
   private static EventApplicationForm form(
       UserRole minRole, Instant opensAt, Instant closesAt, Integer capacity, boolean isOpen) {
+    return form(minRole, opensAt, closesAt, capacity, isOpen, LocalDate.of(2026, 9, 2));
+  }
+
+  private static EventApplicationForm form(
+      UserRole minRole,
+      Instant opensAt,
+      Instant closesAt,
+      Integer capacity,
+      boolean isOpen,
+      LocalDate eventEndDate) {
     EventApplicationForm form =
         EventApplicationForm.create(
             BOARD_ID,
             "가을 해커톤",
             LocalDate.of(2026, 9, 1),
-            LocalDate.of(2026, 9, 2),
+            eventEndDate,
             opensAt,
             closesAt,
             capacity,

--- a/src/test/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminServiceTest.java
+++ b/src/test/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminServiceTest.java
@@ -1,0 +1,133 @@
+package inha.gdgoc.domain.eventapplication.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import inha.gdgoc.domain.board.event.entity.EventBoard;
+import inha.gdgoc.domain.board.event.repository.EventBoardRepository;
+import inha.gdgoc.domain.eventapplication.dto.request.EventFormSaveRequest;
+import inha.gdgoc.domain.eventapplication.entity.EventApplicationForm;
+import inha.gdgoc.domain.eventapplication.exception.EventApplicationErrorCode;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationFormRepository;
+import inha.gdgoc.domain.eventapplication.repository.EventApplicationRepository;
+import inha.gdgoc.domain.user.enums.UserRole;
+import inha.gdgoc.global.exception.BusinessException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * 신청 폼을 만들 수 있는 조건.
+ *
+ * <p>끝난 행사에 폼을 만들어 봐야 아무도 신청할 수 없다. 운영진이 지난 글에 잘못 붙이는 것을 여기서 막는다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EventFormAdminServiceTest {
+
+  private static final Long BOARD_ID = 10L;
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+  /** 2026-09-01 12:00 KST */
+  private static final Instant NOW = Instant.parse("2026-09-01T03:00:00Z");
+
+  @Mock private EventApplicationFormRepository formRepository;
+  @Mock private EventApplicationRepository applicationRepository;
+  @Mock private EventBoardRepository eventBoardRepository;
+
+  private EventFormAdminService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new EventFormAdminService(
+            formRepository,
+            applicationRepository,
+            eventBoardRepository,
+            new EventFormValidator(),
+            Clock.fixed(NOW, KST));
+    when(formRepository.existsByEventBoardId(BOARD_ID)).thenReturn(false);
+    when(formRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  @DisplayName("끝난 행사에는 신청 폼을 만들 수 없다")
+  void rejectsEndedEvent() {
+    givenBoard(LocalDate.of(2026, 8, 20), LocalDate.of(2026, 8, 25));
+
+    assertThatThrownBy(() -> service.createForm(BOARD_ID, request()))
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(EventApplicationErrorCode.EVENT_ENDED);
+
+    verify(formRepository, never()).save(any());
+  }
+
+  // 오늘 끝나는 행사는 아직 끝난 것이 아니다.
+  @Test
+  @DisplayName("종료일이 오늘이면 만들 수 있다")
+  void allowsEventEndingToday() {
+    givenBoard(LocalDate.of(2026, 8, 30), LocalDate.of(2026, 9, 1));
+
+    assertThatCode(() -> service.createForm(BOARD_ID, request())).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("앞으로 열릴 행사는 만들 수 있다")
+  void allowsUpcomingEvent() {
+    givenBoard(LocalDate.of(2026, 9, 10), LocalDate.of(2026, 9, 11));
+
+    assertThatCode(() -> service.createForm(BOARD_ID, request())).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("휴지통에 있는 글에는 만들 수 없다")
+  void rejectsDeletedBoard() {
+    when(eventBoardRepository.findById(BOARD_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.createForm(BOARD_ID, request()))
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(EventApplicationErrorCode.EVENT_BOARD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("신청자가 있으면 폼을 지울 수 없다")
+  void rejectsDeleteWhenApplied() {
+    EventApplicationForm form = EventApplicationForm.create(
+        BOARD_ID, "가을 해커톤", LocalDate.of(2026, 9, 10), LocalDate.of(2026, 9, 11),
+        null, null, null, UserRole.MEMBER, true);
+    when(formRepository.findByEventBoardId(BOARD_ID)).thenReturn(Optional.of(form));
+    when(applicationRepository.countByFormIdAndStatus(any(), any())).thenReturn(1L);
+
+    assertThatThrownBy(() -> service.deleteForm(BOARD_ID))
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorCode())
+        .isEqualTo(EventApplicationErrorCode.FORM_HAS_APPLICATIONS);
+
+    verify(formRepository, never()).delete(any());
+  }
+
+  private void givenBoard(LocalDate start, LocalDate end) {
+    EventBoard board =
+        EventBoard.create("가을 해커톤", start, end, null, null, "내용", true, 1L, "운영진");
+    when(eventBoardRepository.findById(BOARD_ID)).thenReturn(Optional.of(board));
+  }
+
+  private static EventFormSaveRequest request() {
+    return new EventFormSaveRequest(null, null, null, false, UserRole.MEMBER, true);
+  }
+}


### PR DESCRIPTION
## 증상

**끝난 행사에 신청이 들어간다.** dev 에서 `id=2` 행사(2026/08/19~08/25, 이미 종료)에 신청 API 를 던졌더니 「끝난 행사」로 막히지 않고 그대로 통과했다.

## 원인

`blockedBy` 가 `isOpen`·`opensAt`·`closesAt`·권한·정원만 보고 **행사 종료일을 안 본다.** `closesAt` 을 안 넣은 폼이 대부분이라 그것만 믿으면 끝난 행사에 신청이 계속 들어온다. **체크인은 예전부터 행사 기간을 봤는데(`CHECKIN_NOT_IN_PERIOD`) 신청만 안 보고 있었다.**

## 무엇

| | 규칙 |
|---|---|
| 신청 | 행사 **종료일 24:00** 을 암묵적 마감으로 둔다 |
| 폼 생성 | 이미 끝난 행사면 거부한다 |

**시작 전은 막지 않는다** — 현장에서 받는 경우가 있다. 종료일 당일도 아직 행사 중이다.

`FORM_HAS_APPLICATIONS` 문구도 고쳤다. 실제로 하는 일이 폼 삭제인데 "신청 받기를 해제할 수 없습니다" 라 다른 기능처럼 읽혔다.

## 테스트

`EventFormAdminService` 는 **테스트가 아예 없었다.** 폼 생성 조건과 삭제 제한을 덮는 클래스를 새로 만들었다.

- `./gradlew cleanTest test` → **279 통과, 실패 0**
- 끝난 행사에는 신청할 수 없다 / 행사 종료일 당일에는 신청할 수 있다
- 끝난 행사에는 신청 폼을 만들 수 없다 / 종료일이 오늘이면 만들 수 있다 / 앞으로 열릴 행사는 만들 수 있다
- 휴지통에 있는 글에는 만들 수 없다 / 신청자가 있으면 폼을 지울 수 없다

Web: GDGoCINHA/24-2_GDGoC_Web#(웹 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe6SeRKA9ronrfXj3YKQmW