### PR TITLE
fix(event-application): 조건으로 쓰이는 선택지를 지울 수 없게 막는다

### DIFF
--- a/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/exception/EventApplicationErrorCode.java
@@ -31,6 +31,8 @@ public enum EventApplicationErrorCode implements ErrorCode {
   CONDITION_VALUE_INVALID(HttpStatus.BAD_REQUEST, "조건 값이 기준 질문의 선택지에 없습니다."),
   CONDITION_VALUES_EMPTY(HttpStatus.BAD_REQUEST, "조건 값을 하나 이상 지정해야 합니다."),
   CONDITION_REFERENCED(HttpStatus.BAD_REQUEST, "이 질문을 기준으로 삼는 조건이 있습니다. 조건을 먼저 푸세요."),
+  CONDITION_OPTION_REFERENCED(
+      HttpStatus.BAD_REQUEST, "다른 질문이 조건으로 삼는 선택지는 지울 수 없습니다. 조건을 먼저 푸세요."),
   CONDITION_ORDER_BROKEN(HttpStatus.BAD_REQUEST, "이 순서로 바꾸면 조건이 뒤 질문을 가리키게 됩니다."),
 
   CAPACITY_BELOW_APPLICANTS(HttpStatus.BAD_REQUEST, "현재 신청자 수보다 적은 정원으로는 줄일 수 없습니다."),

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormAdminService.java
@@ -194,6 +194,10 @@ public class EventFormAdminService {
       validator.validateNotReferenced(questionId, siblings);
     }
 
+    // 유형을 그대로 두고 선택지 하나만 지워도 그 값을 가리키던 조건은 죽는다.
+    validator.validateOptionValuesNotReferenced(
+        questionId, question.getOptions(), req.options(), siblings);
+
     validator.validateShape(req.type(), req.options());
     Long baseId = req.clearCondition() ? null : req.visibleWhenQuestionId();
     List<String> values = req.clearCondition() ? null : req.visibleWhenValues();

--- a/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormValidator.java
+++ b/src/main/java/inha/gdgoc/domain/eventapplication/service/EventFormValidator.java
@@ -120,6 +120,44 @@ public class EventFormValidator {
     }
   }
 
+  /**
+   * 다른 질문이 조건으로 삼는 선택지는 지울 수 없다.
+   *
+   * <p>지우고 나면 그 조건은 어떤 답으로도 참이 되지 않는 값을 가리킨다. 조건을 건 질문은 폼에서 조용히 사라지는데, 관리자 화면에는 그대로 남아 있어 왜 아무도 답하지
+   * 않는지 알 길이 없다. 유형을 바꿀 때만 막고 선택지 하나를 지울 때는 놔두면 같은 구멍이 남는다.
+   */
+  public void validateOptionValuesNotReferenced(
+      Long questionId,
+      List<QuestionOption> before,
+      List<QuestionOption> after,
+      List<EventFormQuestion> siblings) {
+    if (before == null || before.isEmpty()) {
+      return;
+    }
+    Set<String> afterValues = new HashSet<>();
+    if (after != null) {
+      for (QuestionOption option : after) {
+        if (option != null && option.value() != null) {
+          afterValues.add(option.value());
+        }
+      }
+    }
+    for (QuestionOption option : before) {
+      if (option == null || option.value() == null || afterValues.contains(option.value())) {
+        continue;
+      }
+      for (EventFormQuestion sibling : siblings) {
+        if (sibling.getId().equals(questionId)) {
+          continue;
+        }
+        if (questionId.equals(sibling.getVisibleWhenQuestionId())
+            && sibling.referencesOptionValue(option.value())) {
+          throw new BusinessException(CONDITION_OPTION_REFERENCED);
+        }
+      }
+    }
+  }
+
   /** 새 순서에서도 모든 조건이 앞 질문을 가리키는지 본다. */
   public void validateOrderKeepsConditions(List<EventFormQuestion> inNewOrder) {
     for (int i = 0; i < inNewOrder.size(); i++) {


### PR DESCRIPTION
## 무엇

질문 유형을 바꿀 때만 조건 참조를 검사하고, **선택지 하나를 지울 때는 검사하지 않았다.**

그래서 조건이 가리키던 선택지가 사라지면 그 조건은 어떤 답으로도 참이 되지 않는다. 조건을 건 질문은 폼에서 조용히 사라지는데, 관리자 화면에는 그 질문이 그대로 남아 있어 왜 아무도 답하지 않는지 알 길이 없다.

## 어떻게

`EventFormValidator.validateOptionValuesNotReferenced` 를 추가하고 `updateQuestion` 에서 부른다. 엔티티에 이미 있던 `referencesOptionValue` 를 쓴다 — 넣으려다 빠져 있던 검증이다.

## 확인

`./gradlew compileJava compileTestJava` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjnE8mcNj6sjP2E7BYhsQQ